### PR TITLE
[FIX] Show wearable names in marketplace offers

### DIFF
--- a/src/features/marketplace/components/TradeableOffers.tsx
+++ b/src/features/marketplace/components/TradeableOffers.tsx
@@ -163,7 +163,8 @@ export const TradeableOffers: React.FC<{
   };
 
   const loading = !tradeable;
-  const isResource = isTradeResource(KNOWN_ITEMS[Number(id)]);
+  const isResource =
+    display.type === "collectibles" && isTradeResource(KNOWN_ITEMS[Number(id)]);
   const isVIP = useVipAccess({ game: gameService.getSnapshot().context.state });
 
   const vipIsRequired = tradeable?.isVip && !isVIP;


### PR DESCRIPTION
## Problem

<img width="944" height="644" alt="image" src="https://github.com/user-attachments/assets/05d1a0eb-7a9b-4b4f-9908-58487ec98ba5" />


Marketplace offer rows could show `1` instead of the wearable name. This happened for Pickaxe Shark because wearable token ID `257` overlaps with the collectible resource ID for Barley.

The offers panel classified resources by numeric ID alone, so a wearable with a colliding ID was rendered through the resource table. Listings and the make-offer flow already include the collection in this decision.

## Change

- require the tradeable collection to be `collectibles` before treating an offer as a resource
- preserve quantity and price-per-unit rendering for real resources
- restore the item-name offer layout for wearables and other non-collectible collections with overlapping IDs

## Validation

- `yarn prettier --check src/features/marketplace/components/TradeableOffers.tsx`
- `yarn eslint --quiet src/features/marketplace/components/TradeableOffers.tsx`
- `yarn tsc --noEmit`
- `git diff --check`

React component tests were not added, following the repository handoff rule not to write tests for `.tsx` files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved marketplace offer handling so resource-specific details and taxes appear only for collectible resources.
  - Standard offers now consistently use the regular offer display and acceptance flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->