### PR TITLE
[FIX] Pause timers correctly when items are lifted and placed back down

### DIFF
--- a/src/features/game/events/landExpansion/collectCompost.test.ts
+++ b/src/features/game/events/landExpansion/collectCompost.test.ts
@@ -26,6 +26,40 @@ describe("collectCompost", () => {
     ).toThrow("Composter does not exist");
   });
 
+  it("throws an error if the composter is not placed", () => {
+    // A lifted composter keeps composting until it is placed back down, where the
+    // pause is applied. Collecting from one in the inventory would skip it.
+    expect(() =>
+      collectCompost({
+        state: {
+          ...GAME_STATE,
+          buildings: {
+            "Compost Bin": [
+              {
+                id: "123",
+                createdAt: 0,
+                readyAt: 0,
+                removedAt: dateNow - 1000,
+                producing: {
+                  items: { Earthworm: 1 },
+                  startedAt: dateNow - 10000,
+                  readyAt: dateNow - 5000,
+                },
+              } as CompostBuilding,
+            ],
+          },
+        },
+        action: {
+          type: "compost.collected",
+          building: "Compost Bin",
+          buildingId: "123",
+        },
+        createdAt: dateNow,
+        farmId: 1,
+      }),
+    ).toThrow("Composter is not placed");
+  });
+
   it("throws an error if building is not producing anything", () => {
     expect(() =>
       collectCompost({

--- a/src/features/game/events/landExpansion/collectCompost.ts
+++ b/src/features/game/events/landExpansion/collectCompost.ts
@@ -41,6 +41,13 @@ export function collectCompost({
       throw new Error(translate("error.composterNotExist"));
     }
 
+    // A lifted composter keeps composting while it sits in the inventory - the
+    // pause is only applied when it is placed back down, so collecting from an
+    // unplaced one would side-step it entirely.
+    if (!building.coordinates) {
+      throw new Error("Composter is not placed");
+    }
+
     if (!bumpkin) {
       throw new Error("You do not have a Bumpkin!");
     }

--- a/src/features/game/events/landExpansion/collectCrafting.test.ts
+++ b/src/features/game/events/landExpansion/collectCrafting.test.ts
@@ -8,6 +8,17 @@ describe("collectCrafting", () => {
       collectCrafting({
         state: {
           ...INITIAL_FARM,
+          buildings: {
+            ...INITIAL_FARM.buildings,
+            "Crafting Box": [
+              {
+                id: "1",
+                createdAt: 0,
+                readyAt: 0,
+                coordinates: { x: 0, y: 0 },
+              },
+            ],
+          },
           craftingBox: {
             status: "crafting",
             recipes: {},
@@ -18,12 +29,57 @@ describe("collectCrafting", () => {
     ).toThrow("No item to collect");
   });
 
+  it("throws when the crafting box is not placed", () => {
+    // A lifted box keeps crafting until it is placed back down, where the pause is
+    // applied. Collecting from one in the inventory would skip it.
+    const now = Date.now();
+    expect(() =>
+      collectCrafting({
+        state: {
+          ...INITIAL_FARM,
+          buildings: {
+            ...INITIAL_FARM.buildings,
+            "Crafting Box": [
+              { id: "1", createdAt: 0, readyAt: 0, removedAt: now - 1000 },
+            ],
+          },
+          craftingBox: {
+            status: "crafting",
+            recipes: {},
+            queue: [
+              {
+                id: "timber-1",
+                name: "Timber",
+                readyAt: now - 1000,
+                startedAt: now - 10000,
+                type: "collectible",
+              },
+            ],
+          },
+        },
+        action: { type: "crafting.collected" },
+        createdAt: now,
+      }),
+    ).toThrow("Crafting Box is not placed");
+  });
+
   describe("queue", () => {
     it("collects all ready items from the queue", () => {
       const now = Date.now();
       const state = collectCrafting({
         state: {
           ...INITIAL_FARM,
+          buildings: {
+            ...INITIAL_FARM.buildings,
+            "Crafting Box": [
+              {
+                id: "1",
+                createdAt: 0,
+                readyAt: 0,
+                coordinates: { x: 0, y: 0 },
+              },
+            ],
+          },
           craftingBox: {
             status: "crafting",
             queue: [
@@ -70,6 +126,17 @@ describe("collectCrafting", () => {
       const state = collectCrafting({
         state: {
           ...INITIAL_FARM,
+          buildings: {
+            ...INITIAL_FARM.buildings,
+            "Crafting Box": [
+              {
+                id: "1",
+                createdAt: 0,
+                readyAt: 0,
+                coordinates: { x: 0, y: 0 },
+              },
+            ],
+          },
           craftingBox: {
             status: "crafting",
             queue: [
@@ -108,6 +175,17 @@ describe("collectCrafting", () => {
         collectCrafting({
           state: {
             ...INITIAL_FARM,
+            buildings: {
+              ...INITIAL_FARM.buildings,
+              "Crafting Box": [
+                {
+                  id: "1",
+                  createdAt: 0,
+                  readyAt: 0,
+                  coordinates: { x: 0, y: 0 },
+                },
+              ],
+            },
             craftingBox: {
               status: "crafting",
               queue: [

--- a/src/features/game/events/landExpansion/collectCrafting.ts
+++ b/src/features/game/events/landExpansion/collectCrafting.ts
@@ -47,6 +47,18 @@ export function collectCrafting({
       throw new Error("No item to collect");
     }
 
+    // A lifted box keeps crafting while it sits in the inventory - the pause is
+    // only applied when it is placed back down, so collecting from an unplaced
+    // one would side-step it entirely. The queue lives on `game.craftingBox`, not
+    // on the building, so lifting it does not put it out of reach on its own.
+    if (
+      !(copy.buildings["Crafting Box"] ?? []).some(
+        (b) => b.coordinates !== undefined,
+      )
+    ) {
+      throw new Error("Crafting Box is not placed");
+    }
+
     const nothingReady = queue.every((item) => item.readyAt > createdAt);
     if (nothingReady) {
       throw new Error("No items are ready");

--- a/src/features/game/events/landExpansion/collectLavaPit.test.ts
+++ b/src/features/game/events/landExpansion/collectLavaPit.test.ts
@@ -46,6 +46,28 @@ describe("collectLavaPit", () => {
     expect(result.lavaPits[1].collectedAt).toBe(now);
   });
 
+  it("requires the lava pit to be placed", () => {
+    // A lifted pit keeps burning until it is placed back down, where the pause is
+    // applied. Collecting from one in the inventory would skip it.
+    expect(() =>
+      collectLavaPit({
+        state: {
+          ...INITIAL_FARM,
+          lavaPits: {
+            1: {
+              createdAt: 0,
+              startedAt: now - 100 * 60 * 60 * 1000,
+              readyAt: now - 1000,
+              removedAt: now - 500,
+            },
+          },
+        },
+        action: { type: "lavaPit.collected", id: "1" },
+        createdAt: now,
+      }),
+    ).toThrow("Lava pit is not placed");
+  });
+
   it("requires the lava pit was started 72 hours ago", () => {
     expect(() =>
       collectLavaPit({

--- a/src/features/game/events/landExpansion/collectLavaPit.test.ts
+++ b/src/features/game/events/landExpansion/collectLavaPit.test.ts
@@ -95,6 +95,60 @@ describe("collectLavaPit", () => {
     expect(result.lavaPits[1].collectedAt).toBe(now);
   });
 
+  it("does not speed up a burn when the necklace is equipped after it started", () => {
+    // Started WITHOUT the necklace, so the snapshot is the full 72h. Equipping
+    // mid-burn must not bring that forward.
+    expect(() =>
+      collectLavaPit({
+        state: {
+          ...INITIAL_FARM,
+          bumpkin: {
+            ...INITIAL_FARM.bumpkin,
+            equipped: {
+              ...INITIAL_FARM.bumpkin.equipped,
+              necklace: "Obsidian Necklace",
+            },
+          },
+          lavaPits: {
+            1: {
+              x: 0,
+              y: 0,
+              startedAt: now - 36 * 60 * 60 * 1000,
+              readyAt: now + 36 * 60 * 60 * 1000,
+              createdAt: 0,
+            },
+          },
+        },
+        action: { type: "lavaPit.collected", id: "1" },
+        createdAt: now,
+      }),
+    ).toThrow("Lava pit still active");
+  });
+
+  it("does not delay a burn when the necklace is removed after it started", () => {
+    // Started WITH the necklace, so the snapshot is 36h. Taking it off mid-burn
+    // must not push the pit back out to the unboosted 72h.
+    const result = collectLavaPit({
+      state: {
+        ...INITIAL_FARM,
+        lavaPits: {
+          1: {
+            x: 0,
+            y: 0,
+            startedAt: now - 36 * 60 * 60 * 1000,
+            readyAt: now,
+            createdAt: 0,
+          },
+        },
+      },
+      action: { type: "lavaPit.collected", id: "1" },
+      createdAt: now,
+    });
+
+    expect(result.lavaPits[1].startedAt).toBe(undefined);
+    expect(result.lavaPits[1].collectedAt).toBe(now);
+  });
+
   it("gives an obsidian", () => {
     const result = collectLavaPit({
       state: {

--- a/src/features/game/events/landExpansion/collectLavaPit.ts
+++ b/src/features/game/events/landExpansion/collectLavaPit.ts
@@ -45,6 +45,13 @@ export function collectLavaPit({
       throw new Error("Lava pit not found");
     }
 
+    // A lifted pit keeps burning while it sits in the inventory - the pause is
+    // only applied when it is placed back down, so collecting from an unplaced
+    // pit would side-step it entirely.
+    if (lavaPit.x === undefined && lavaPit.y === undefined) {
+      throw new Error("Lava pit is not placed");
+    }
+
     if (lavaPit.startedAt === undefined) {
       throw new Error("Lava pit not started");
     }

--- a/src/features/game/events/landExpansion/collectLavaPit.ts
+++ b/src/features/game/events/landExpansion/collectLavaPit.ts
@@ -56,10 +56,18 @@ export function collectLavaPit({
     const { time: lavaPitTime, boostsUsed: lavaPitTimeBoostsUsed } =
       getLavaPitTime({ game: copy });
 
-    if (
-      createdAt - lavaPit.startedAt < lavaPitTime ||
-      (lavaPit.readyAt && createdAt < lavaPit.readyAt)
-    ) {
+    // `readyAt` is the snapshot taken when the burn started and is authoritative
+    // in BOTH directions: equipping the Obsidian Necklace mid-burn must not bring
+    // the pit forward, and taking it off must not push it back out to 72h. It
+    // applies from the next burn, not this one. Pits started before `readyAt`
+    // existed (#6287) carry no snapshot, and are the only case where deriving the
+    // duration from current state is the right answer.
+    const isReady =
+      lavaPit.readyAt !== undefined
+        ? createdAt >= lavaPit.readyAt
+        : createdAt - lavaPit.startedAt >= lavaPitTime;
+
+    if (!isReady) {
       throw new Error("Lava pit still active");
     }
 

--- a/src/features/game/events/landExpansion/collectProcessedResource.test.ts
+++ b/src/features/game/events/landExpansion/collectProcessedResource.test.ts
@@ -35,6 +35,42 @@ const SPRING_STATE: GameState = {
 };
 
 describe("collectProcessedFood", () => {
+  it("throws if the building is not placed", () => {
+    // A lifted building keeps processing until it is placed back down, where the
+    // pause is applied. Collecting from one in the inventory would skip it.
+    expect(() =>
+      collectProcessedResource({
+        state: {
+          ...SPRING_STATE,
+          buildings: {
+            ...SPRING_STATE.buildings,
+            "Fish Market": [
+              {
+                id: "123",
+                createdAt: 0,
+                readyAt: 0,
+                removedAt: createdAt - 1000,
+                processing: [
+                  {
+                    name: "Fish Flake",
+                    readyAt: createdAt - 500,
+                    startedAt: createdAt - 5000,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        action: {
+          type: "processedResource.collected",
+          buildingId: "123",
+          buildingName: "Fish Market" as ProcessingBuildingName,
+        } as CollectProcessedResourceAction,
+        createdAt,
+        farmId: 1,
+      }),
+    ).toThrow("Fish Market is not placed");
+  });
   it("throws if the building is not a food processing building", () => {
     expect(() => {
       collectProcessedResource({

--- a/src/features/game/events/landExpansion/collectProcessedResource.ts
+++ b/src/features/game/events/landExpansion/collectProcessedResource.ts
@@ -83,6 +83,13 @@ export function collectProcessedResource({
       throw new Error("Fish Market does not exist");
     }
 
+    // A lifted building keeps processing while it sits in the inventory - the
+    // pause is only applied when it is placed back down, so collecting from an
+    // unplaced one would side-step it entirely.
+    if (!building.coordinates) {
+      throw new Error(`${action.buildingName} is not placed`);
+    }
+
     const processing: BuildingProduct[] = building.processing ?? [];
 
     if (!processing.length) {

--- a/src/features/game/events/landExpansion/collectRecipe.test.ts
+++ b/src/features/game/events/landExpansion/collectRecipe.test.ts
@@ -24,6 +24,46 @@ describe("collect Recipes", () => {
   // stored `readyAt` is only a cache of the derived value, so collecting has to ask
   // the chain, not the cache — otherwise the player watches a finished recipe sit
   // there until some other event happens to rewrite the queue.
+  it("does not collect from a building that is not placed", () => {
+    // Lifted buildings keep cooking until they are placed back down, where the
+    // pause is applied. Collecting from one in the inventory would skip it.
+    const now = dateNow;
+
+    expect(() =>
+      collectRecipe({
+        farmId,
+        state: {
+          ...GAME_STATE,
+          buildings: {
+            "Fire Pit": [
+              {
+                id: "1",
+                createdAt: 0,
+                readyAt: 0,
+                removedAt: now - 1000,
+                crafting: [
+                  {
+                    id: "abc",
+                    name: "Boiled Eggs",
+                    startedAt: now - 10 * 60 * 60 * 1000,
+                    baseDurationMs: 60 * 60 * 1000,
+                    readyAt: now - 9 * 60 * 60 * 1000,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        action: {
+          type: "recipes.collected",
+          building: "Fire Pit",
+          buildingId: "1",
+        },
+        createdAt: now,
+      }),
+    ).toThrow("Building is not placed");
+  });
+
   it("collects a recipe whose DERIVED ready time has passed", () => {
     const now = dateNow;
     const HOUR = 60 * 60 * 1000;

--- a/src/features/game/events/landExpansion/collectRecipe.ts
+++ b/src/features/game/events/landExpansion/collectRecipe.ts
@@ -134,6 +134,13 @@ export function collectRecipe({
       throw new Error("You do not have a Bumpkin!");
     }
 
+    // A lifted building keeps cooking while it sits in the inventory - the pause
+    // is only applied when it is placed back down, so collecting from an
+    // unplaced building would side-step it entirely.
+    if (!building.coordinates) {
+      throw new Error("Building is not placed");
+    }
+
     const recipes = building.crafting ?? [];
     if (!recipes.length) {
       throw new Error(translate("error.buildingNotCooking"));

--- a/src/features/game/events/landExpansion/harvest.test.ts
+++ b/src/features/game/events/landExpansion/harvest.test.ts
@@ -13,6 +13,14 @@ const dateNow = Date.now();
 const GAME_STATE: GameState = {
   ...INITIAL_FARM,
   crops: {
+    // Fixtures below write to plot `0` and spread `GAME_STATE.crops[0]`, which
+    // resolved to `undefined` while no such plot existed - so those plots came
+    // out with no coordinates. `harvest` now rejects an unplaced plot.
+    "0": {
+      createdAt: dateNow,
+      x: 20,
+      y: 20,
+    },
     "12": {
       createdAt: dateNow,
       x: 0,
@@ -50,6 +58,30 @@ describe("harvest", () => {
         createdAt: dateNow,
       }),
     ).toThrow("Nothing was planted");
+  });
+
+  it("does not harvest a plot that is not placed", () => {
+    // A lifted plot keeps growing until it is placed back down, where the pause
+    // is applied. Harvesting one from the inventory would skip it.
+    expect(() =>
+      harvest({
+        state: {
+          ...GAME_STATE,
+          crops: {
+            0: {
+              createdAt: dateNow,
+              removedAt: dateNow - 1000,
+              crop: { name: "Sunflower", plantedAt: 0 },
+            },
+          },
+        },
+        action: {
+          type: "crop.harvested",
+          index: "0",
+        },
+        createdAt: dateNow,
+      }),
+    ).toThrow("Plot is not placed");
   });
 
   it("does not harvest if the crop is not ripe", () => {
@@ -703,7 +735,9 @@ describe("harvest", () => {
   });
 
   describe("cropBuffs", () => {
-    const firstId = Object.keys(GAME_STATE.crops)[0];
+    // Pinned: `Object.keys` orders integer-like keys numerically, so this must not
+    // drift onto plot `0` - the AOE fixtures below are keyed to this plot's (0,-2).
+    const firstId = "12";
 
     it("gives double the yield of Soybeans when Soybliss is placed and ready", () => {
       const state = harvest({

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -1113,6 +1113,13 @@ export function harvestCropFromPlot({
     throw new Error("Plot does not exist");
   }
 
+  // A lifted plot keeps growing while it sits in the inventory - the pause is
+  // only applied when it is placed back down, so harvesting an unplaced plot
+  // would side-step it entirely.
+  if (plot.x === undefined && plot.y === undefined) {
+    throw new Error("Plot is not placed");
+  }
+
   const cropAffectedBy = getAffectedWeather({
     id: plotId,
     game,

--- a/src/features/game/events/landExpansion/harvestFlower.test.ts
+++ b/src/features/game/events/landExpansion/harvestFlower.test.ts
@@ -44,6 +44,33 @@ describe("harvestFlower", () => {
     ).toThrow("Flower bed does not have a flower");
   });
 
+  it("throws an error if the flower bed is not placed", () => {
+    // Lifted beds keep growing until they are placed back down, where the pause
+    // is applied. Collecting from one in the inventory would skip it.
+    const flowerBedId = "123";
+    expect(() =>
+      harvestFlower({
+        state: {
+          ...GAME_STATE,
+          flowers: {
+            discovered: {},
+            flowerBeds: {
+              [flowerBedId]: {
+                createdAt: 0,
+                removedAt: Date.now() - 1000,
+                flower: {
+                  name: "Red Pansy",
+                  plantedAt: 0,
+                },
+              },
+            },
+          },
+        },
+        action: { type: "flower.harvested", id: flowerBedId },
+      }),
+    ).toThrow("Flower bed is not placed");
+  });
+
   it("throws an error if the flower is not ready to harvest", () => {
     const flowerBedId = "123";
     expect(() =>

--- a/src/features/game/events/landExpansion/harvestFlower.ts
+++ b/src/features/game/events/landExpansion/harvestFlower.ts
@@ -114,6 +114,13 @@ export function harvestFlower({
 
     if (!flowerBed) throw new Error(translate("harvestflower.noFlowerBed"));
 
+    // A lifted bed keeps growing while it sits in the inventory - the pause is
+    // only applied when it is placed back down, so harvesting an unplaced bed
+    // would side-step it entirely.
+    if (flowerBed.x === undefined && flowerBed.y === undefined) {
+      throw new Error("Flower bed is not placed");
+    }
+
     const flower = flowerBed.flower;
 
     if (!flower) throw new Error(translate("harvestflower.noFlower"));

--- a/src/features/game/events/landExpansion/harvestGreenHouse.ts
+++ b/src/features/game/events/landExpansion/harvestGreenHouse.ts
@@ -167,6 +167,14 @@ export function harvestGreenHouse({
       throw new Error("Greenhouse does not exist");
     }
 
+    // A lifted greenhouse keeps its pots growing while it sits in the inventory -
+    // the pause is only applied when it is placed back down, so harvesting from
+    // an unplaced one would side-step it entirely. The pots live on `game`, not
+    // on the building, so lifting it does not put them out of reach on its own.
+    if (!game.buildings.Greenhouse.some((b) => b.coordinates !== undefined)) {
+      throw new Error("Greenhouse is not placed");
+    }
+
     if (!game.bumpkin) {
       throw new Error("No Bumpkin");
     }

--- a/src/features/game/events/landExpansion/harvestGreenhouse.test.ts
+++ b/src/features/game/events/landExpansion/harvestGreenhouse.test.ts
@@ -59,6 +59,35 @@ const greenhouseFarm = (): GameState => ({
 });
 
 describe("plantGreenhouse", () => {
+  it("throws if the greenhouse is not placed", () => {
+    // A lifted greenhouse keeps its pots growing until it is placed back down,
+    // where the pause is applied. Harvesting one from the inventory would skip it.
+    const now = Date.now();
+    expect(() =>
+      harvestGreenHouse({
+        state: {
+          ...greenhouseFarm(),
+          buildings: {
+            ...farm.buildings,
+            Greenhouse: [
+              { id: "1", createdAt: 0, readyAt: 0, removedAt: now - 1000 },
+            ],
+          },
+          greenhouse: {
+            oil: 50,
+            pots: {
+              1: {
+                plant: { name: "Rice", plantedAt: 0, amount: 1 },
+              },
+            },
+          },
+        },
+        action: { type: "greenhouse.harvested", id: 1 },
+        createdAt: now,
+        farmId: 1,
+      }),
+    ).toThrow("Greenhouse is not placed");
+  });
   it("requires greenhouse exists", () => {
     expect(() =>
       harvestGreenHouse({

--- a/src/features/game/events/landExpansion/placeBuilding.test.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.test.ts
@@ -928,6 +928,64 @@ describe("Place building", () => {
     );
   });
 
+  it("shifts aging shed aging rack slots by downtime when re-placing", () => {
+    const removedAt = dateNow - 120000;
+    const slotStartedAt = dateNow - 180000;
+    const slotReadyAt = dateNow + 60 * 60 * 1000;
+
+    const state = placeBuilding({
+      farmId,
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Aging Shed": new Decimal(1),
+          "Basic Land": new Decimal(10),
+        },
+        buildings: {
+          "Aging Shed": [
+            {
+              id: "123",
+              createdAt: dateNow,
+              readyAt: dateNow,
+              removedAt,
+            },
+          ],
+        },
+        agingShed: {
+          ...createInitialAgingShed(),
+          level: 1,
+          racks: {
+            ...createInitialAgingShed().racks,
+            aging: [
+              {
+                id: "slot-1",
+                fish: "Anchovy",
+                startedAt: slotStartedAt,
+                readyAt: slotReadyAt,
+              },
+            ],
+          },
+        },
+      },
+      action: {
+        type: "building.placed",
+        name: "Aging Shed",
+        id: "123",
+        coordinates: { x: 0, y: 1 },
+      },
+      createdAt: dateNow,
+    });
+
+    const downtimeDelta = dateNow - removedAt;
+    expect(state.agingShed.racks.aging).toHaveLength(1);
+    expect(state.agingShed.racks.aging[0].startedAt).toEqual(
+      slotStartedAt + downtimeDelta,
+    );
+    expect(state.agingShed.racks.aging[0].readyAt).toEqual(
+      slotReadyAt + downtimeDelta,
+    );
+  });
+
   it("shifts aging shed spice rack jobs by downtime when re-placing", () => {
     const removedAt = dateNow - 120000;
     const jobStartedAt = dateNow - 180000;

--- a/src/features/game/events/landExpansion/placeBuilding.test.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.test.ts
@@ -212,6 +212,63 @@ describe("Place building", () => {
     ).toEqual(dateNow - 60000 + 12 * 60 * 60 * 1000);
   });
 
+  it("does not re-price an in-flight compost with a boost placed after it started", () => {
+    const startedAt = dateNow - 60 * 60 * 1000;
+    const readyAt = startedAt + 12 * 60 * 60 * 1000;
+    const removedAt = dateNow - 30 * 60 * 1000;
+
+    const state = placeBuilding({
+      farmId,
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Premium Composter": new Decimal(1),
+          "Basic Land": new Decimal(10),
+        },
+        // Soil Krabby takes 10% off a compost, but it was placed AFTER this
+        // batch started - the duration is a snapshot, not a live lookup.
+        collectibles: {
+          "Soil Krabby": [
+            {
+              id: "krabby",
+              createdAt: dateNow,
+              coordinates: { x: 5, y: 5 },
+              readyAt: dateNow,
+            },
+          ],
+        },
+        buildings: {
+          "Premium Composter": [
+            {
+              id: "123",
+              createdAt: dateNow,
+              readyAt: dateNow,
+              removedAt,
+              producing: {
+                items: { "Rapid Root": 10 },
+                startedAt,
+                readyAt,
+              },
+            },
+          ],
+        },
+      },
+      action: {
+        type: "building.placed",
+        name: "Premium Composter",
+        id: "123",
+        coordinates: { x: 1, y: 1 },
+      },
+      createdAt: dateNow,
+    });
+
+    const downtime = dateNow - removedAt;
+    const producing = state.buildings["Premium Composter"]?.[0].producing;
+
+    expect(producing?.startedAt).toEqual(startedAt + downtime);
+    expect(producing?.readyAt).toEqual(readyAt + downtime);
+  });
+
   it("adjusts the new readyAt for crop machines", () => {
     const startTime = dateNow - 20000000;
     const state = placeBuilding({

--- a/src/features/game/events/landExpansion/placeBuilding.test.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.test.ts
@@ -2,11 +2,13 @@ import Decimal from "decimal.js-light";
 import { LEVEL_EXPERIENCE } from "features/game/lib/level";
 import { INITIAL_BUMPKIN, TEST_FARM } from "../../lib/constants";
 import { createInitialAgingShed } from "../../lib/agingShed";
-import type { GameState } from "../../types/game";
+import type { BuildingProduct, GameState } from "../../types/game";
 import { getAnimalReadyAt } from "../../lib/animals";
 import { getNextLoveAvailableAt, isAnimalNeedingLove } from "./loveAnimal";
 import { placeBuilding } from "./placeBuilding";
 import { RECIPES } from "features/game/lib/crafting";
+import { getCookingQueueReadyAts } from "features/game/lib/cookingReadiness";
+import { getExpiryCooldown } from "features/game/lib/collectibleBuilt";
 
 const GAME_STATE: GameState = {
   ...TEST_FARM,
@@ -114,26 +116,24 @@ describe("Place building", () => {
               id: "123",
               createdAt: dateNow,
               readyAt: dateNow,
+              // Lifted 50s ago; every recipe moves out by that downtime.
+              removedAt: dateNow - 50000,
               crafting: [
                 {
                   name: "Pizza Margherita",
                   readyAt: dateNow + 10000,
-                  timeRemaining: 60000,
                 },
                 {
                   name: "Pizza Margherita",
                   readyAt: dateNow + 70000,
-                  timeRemaining: 120000,
                 },
                 {
                   name: "Pizza Margherita",
                   readyAt: dateNow + 130000,
-                  timeRemaining: 180000,
                 },
                 {
                   name: "Pizza Margherita",
                   readyAt: dateNow + 190000,
-                  timeRemaining: 240000,
                 },
               ],
             },
@@ -267,6 +267,150 @@ describe("Place building", () => {
 
     expect(producing?.startedAt).toEqual(startedAt + downtime);
     expect(producing?.readyAt).toEqual(readyAt + downtime);
+  });
+
+  describe("cooking queues", () => {
+    const MIN = 60 * 1000;
+
+    const firePit = (
+      crafting: BuildingProduct[],
+      removedAt: number,
+    ): GameState["buildings"] => ({
+      "Fire Pit": [
+        {
+          id: "123",
+          createdAt: dateNow - 24 * 60 * MIN,
+          readyAt: dateNow - 24 * 60 * MIN,
+          removedAt,
+          crafting,
+        },
+      ],
+    });
+
+    const place = (state: GameState) =>
+      placeBuilding({
+        farmId,
+        state,
+        action: {
+          type: "building.placed",
+          name: "Fire Pit",
+          id: "123",
+          coordinates: { x: 1, y: 1 },
+        },
+        createdAt: dateNow,
+      });
+
+    it("pauses a windowed queue across a lift", () => {
+      const startedAt = dateNow - 20 * MIN;
+      const removedAt = dateNow - 10 * MIN;
+      const downtime = dateNow - removedAt;
+
+      const state = place({
+        ...GAME_STATE,
+        inventory: { "Fire Pit": new Decimal(1) },
+        buildings: firePit(
+          [
+            {
+              id: "a",
+              name: "Boiled Eggs",
+              startedAt,
+              baseDurationMs: 60 * MIN,
+              readyAt: startedAt + 60 * MIN,
+            },
+            {
+              id: "b",
+              name: "Boiled Eggs",
+              baseDurationMs: 30 * MIN,
+              readyAt: startedAt + 90 * MIN,
+            },
+          ],
+          removedAt,
+        ),
+      });
+
+      const crafting = state.buildings["Fire Pit"]![0].crafting!;
+      const readyAts = getCookingQueueReadyAts({ crafting, game: state });
+
+      // Both recipes move out by exactly the time the building spent unplaced.
+      expect(readyAts[0]).toEqual(startedAt + 60 * MIN + downtime);
+      expect(readyAts[1]).toEqual(startedAt + 90 * MIN + downtime);
+      // ...and the persisted cache agrees with the derived chain again.
+      expect(crafting[0].readyAt).toEqual(readyAts[0]);
+      expect(crafting[1].readyAt).toEqual(readyAts[1]);
+    });
+
+    it("pauses a legacy queue across a lift", () => {
+      const removedAt = dateNow - 10 * MIN;
+      const downtime = dateNow - removedAt;
+
+      const state = place({
+        ...GAME_STATE,
+        inventory: { "Fire Pit": new Decimal(1) },
+        buildings: firePit(
+          [
+            { name: "Boiled Eggs", readyAt: dateNow + 40 * MIN },
+            { name: "Boiled Eggs", readyAt: dateNow + 70 * MIN },
+          ],
+          removedAt,
+        ),
+      });
+
+      const crafting = state.buildings["Fire Pit"]![0].crafting!;
+
+      expect(crafting[0].readyAt).toEqual(dateNow + 40 * MIN + downtime);
+      expect(crafting[1].readyAt).toEqual(dateNow + 70 * MIN + downtime);
+      expect(crafting[0].timeRemaining).toBeUndefined();
+    });
+
+    it("keeps boost credit earned before the lift when the window expires during it", () => {
+      // 60m of work. A 2x hourglass covers the first 15m, so 30m of work is
+      // banked; the window then expires while the building sits unplaced.
+      const start = dateNow - 45 * MIN;
+      const removedAt = start + 15 * MIN;
+
+      const base: GameState = {
+        ...GAME_STATE,
+        inventory: { "Fire Pit": new Decimal(1) },
+      };
+      const cooldown = getExpiryCooldown("Gourmet Hourglass", base);
+
+      const state = place({
+        ...base,
+        collectibles: {
+          "Gourmet Hourglass": [
+            {
+              id: "hourglass",
+              // Expires exactly when the building is lifted.
+              createdAt: removedAt - cooldown,
+              readyAt: removedAt - cooldown,
+              coordinates: { x: 5, y: 5 },
+            },
+          ],
+        },
+        buildings: firePit(
+          [
+            {
+              id: "a",
+              name: "Boiled Eggs",
+              startedAt: start,
+              baseDurationMs: 60 * MIN,
+              readyAt: start + 45 * MIN,
+            },
+          ],
+          removedAt,
+        ),
+      });
+
+      const crafting = state.buildings["Fire Pit"]![0].crafting!;
+
+      // 30m of work banked, 30m left, resumed unboosted from the moment it was
+      // placed. Shifting the timeline instead would have stranded the window
+      // before the new start and lost that credit (dateNow + 45m).
+      expect(crafting[0].baseDurationMs).toEqual(30 * MIN);
+      expect(getCookingQueueReadyAts({ crafting, game: state })[0]).toEqual(
+        dateNow + 30 * MIN,
+      );
+    });
   });
 
   it("adjusts the new readyAt for crop machines", () => {

--- a/src/features/game/events/landExpansion/placeBuilding.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.ts
@@ -15,7 +15,6 @@ import {
   getGreenhouseGlowWindows,
   pauseWindowedTimer,
 } from "features/game/lib/boostWindows";
-import { getReadyAt } from "./startComposter";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { mfTrack } from "lib/moonforgeAnalytics";
 
@@ -96,15 +95,15 @@ export function placeBuilding({
       ) {
         const existingComposter = existingBuilding as CompostBuilding;
         if (existingComposter.producing && existingComposter.removedAt) {
-          const timeOffset =
-            existingComposter.removedAt - existingComposter.producing.startedAt;
-          existingComposter.producing.startedAt = createdAt - timeOffset;
-          const timeRemaining = getReadyAt({
-            gameState: stateCopy,
-            composter: action.name as ComposterName,
-          }).timeToFinishMilliseconds;
-          existingComposter.producing.readyAt =
-            createdAt + timeRemaining - timeOffset;
+          // Pause the batch across the lift by shifting both timestamps by the
+          // downtime (the Crafting Box / Aging Shed pattern below). The batch's
+          // duration is a SNAPSHOT taken by `startComposter` - re-deriving it
+          // here would re-price an in-flight batch with boosts acquired after
+          // it started, so placing a Soil Krabby then lifting the composter
+          // took 10% off a batch already under way.
+          const downtime = Math.max(0, createdAt - existingComposter.removedAt);
+          existingComposter.producing.startedAt += downtime;
+          existingComposter.producing.readyAt += downtime;
         }
       }
 

--- a/src/features/game/events/landExpansion/placeBuilding.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.ts
@@ -11,10 +11,12 @@ import { produce } from "immer";
 import type { ComposterName } from "features/game/types/composters";
 import { createInitialAgingShed } from "features/game/lib/agingShed";
 import {
+  getCookingBoostWindows,
   getGreenhouseBoostWindows,
   getGreenhouseGlowWindows,
   pauseWindowedTimer,
 } from "features/game/lib/boostWindows";
+import { pauseCookingQueue } from "features/game/lib/cookingReadiness";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { mfTrack } from "lib/moonforgeAnalytics";
 
@@ -75,11 +77,13 @@ export function placeBuilding({
       // Assign the coordinates to the building
       existingBuilding.coordinates = action.coordinates;
 
-      // Update the readyAt for Cooking buildings
-      if (existingBuilding.crafting) {
-        existingBuilding.crafting.forEach((crafting) => {
-          crafting.readyAt = createdAt + (crafting.timeRemaining ?? 0);
-          delete crafting.timeRemaining;
+      // Pause the queue for Cooking buildings
+      if (existingBuilding.crafting && existingBuilding.removedAt) {
+        pauseCookingQueue({
+          crafting: existingBuilding.crafting,
+          removedAt: existingBuilding.removedAt,
+          placedAt: createdAt,
+          windows: getCookingBoostWindows(stateCopy),
         });
       }
 

--- a/src/features/game/events/landExpansion/placeLavaPit.test.ts
+++ b/src/features/game/events/landExpansion/placeLavaPit.test.ts
@@ -1,6 +1,7 @@
 import Decimal from "decimal.js-light";
 import { placeLavaPit } from "./placeLavaPit";
 import { INITIAL_FARM } from "features/game/lib/constants";
+import { LAVA_PIT_TIME } from "./startLavaPit";
 
 describe("placeLavaPit", () => {
   it("ensures lava pits are in inventory", () => {
@@ -149,6 +150,7 @@ describe("placeLavaPit", () => {
           "123": {
             createdAt: dateNow,
             startedAt: dateNow - 180000,
+            readyAt: dateNow - 180000 + 72 * 60 * 60 * 1000,
             removedAt: dateNow - 120000,
           },
         },
@@ -165,5 +167,82 @@ describe("placeLavaPit", () => {
         y: 2,
       },
     });
+  });
+
+  it("does not re-price an in-flight burn with a boost equipped after it started", () => {
+    const dateNow = Date.now();
+    const startedAt = dateNow - 60 * 60 * 1000;
+    const readyAt = startedAt + LAVA_PIT_TIME;
+    const removedAt = dateNow - 30 * 60 * 1000;
+
+    const state = placeLavaPit({
+      action: {
+        name: "Lava Pit",
+        coordinates: { x: 2, y: 2 },
+        id: "1",
+        type: "lavaPit.placed",
+      },
+      state: {
+        ...INITIAL_FARM,
+        // Obsidian Necklace halves the burn, but it was equipped AFTER the pit
+        // was started - the duration is a snapshot, not a live lookup.
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          equipped: {
+            ...INITIAL_FARM.bumpkin.equipped,
+            necklace: "Obsidian Necklace",
+          },
+        },
+        buildings: {},
+        inventory: {
+          "Lava Pit": new Decimal(2),
+        },
+        lavaPits: {
+          "123": {
+            createdAt: startedAt,
+            startedAt,
+            readyAt,
+            removedAt,
+          },
+        },
+      },
+      createdAt: dateNow,
+    });
+
+    const downtime = dateNow - removedAt;
+
+    expect(state.lavaPits["123"].startedAt).toEqual(startedAt + downtime);
+    expect(state.lavaPits["123"].readyAt).toEqual(readyAt + downtime);
+  });
+
+  it("pauses a burn that has no stored readyAt without inventing one", () => {
+    const dateNow = Date.now();
+    const startedAt = dateNow - 60 * 60 * 1000;
+    const removedAt = dateNow - 30 * 60 * 1000;
+
+    const state = placeLavaPit({
+      action: {
+        name: "Lava Pit",
+        coordinates: { x: 2, y: 2 },
+        id: "1",
+        type: "lavaPit.placed",
+      },
+      state: {
+        ...INITIAL_FARM,
+        buildings: {},
+        inventory: {
+          "Lava Pit": new Decimal(2),
+        },
+        lavaPits: {
+          "123": { createdAt: startedAt, startedAt, removedAt },
+        },
+      },
+      createdAt: dateNow,
+    });
+
+    expect(state.lavaPits["123"].startedAt).toEqual(
+      startedAt + (dateNow - removedAt),
+    );
+    expect(state.lavaPits["123"].readyAt).toBeUndefined();
   });
 });

--- a/src/features/game/events/landExpansion/placeLavaPit.ts
+++ b/src/features/game/events/landExpansion/placeLavaPit.ts
@@ -3,7 +3,6 @@ import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import type { GameState, LavaPit } from "features/game/types/game";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
-import { getLavaPitTime } from "./startLavaPit";
 
 export type PlaceLavaPitAction = {
   type: "lavaPit.placed";
@@ -53,11 +52,19 @@ export function placeLavaPit({
     };
 
     if (updatedLavaPit.startedAt && updatedLavaPit.removedAt) {
-      const existingProgress =
-        updatedLavaPit.removedAt - updatedLavaPit.startedAt;
-      updatedLavaPit.startedAt = createdAt - existingProgress;
-      updatedLavaPit.readyAt =
-        updatedLavaPit.startedAt + getLavaPitTime({ game }).time;
+      // Pause the burn across the lift by shifting every timestamp it owns by
+      // the downtime, so the unplaced interval doesn't count. The duration is a
+      // SNAPSHOT taken when the burn started - re-deriving it here from current
+      // state would re-price an in-flight burn with boosts equipped after it
+      // began (equip the Obsidian Necklace, lift, re-place, and 72h becomes
+      // 36h). A pit with no stored `readyAt` keeps none: inventing one is the
+      // same re-derivation, and `collectLavaPit` already falls back to
+      // `startedAt` when it's absent.
+      const downtime = Math.max(0, createdAt - updatedLavaPit.removedAt);
+      updatedLavaPit.startedAt += downtime;
+      if (updatedLavaPit.readyAt !== undefined) {
+        updatedLavaPit.readyAt += downtime;
+      }
     }
     delete updatedLavaPit.removedAt;
 

--- a/src/features/game/events/landExpansion/placeSunstone.test.ts
+++ b/src/features/game/events/landExpansion/placeSunstone.test.ts
@@ -152,4 +152,49 @@ describe("placeSunstone", () => {
       },
     });
   });
+
+  it("banks the work done before the lift for a windowed sunstone", () => {
+    const dateNow = Date.now();
+    const RECOVERY = 60 * 60 * 1000;
+
+    const state = placeSunstone({
+      action: {
+        coordinates: { x: 2, y: 2 },
+        id: "1",
+        name: "Sunstone Rock",
+        type: "sunstone.placed",
+      },
+      state: {
+        ...INITIAL_FARM,
+        buildings: {},
+        inventory: {
+          "Sunstone Rock": new Decimal(2),
+        },
+        sunstones: {
+          "123": {
+            createdAt: dateNow,
+            stone: {
+              minedAt: dateNow - 180000,
+              baseDurationMs: RECOVERY,
+            },
+            removedAt: dateNow - 120000,
+            minesLeft: 5,
+          },
+        },
+      },
+      createdAt: dateNow,
+    });
+
+    const stone = state.sunstones["123"].stone;
+
+    // A windowed node banks its accrued work and resumes from the placement, the
+    // same as every other rock. Back-dating `minedAt` instead happens to give the
+    // right readyAt only while sunstone has no boost windows to be re-exposed to.
+    expect(stone.minedAt).toEqual(dateNow);
+    expect(stone.baseDurationMs).toEqual(RECOVERY - 60000);
+    // Unchanged either way: still 59 minutes of recovery left.
+    expect(stone.minedAt + (stone.baseDurationMs ?? 0)).toEqual(
+      dateNow + RECOVERY - 60000,
+    );
+  });
 });

--- a/src/features/game/events/landExpansion/placeSunstone.ts
+++ b/src/features/game/events/landExpansion/placeSunstone.ts
@@ -2,6 +2,10 @@ import type { FiniteResource, GameState } from "features/game/types/game";
 import type { ResourceName } from "features/game/types/resources";
 import Decimal from "decimal.js-light";
 import { produce } from "immer";
+import {
+  getMineBoostWindows,
+  pauseWindowedTimer,
+} from "features/game/lib/boostWindows";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 
 export type PlaceSunstoneAction = {
@@ -46,9 +50,17 @@ export function placeSunstone({
       };
 
       if (updatedSunstone.stone && updatedSunstone.removedAt) {
-        const existingProgress =
-          updatedSunstone.removedAt - updatedSunstone.stone.minedAt;
-        updatedSunstone.stone.minedAt = createdAt - existingProgress;
+        // Pause recovery across the lift (windowed banking or legacy back-date),
+        // as every other rock does. Sunstone has no boost windows today, so this
+        // is behaviour-identical to the back-date it replaces - but it stops a
+        // future sunstone boost from silently mis-crediting a lifted node.
+        updatedSunstone.stone.minedAt = pauseWindowedTimer({
+          timer: updatedSunstone.stone,
+          startedAt: updatedSunstone.stone.minedAt,
+          removedAt: updatedSunstone.removedAt,
+          createdAt,
+          windows: getMineBoostWindows(game, "Sunstone Rock"),
+        });
       }
       delete updatedSunstone.removedAt;
 

--- a/src/features/game/events/landExpansion/removeBuilding.test.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.test.ts
@@ -444,7 +444,7 @@ describe("removeBuilding", () => {
   //   expect(expansions[1].plots?.["4"].crop).not.toBeUndefined();
   // });
 
-  it("stores the time remaining for cooking buildings", () => {
+  it("stamps removedAt and leaves the cooking queue untouched", () => {
     const dateNow = Date.now();
     const state = removeBuilding({
       state: {
@@ -486,18 +486,16 @@ describe("removeBuilding", () => {
       createdAt: dateNow,
     });
 
-    expect(
-      state.buildings["Fire Pit"]?.[0].crafting?.[0].timeRemaining,
-    ).toEqual(60000);
-    expect(
-      state.buildings["Fire Pit"]?.[0].crafting?.[1].timeRemaining,
-    ).toEqual(120000);
-    expect(
-      state.buildings["Fire Pit"]?.[0].crafting?.[2].timeRemaining,
-    ).toEqual(180000);
-    expect(
-      state.buildings["Fire Pit"]?.[0].crafting?.[3].timeRemaining,
-    ).toEqual(240000);
+    // Removal only records WHEN the building was lifted; the queue is paused on
+    // re-place, from that timestamp (see `pauseCookingQueue`). Banking a
+    // `timeRemaining` here would be a cache the resolver ignores.
+    expect(state.buildings["Fire Pit"]?.[0].removedAt).toEqual(dateNow);
+    expect(state.buildings["Fire Pit"]?.[0].crafting).toEqual([
+      { name: "Pizza Margherita", readyAt: dateNow + 60000 },
+      { name: "Pizza Margherita", readyAt: dateNow + 120000 },
+      { name: "Pizza Margherita", readyAt: dateNow + 180000 },
+      { name: "Pizza Margherita", readyAt: dateNow + 240000 },
+    ]);
   });
 
   it("saves the remaining time for each pack in the crop machine", () => {

--- a/src/features/game/events/landExpansion/removeBuilding.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.ts
@@ -59,13 +59,6 @@ export function removeBuilding({
     delete buildingToRemove.coordinates;
     buildingToRemove.removedAt = createdAt;
 
-    // Cooking buildings
-    if (buildingToRemove.crafting) {
-      buildingToRemove.crafting.forEach((crafting) => {
-        crafting.timeRemaining = crafting.readyAt - createdAt;
-      });
-    }
-
     if (action.name === "Crop Machine") {
       const cropMachine = buildingToRemove as CropMachineBuilding;
       if (cropMachine.queue) {

--- a/src/features/game/lib/cookingReadiness.test.ts
+++ b/src/features/game/lib/cookingReadiness.test.ts
@@ -1,4 +1,4 @@
-import { getCookingQueueReadyAts } from "./cookingReadiness";
+import { getCookingQueueReadyAts, pauseCookingQueue } from "./cookingReadiness";
 import { COOKING_BOOST_SPEED } from "./boostWindows";
 import { getExpiryCooldown } from "./collectibleBuilt";
 import { TEST_FARM } from "./constants";
@@ -258,5 +258,60 @@ describe("COOKING_BOOST_SPEED", () => {
     expect(COOKING_BOOST_SPEED["Time Warp Totem"]).toEqual(2);
     expect(COOKING_BOOST_SPEED["Legendary Shrine"]).toEqual(2);
     expect(COOKING_BOOST_SPEED["Boar Shrine"]).toEqual(1.25);
+  });
+});
+
+describe("pauseCookingQueue", () => {
+  const MIN = 60 * 1000;
+  const now = 1700000000000;
+
+  it("does not credit pre-lift progress twice behind a completed legacy recipe", () => {
+    // A legacy recipe keeps its wall-clock remainder, which for one that had
+    // already FINISHED is a readyAt in the past. A windowed recipe chained to it
+    // would otherwise derive a start before the placement and re-accrue the work
+    // it had already banked.
+    const legacyReadyAt = now - 50 * MIN;
+    const removedAt = now - 30 * MIN;
+
+    const crafting: BuildingProduct[] = [
+      { id: "legacy", name: "Boiled Eggs", readyAt: legacyReadyAt },
+      {
+        id: "windowed",
+        name: "Boiled Eggs",
+        baseDurationMs: 60 * MIN,
+        readyAt: 0,
+      },
+    ];
+
+    pauseCookingQueue({ crafting, removedAt, placedAt: now, windows: [] });
+
+    // It had banked 20m (legacyReadyAt -> removedAt), so 40m of work remains and
+    // it resumes from the placement.
+    expect(crafting[1].baseDurationMs).toEqual(40 * MIN);
+    expect(crafting[1].startedAt).toEqual(now);
+    expect(crafting[1].readyAt).toEqual(now + 40 * MIN);
+  });
+
+  it("leaves a recipe that had not started chained to the one ahead of it", () => {
+    const removedAt = now - 30 * MIN;
+
+    const crafting: BuildingProduct[] = [
+      {
+        id: "head",
+        name: "Boiled Eggs",
+        startedAt: now - 40 * MIN,
+        baseDurationMs: 60 * MIN,
+        readyAt: now + 20 * MIN,
+      },
+      { id: "tail", name: "Boiled Eggs", baseDurationMs: 30 * MIN, readyAt: 0 },
+    ];
+
+    pauseCookingQueue({ crafting, removedAt, placedAt: now, windows: [] });
+
+    // The head banked 10m, so 50m left from the placement; the tail never began,
+    // so it keeps chaining off whatever the head derives to.
+    expect(crafting[0].readyAt).toEqual(now + 50 * MIN);
+    expect(crafting[1].startedAt).toBeUndefined();
+    expect(crafting[1].readyAt).toEqual(now + 80 * MIN);
   });
 });

--- a/src/features/game/lib/cookingReadiness.ts
+++ b/src/features/game/lib/cookingReadiness.ts
@@ -158,7 +158,14 @@ export const pauseCookingQueue = ({
     );
     recipe.baseDurationMs -= banked;
 
-    if (recipe.startedAt !== undefined) {
+    // Re-anchor anything that had actually BEGUN by the lift. An explicit
+    // `startedAt` says so outright; `banked > 0` catches a chained recipe whose
+    // predecessor was a LEGACY one that had already finished - that predecessor
+    // keeps its wall-clock remainder, which is a `readyAt` in the PAST, and a
+    // successor left chained to it would derive a start before the placement and
+    // re-accrue the work it just banked. A recipe that had not begun keeps no
+    // anchor, so it goes on tracking the recipe ahead of it.
+    if (recipe.startedAt !== undefined || banked > 0) {
       recipe.startedAt = placedAt;
     }
   });

--- a/src/features/game/lib/cookingReadiness.ts
+++ b/src/features/game/lib/cookingReadiness.ts
@@ -2,6 +2,7 @@ import type { BuildingProduct, GameState } from "features/game/types/game";
 import {
   computeReadyAt,
   getCookingBoostWindows,
+  workAccruedAt,
   type BoostWindow,
 } from "./boostWindows";
 
@@ -103,3 +104,69 @@ export const getCookingQueueReadyAts = ({
   game: GameState;
 }): number[] =>
   resolveCookingQueue({ crafting, windows: getCookingBoostWindows(game) });
+
+/**
+ * Pause a cooking queue across a landscaping lift, in place.
+ *
+ * The rule is the same one every other activity follows: time the building spent
+ * in the inventory doesn't count. What differs is HOW, and cooking cannot use the
+ * legacy trick of shifting each start forward by the downtime. Shifting re-exposes
+ * a recipe to a different slice of the boost windows — a cook that banked 30
+ * minutes of work under an hourglass which then expired while the building sat
+ * unplaced would find that window stranded entirely before its new start, and lose
+ * the credit. So the work already done is BANKED (subtracted from
+ * `baseDurationMs`) and the recipe resumes, with only the remainder left to cook,
+ * from the moment it was placed. This mirrors `pauseWindowedTimer` for resource
+ * nodes; cooking needs its own because it pauses a CHAIN rather than one timer.
+ *
+ * The queue must be resolved BEFORE anything is mutated: a chained recipe carries
+ * no `startedAt` of its own, so how much work it had accrued is only knowable from
+ * the recipe ahead of it.
+ *
+ * Only an ANCHORED recipe (one with its own `startedAt`) is re-anchored to
+ * `placedAt`; a chained one is deliberately left chained so it keeps tracking
+ * whatever the recipe ahead of it derives to. Legacy recipes have no work model to
+ * bank into, so they keep the pre-windowed behaviour of preserving their wall-clock
+ * remainder — which is exactly what the old `timeRemaining` round-trip computed.
+ */
+export const pauseCookingQueue = ({
+  crafting,
+  removedAt,
+  placedAt,
+  windows,
+}: {
+  crafting: BuildingProduct[];
+  removedAt: number;
+  placedAt: number;
+  windows: BoostWindow[];
+}): void => {
+  const timings = resolveCookingQueueTimings({ crafting, windows });
+
+  crafting.forEach((recipe, index) => {
+    const { startedAt } = timings[index];
+
+    if (recipe.baseDurationMs === undefined || startedAt === undefined) {
+      // Not clamped: a recipe that finished before the lift keeps its negative
+      // remainder and stays ready, as it did before.
+      recipe.readyAt = placedAt + (recipe.readyAt - removedAt);
+      return;
+    }
+
+    const banked = Math.min(
+      workAccruedAt({ startedAt, at: removedAt, windows }),
+      recipe.baseDurationMs,
+    );
+    recipe.baseDurationMs -= banked;
+
+    if (recipe.startedAt !== undefined) {
+      recipe.startedAt = placedAt;
+    }
+  });
+
+  // Refresh the cache so it agrees with the derived chain again.
+  const readyAts = resolveCookingQueue({ crafting, windows });
+  crafting.forEach((recipe, index) => {
+    recipe.readyAt = readyAts[index];
+    delete recipe.timeRemaining;
+  });
+};


### PR DESCRIPTION
Companion to sunflower-land-api#3562 (BE) — same eight commits, same split. **Merge the BE first.**

An audit of the lift/re-place "pause" mechanic across every activity. The intended effect is unchanged — time an item spends unplaced doesn't count, and it's recalculated when it goes back down — but the recalculation was wrong in several places. Two rules came out of it:

1. **Never recompute a duration from live game state on re-place.** The duration is a snapshot taken when the task started.
2. **Bank work, don't shift the timeline, once a timer is windowed.** Shifting re-exposes a task to a different slice of the boost windows.

Reviewed commit by commit — each one stands alone and was verified in isolation.

### `[FIX] Don't re-price in-flight timers when a building is placed back down`

`placeLavaPit` and `placeBuilding` recomputed a burn's / compost batch's duration from current state, so a boost acquired *after* the task started applied to it retroactively:

- equip the Obsidian Necklace, lift the pit, re-place → **71h remaining became 35h**
- place a Soil Krabby, lift the composter → **36 minutes off an in-flight 6h batch**

Both live on mainnet today — neither is behind `SPEED_BOOSTS`. They now shift every timestamp they own by the downtime, matching the Crafting Box and Aging Shed. A pit with no stored `readyAt` keeps none — inventing one is the same re-derivation, and `collectLavaPit` already falls back to `startedAt`.

### `[FIX] Collect lava pits against the duration snapshotted at start`

`collectLavaPit` gated collection on *both* the stored `readyAt` and a live recomputation, taking whichever was later. The live branch was the fallback for pits started before `readyAt` existed (#6287) but was never scoped to them, so taking the necklace off mid-burn held a 36h pit to the full 72h. The snapshot is now authoritative in both directions — equipping or unequipping mid-burn changes nothing until the next burn.

The UI needed no change: `LavaPit.tsx` and the modal already read the stored `readyAt`, and only show the live duration as the next-burn preview under `!lavaPitInProgress`.

### `[FIX] Pause cooking queues while the building is unplaced`

`removeBuilding` banked a `timeRemaining` off the cached `readyAt`, but `resolveCookingQueueTimings` derives from `startedAt` + `baseDurationMs` and ignores that cache — so windowed recipes kept cooking in the inventory while legacy ones paused correctly. Verified: a 30-minute lift moved the derived ready time by **zero**.

New `pauseCookingQueue` resolves the queue *before* mutating (a chained recipe's accrued work is only knowable from the recipe ahead of it), banks that work off each `baseDurationMs`, and re-anchors only anchored recipes. Chained recipes stay chained so they keep tracking the recipe ahead.

The test worth reading is `keeps boost credit earned before the lift when the window expires during it`: a 60m cook banks 30m under a 2× hourglass that then expires *during* the downtime. Bank-and-shrink gives `now + 30m`; shifting the start instead would strand the window before the new start and give `now + 45m`.

### `[FIX] Reject harvesting and collecting from unplaced items`

`harvest`, `harvestFlower` and `collectRecipe` had no placement guard, unlike every other collect event. Since the pause is only applied on re-place, collecting while the item sat in the inventory side-stepped it entirely — a lifted plot could be harvested outright.

Note for reviewers: `harvest.test.ts` built most fixtures by spreading `GAME_STATE.crops[0]`, which resolved to `undefined` because no such plot existed — so those plots had no coordinates and 34 tests died on the new guard. `firstId` is pinned to `"12"` because `Object.keys` orders integer-like keys numerically, so adding plot `0` would otherwise move it off the plot the AOE fixtures are built around.

### `[CHORE] Cover the aging shed racks that lift/re-place already shifts`

Only fermentation was pinned by a test; adds the aging rack so all three are covered.

### `[FIX] Pause sunstone recovery the same way as every other rock`

`placeSunstone` hand-rolled a back-date while the other four rocks use `pauseWindowedTimer`. No behaviour change today — sunstone has no boost windows — but it writes `baseDurationMs` like the rest, so adding a sunstone boost later would silently lose pre-lift credit. Done now rather than deferred because sunstone is already migrated, so no upcoming slice would revisit that handler.

### `[FIX] Do not re-credit banked work behind a completed legacy recipe`

Raised by the BE review bot. `pauseCookingQueue` re-anchored only recipes carrying their own `startedAt`. A legacy recipe keeps its wall-clock remainder — which for one that had already *finished* is a `readyAt` in the past — so a windowed recipe chained to it derived a start before the placement and re-accrued the work it had just banked.

With a legacy recipe done at `T0`, a chained 60m cook lifted at `T0+20m` and placed at `T0+50m` finished at `T0+70m` instead of `T0+90m`: the 20 minutes counted twice. Now anything that had actually begun by the lift (`banked > 0`) is re-anchored. The all-windowed path was already correct, which is why the original tests missed it.

### `[FIX] Reject collecting from more unplaced buildings`

Raised by CodeRabbit against `collectLavaPit`, and it was the tip of a larger miss — the earlier sweep used a hand-picked file list rather than every collect event. Five were unguarded:

- `collectLavaPit` — collected an unplaced pit outright, granting Obsidian
- `harvestGreenHouse` — checked the `Greenhouse` array existed, not that one was *placed*
- `collectCrafting` — no building check at all
- `collectCompost`, `collectProcessedResource` — found the building by id without checking `coordinates`

The greenhouse pots, crafting queue and aging shed racks live on the game state rather than on the building, so lifting it never put them out of reach. The aging shed events were already guarded via `hasPlacedAgingShed` (a helper, which is why a coordinate grep missed them), and water traps cannot be lifted. `bulkHarvest` is covered transitively — it calls the guarded `harvestCropFromPlot` inside a try/catch, so an unplaced plot is skipped rather than throwing the batch.

## Deliberately not in scope

- **Crop Machine** — its `placeBuilding` block is still ungated and `removeBuilding` writes `pausedTimeRemaining` twice. Both unreachable today, and its speed-boost slice rewrites that exact code.
- **Crafting Box** — pause handling is already correct and complete. It needs `pauseWindowedTimer` only once the Fox Shrine slice makes crafting windowed, which is a step inside that slice.
- **Water Well** — `upgradeTime` is a flat per-level constant with no boost, so a downtime shift is permanently correct.

## Testing

Red-first throughout, and each fix mutation-checked by reverting the source and confirming the new tests fail.

**Browser-verified** on a local dev server (`SPEED_BOOSTS` on): cooking pauses across a lift, a two-recipe queue keeps its chain and both entries shift by the downtime, and a lava pit neither re-prices on re-place nor reacts to the Obsidian Necklace being equipped or removed mid-burn. The composter case and a full normal-collection regression pass have not been walked through by hand — the composter shares the re-pricing path already verified on the lava pit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented harvesting or collecting from unplaced crops, flower beds, greenhouses, and processing or cooking buildings.
  * Cooking, lava pit, sunstone recovery, and aging timers now preserve progress accurately when buildings or resources are lifted and placed again.
  * Boost effects are locked in when work begins, preventing later equipment changes from incorrectly changing active timers.
  * Preserved progress earned before removal across composting, cooking, lava burns, recovery, and aging tasks.
* **Tests**
  * Added coverage for placement validation, timer behavior, boosts, and progress preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
