### PR TITLE
[FEAT] Show Bud Box availability in Plaza

### DIFF
--- a/src/components/ui/CheckList.tsx
+++ b/src/components/ui/CheckList.tsx
@@ -16,7 +16,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { NoticeboardItems } from "features/world/ui/kingdom/KingdomNoticeboard";
 import { isMinigameComplete } from "features/game/events/minigames/claimMinigamePrize";
 import { PORTAL_OPTIONS } from "features/world/ui/portals/PortalChooser";
-import { BUD_ORDER, getDailyBudBoxType } from "features/world/ui/chests/BudBox";
+import { BUD_ORDER, getDailyBudBoxType } from "features/game/lib/budBox";
 import {
   getDayOfYear,
   secondsTillReset,

--- a/src/features/game/lib/budBox.ts
+++ b/src/features/game/lib/budBox.ts
@@ -1,0 +1,23 @@
+import type { TypeTrait } from "features/game/types/buds";
+
+export const BUD_ORDER: TypeTrait[] = [
+  "Plaza",
+  "Woodlands",
+  "Cave",
+  "Sea",
+  "Castle",
+  "Port",
+  "Retreat",
+  "Saphiro",
+  "Snow",
+  "Beach",
+];
+
+/**
+ * Based on day of year + year to get a consistent order of buds
+ */
+export function getDailyBudBoxType(ms: number): TypeTrait {
+  const daysSinceEpoch = Math.floor(ms / (1000 * 60 * 60 * 24)) + 2; // +2 to match with current order
+  const index = daysSinceEpoch % BUD_ORDER.length;
+  return BUD_ORDER[index];
+}

--- a/src/features/world/scenes/PlazaScene.ts
+++ b/src/features/world/scenes/PlazaScene.ts
@@ -28,7 +28,6 @@ import { getAnimationUrl } from "../lib/animations";
 import { tokenUriBuilder } from "lib/utils/tokenUriBuilder";
 import type { Player } from "../types/Room";
 import { getDailyBudBoxType } from "features/game/lib/budBox";
-import { getDayOfYear } from "lib/utils/time";
 
 const CHAPTER_BANNERS: Record<ChapterName, string | undefined> = {
   "Solar Flare": undefined,
@@ -222,7 +221,8 @@ export class PlazaScene extends BaseScene {
     const openedAt = this.gameState.pumpkinPlaza.budBox?.openedAt ?? 0;
     const hasOpenedToday =
       !!openedAt &&
-      getDayOfYear(new Date(now)) === getDayOfYear(new Date(openedAt));
+      new Date(now).toISOString().substring(0, 10) ===
+        new Date(openedAt).toISOString().substring(0, 10);
 
     return hasTodayBud && !hasOpenedToday;
   }

--- a/src/features/world/scenes/PlazaScene.ts
+++ b/src/features/world/scenes/PlazaScene.ts
@@ -582,12 +582,7 @@ export class PlazaScene extends BaseScene {
       this.add.sprite(825, 50, "locked_disc").setDepth(1000000000);
     }
 
-    const clubHouseLabel = new Label(
-      this,
-      "CLUBHOUSE",
-      "brown",
-      "delivery_icon",
-    );
+    const clubHouseLabel = new Label(this, "CLUBHOUSE", "brown", "gift_icon");
     clubHouseLabel.setPosition(152, 262);
     clubHouseLabel.setDepth(10000000);
     this.add.existing(clubHouseLabel);

--- a/src/features/world/scenes/PlazaScene.ts
+++ b/src/features/world/scenes/PlazaScene.ts
@@ -27,6 +27,10 @@ import { BumpkinContainer } from "../containers/BumpkinContainer";
 import { getAnimationUrl } from "../lib/animations";
 import { tokenUriBuilder } from "lib/utils/tokenUriBuilder";
 import type { Player } from "../types/Room";
+import emptyDisc from "assets/icons/empty_disc.png";
+import emptyDiscBackground from "assets/icons/empty_disc_background.png";
+import { getDailyBudBoxType } from "../ui/chests/BudBox";
+import { getDayOfYear } from "lib/utils/time";
 
 const CHAPTER_BANNERS: Record<ChapterName, string | undefined> = {
   "Solar Flare": undefined,
@@ -212,6 +216,19 @@ export class PlazaScene extends BaseScene {
     });
   }
 
+  private isBudBoxRewardAvailable(now = Date.now()) {
+    const todayBud = getDailyBudBoxType(now);
+    const hasTodayBud = Object.values(this.gameState.buds ?? {}).some(
+      (bud) => bud.type === todayBud,
+    );
+    const openedAt = this.gameState.pumpkinPlaza.budBox?.openedAt ?? 0;
+    const hasOpenedToday =
+      !!openedAt &&
+      getDayOfYear(new Date(now)) === getDayOfYear(new Date(openedAt));
+
+    return hasTodayBud && !hasOpenedToday;
+  }
+
   preload() {
     this.load.audio("chime", SOUNDS.notifications.chime);
 
@@ -270,6 +287,8 @@ export class PlazaScene extends BaseScene {
     this.load.image("locked_disc", "world/locked_disc.png");
     this.load.image("key_disc", "world/key_disc.png");
     this.load.image("luxury_key_disc", "world/luxury_key_disc.png");
+    this.load.image("empty_disc", emptyDisc);
+    this.load.image("empty_disc_background", emptyDiscBackground);
 
     // Stella Megastore items
     this.load.image("magma_stone", "world/magma_stone.webp");
@@ -744,7 +763,9 @@ export class PlazaScene extends BaseScene {
       .setInteractive({ cursor: "pointer" })
       .on("pointerdown", () => {
         if (this.checkDistanceToSprite(turtle, 75)) {
-          interactableModalManager.open("bud");
+          interactableModalManager.open(
+            this.isBudBoxRewardAvailable() ? "bud_box_guide" : "bud",
+          );
         } else {
           this.currentPlayer?.speak(translateForBubble("base.iam.far.away"));
         }
@@ -774,6 +795,24 @@ export class PlazaScene extends BaseScene {
           this.currentPlayer?.speak(translateForBubble("base.iam.far.away"));
         }
       });
+
+    const budBoxIndicator = this.add
+      .container(118.5, 275.5)
+      .setDepth(1000000000)
+      .setVisible(false);
+    budBoxIndicator.add(this.add.image(0, 0, "empty_disc_background"));
+    budBoxIndicator.add(this.add.image(0, 0, "empty_disc"));
+    budBoxIndicator.add(this.add.image(0, -2, "chest").setDisplaySize(12, 14));
+
+    const refreshBudBoxIndicator = () => {
+      budBoxIndicator.setVisible(this.isBudBoxRewardAvailable());
+    };
+
+    refreshBudBoxIndicator();
+    this.game.events.on("gameStateUpdated", refreshBudBoxIndicator);
+    this.events.once("shutdown", () => {
+      this.game.events.off("gameStateUpdated", refreshBudBoxIndicator);
+    });
 
     if (this.textures.exists("sparkle")) {
       const sparkle = this.add.sprite(567, 191, "sparkle");
@@ -867,6 +906,7 @@ export class PlazaScene extends BaseScene {
 
       snowHornBud.setVisible(!isOpen);
       chest.setVisible(!isOpen);
+      refreshBudBoxIndicator();
 
       if (wasOpen === isOpen) {
         this.mmoService?.state.context.server?.send(0, {

--- a/src/features/world/scenes/PlazaScene.ts
+++ b/src/features/world/scenes/PlazaScene.ts
@@ -29,7 +29,7 @@ import { tokenUriBuilder } from "lib/utils/tokenUriBuilder";
 import type { Player } from "../types/Room";
 import emptyDisc from "assets/icons/empty_disc.png";
 import emptyDiscBackground from "assets/icons/empty_disc_background.png";
-import { getDailyBudBoxType } from "../ui/chests/BudBox";
+import { getDailyBudBoxType } from "features/game/lib/budBox";
 import { getDayOfYear } from "lib/utils/time";
 
 const CHAPTER_BANNERS: Record<ChapterName, string | undefined> = {

--- a/src/features/world/scenes/PlazaScene.ts
+++ b/src/features/world/scenes/PlazaScene.ts
@@ -27,8 +27,6 @@ import { BumpkinContainer } from "../containers/BumpkinContainer";
 import { getAnimationUrl } from "../lib/animations";
 import { tokenUriBuilder } from "lib/utils/tokenUriBuilder";
 import type { Player } from "../types/Room";
-import emptyDisc from "assets/icons/empty_disc.png";
-import emptyDiscBackground from "assets/icons/empty_disc_background.png";
 import { getDailyBudBoxType } from "features/game/lib/budBox";
 import { getDayOfYear } from "lib/utils/time";
 
@@ -287,8 +285,6 @@ export class PlazaScene extends BaseScene {
     this.load.image("locked_disc", "world/locked_disc.png");
     this.load.image("key_disc", "world/key_disc.png");
     this.load.image("luxury_key_disc", "world/luxury_key_disc.png");
-    this.load.image("empty_disc", emptyDisc);
-    this.load.image("empty_disc_background", emptyDiscBackground);
 
     // Stella Megastore items
     this.load.image("magma_stone", "world/magma_stone.webp");
@@ -586,7 +582,12 @@ export class PlazaScene extends BaseScene {
       this.add.sprite(825, 50, "locked_disc").setDepth(1000000000);
     }
 
-    const clubHouseLabel = new Label(this, "CLUBHOUSE", "brown");
+    const clubHouseLabel = new Label(
+      this,
+      "CLUBHOUSE",
+      "brown",
+      "delivery_icon",
+    );
     clubHouseLabel.setPosition(152, 262);
     clubHouseLabel.setDepth(10000000);
     this.add.existing(clubHouseLabel);
@@ -796,16 +797,8 @@ export class PlazaScene extends BaseScene {
         }
       });
 
-    const budBoxIndicator = this.add
-      .container(118.5, 275.5)
-      .setDepth(1000000000)
-      .setVisible(false);
-    budBoxIndicator.add(this.add.image(0, 0, "empty_disc_background"));
-    budBoxIndicator.add(this.add.image(0, 0, "empty_disc"));
-    budBoxIndicator.add(this.add.image(0, -2, "chest").setDisplaySize(12, 14));
-
     const refreshBudBoxIndicator = () => {
-      budBoxIndicator.setVisible(this.isBudBoxRewardAvailable());
+      clubHouseLabel.setIconVisible(this.isBudBoxRewardAvailable());
     };
 
     refreshBudBoxIndicator();

--- a/src/features/world/ui/InteractableModals.tsx
+++ b/src/features/world/ui/InteractableModals.tsx
@@ -72,6 +72,7 @@ type InteractableName =
   | "nye_button"
   | "welcome_sign"
   | "bud"
+  | "bud_box_guide"
   | "plaza_statue"
   | "auction_item"
   | "boat_modal"
@@ -326,6 +327,16 @@ export const InteractableModals: React.FC<Props> = ({ id, scene }) => {
           message={[
             {
               text: t("interactableModals.bud.message"),
+            },
+          ]}
+        />
+      </Modal>
+      <Modal show={interactable === "bud_box_guide"} onHide={closeModal}>
+        <SpeakingModal
+          onClose={closeModal}
+          message={[
+            {
+              text: t("interactableModals.bud.dailyPrizeAvailable"),
             },
           ]}
         />

--- a/src/features/world/ui/chests/BudBox.tsx
+++ b/src/features/world/ui/chests/BudBox.tsx
@@ -15,7 +15,8 @@ import rewardsIcon from "assets/icons/stock.webp";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { ChestRevealing } from "./ChestRevealing";
 import { getKeys } from "lib/object";
-import type { Bud, TypeTrait } from "features/game/types/buds";
+import type { Bud } from "features/game/types/buds";
+import { BUD_ORDER, getDailyBudBoxType } from "features/game/lib/budBox";
 import {
   getDayOfYear,
   secondsTillReset,
@@ -28,28 +29,6 @@ import type { PanelTabs } from "features/game/components/CloseablePanel";
 interface Props {
   onClose: () => void;
   setIsLoading?: (isLoading: boolean) => void;
-}
-
-export const BUD_ORDER: TypeTrait[] = [
-  "Plaza",
-  "Woodlands",
-  "Cave",
-  "Sea",
-  "Castle",
-  "Port",
-  "Retreat",
-  "Saphiro",
-  "Snow",
-  "Beach",
-];
-
-/**
- * Based on day of year + year to get a consistent order of buds
- */
-export function getDailyBudBoxType(ms: number): TypeTrait {
-  const daysSinceEpoch = Math.floor(ms / (1000 * 60 * 60 * 24)) + 2; // +2 to match with current order
-  const index = daysSinceEpoch % BUD_ORDER.length;
-  return BUD_ORDER[index];
 }
 
 export const BudBox: React.FC<Props> = ({ onClose, setIsLoading }) => {

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2472,6 +2472,7 @@
   "interactableModals.fatChicken.message": "Why won't these Bumpkins leave me alone, I just want to relax.",
   "interactableModals.lazyBud.message": "Eeeep! So tired.....",
   "interactableModals.bud.message": "Hmmm, I better leave that bud alone. I'm sure it's owner is looking for it",
+  "interactableModals.bud.dailyPrizeAvailable": "Your daily prize is waiting for you inside.",
   "interactableModals.walrus.message": "Arrr arr arrr! The fish shop ain't open 'til I get my fish.",
   "interactableModals.plazaBlueBook.message1": "To summon the seekers, we must gather the essence of the land - pumpkins, nurtured by the earth, and eggs, the promise of new beginnings. ",
   "interactableModals.plazaBlueBook.message2": "As dusk falls and the moon casts its silvery glow, we offer our humble gifts, hoping to awaken their watchful eyes once more.",


### PR DESCRIPTION
## Problem

The Plaza Bud Box is hidden inside the Clubhouse, so players cannot tell from outside whether today's reward is available. NPC delivery labels already expose ready rewards with a standard chest icon, but the Bud Box has no equivalent signal.

## Changes

- show the existing gift icon beside the `CLUBHOUSE` label when the player owns today's required Bud type and has not opened the Bud Box today
- reuse the same `Label` icon mechanism and `gift_icon` asset (`world/gift.png`)
- refresh its visibility when game state changes, so it disappears after the daily reward is opened
- give the highlighted Bud a contextual message while the reward is available: “Your daily prize is waiting for you inside.”
- preserve the existing Bud dialogue when the reward is unavailable

## Validation

- `yarn prettier --check src/features/world/scenes/PlazaScene.ts src/features/world/ui/InteractableModals.tsx src/lib/i18n/dictionaries/dictionary.json`
- `yarn eslint --quiet src/features/world/scenes/PlazaScene.ts src/features/world/ui/InteractableModals.tsx`
- `yarn tsc --noEmit`
- `git diff --check`
- the reward-availability flow and dialogue were previously reviewed through the isolated `bud-box-ready` DevStand preset; the latest gift-icon presentation was validated statically

The DevStand preset is local preview-only infrastructure and is not included in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a daily bud box reward indicator near the clubhouse when a prize is available.
  * Players can interact with the turtle bud to view guidance for claiming an available daily prize.
  * Added messaging to let players know when their daily prize is waiting inside.
  * The indicator updates automatically as reward availability changes during gameplay.
  * Daily reward availability now reflects the player’s owned buds and whether the day’s box has already been opened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->