### PR TITLE
[FIX] Show known water trap catch

### DIFF
--- a/src/features/island/fisherman/WaterTrapSpot.tsx
+++ b/src/features/island/fisherman/WaterTrapSpot.tsx
@@ -130,7 +130,7 @@ export const WaterTrapSpot: React.FC<Props> = ({ id }) => {
   const caught = waterTrap?.caught ? getKeys(waterTrap.caught)[0] : undefined;
   const caughtItem =
     caught &&
-    caught in CRUSTACEANS &&
+    CRUSTACEANS.includes(caught) &&
     (farmActivity[`${caught} Caught`] ?? 0) > 0
       ? caught
       : undefined;
@@ -170,12 +170,12 @@ export const WaterTrapSpot: React.FC<Props> = ({ id }) => {
               showPopover={showTimerPopover}
               timeLeft={secondsLeft}
               secondaryImage={
-                waterTrap.chum != null
+                !caughtItem && waterTrap.chum != null
                   ? ITEM_DETAILS[waterTrap.chum].image
                   : undefined
               }
               secondaryDescription={
-                waterTrap.chum != null
+                !caughtItem && waterTrap.chum != null
                   ? `${CRUSTACEAN_CHUM_AMOUNTS[waterTrap.chum]} ${waterTrap.chum}`
                   : undefined
               }


### PR DESCRIPTION
## Problem

<img width="197" height="147" alt="image" src="https://github.com/user-attachments/assets/d5f9b2f7-d858-4ae1-b833-73036f34b831" />


The in-progress water trap popover always showed the unknown catch icon, even when the player had already discovered that catch. The catch validation used JavaScript's `in` operator against the `CRUSTACEANS` array, which checks array property keys rather than contained values.

The popover also continued to show the used chum after the resulting catch was known, duplicating information that was only useful while discovering a combination.

## Changes

<img width="161" height="133" alt="image" src="https://github.com/user-attachments/assets/7646d9c8-cf20-4c95-b612-7e53a2ad11eb" />


- Check known catches with `CRUSTACEANS.includes(caught)` so previously discovered catches are revealed after placing a trap.
- Keep first-time catches hidden behind the unknown icon until they have been collected before.
- Hide the secondary chum image and label when the resulting catch is known.
- Continue showing the chum alongside the unknown icon for undiscovered combinations.

## Validation

- `yarn tsc --noEmit`
- Targeted ESLint for `WaterTrapSpot.tsx`
- Prettier check for `WaterTrapSpot.tsx`
- `git diff --check`
- Isolated DevStand prepared with both trap types, all chum types, and all combinations marked as previously discovered; manual visual review is pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected identification of caught crustaceans in water traps.
  * Updated trap details to show the secondary image and description only when no caught item is identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->