### PR TITLE
[FEAT] Show resource trade count badges

### DIFF
--- a/src/features/marketplace/components/MakeOffer.tsx
+++ b/src/features/marketplace/components/MakeOffer.tsx
@@ -30,6 +30,7 @@ import { RequiredReputation } from "features/island/hud/components/reputation/Re
 import { SUNNYSIDE } from "assets/sunnyside";
 import { getKeys } from "lib/object";
 import { useNow } from "lib/utils/hooks/useNow";
+import { MAX_ITEM_OFFERS } from "../lib/tradeLimits";
 import {
   Locked,
   useIsLocked,
@@ -127,7 +128,7 @@ export const MakeOffer: React.FC<{
     );
   }
 
-  if (itemOfferCount >= 5) {
+  if (itemOfferCount >= MAX_ITEM_OFFERS) {
     return (
       <>
         <div className="p-2">

--- a/src/features/marketplace/components/ResourceList.tsx
+++ b/src/features/marketplace/components/ResourceList.tsx
@@ -25,10 +25,9 @@ import { getResourceTax } from "features/game/types/marketplace";
 import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import { InnerPanel } from "components/ui/Panel";
 import { useNow } from "lib/utils/hooks/useNow";
+import { MAX_RESOURCE_LISTINGS } from "../lib/tradeLimits";
 
 const LISTING_MULTIPLE_MIN = 1;
-const MAX_LISTINGS_OF_RESOURCE_FOR_BULK = 20;
-
 type Props = {
   inventoryCount: Decimal;
   itemName: TradeResource;
@@ -359,7 +358,7 @@ export const ResourceList: React.FC<Props> = ({
               <InnerPanel>
                 <p className="text-xxs w-40 px-0.5">
                   {t("marketplace.maxBulk", {
-                    max: MAX_LISTINGS_OF_RESOURCE_FOR_BULK,
+                    max: MAX_RESOURCE_LISTINGS,
                   })}
                 </p>
               </InnerPanel>

--- a/src/features/marketplace/components/TradeableList.tsx
+++ b/src/features/marketplace/components/TradeableList.tsx
@@ -44,6 +44,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { FaceRecognition } from "features/retreat/components/personhood/FaceRecognition";
 import { isFaceVerified } from "features/retreat/components/personhood/lib/faceRecognition";
 import { useNow } from "lib/utils/hooks/useNow";
+import { MAX_RESOURCE_LISTINGS } from "../lib/tradeLimits";
 import {
   Locked,
   useIsLocked,
@@ -143,7 +144,12 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
       ).length
     : 0;
   const maxMultiple =
-    currentListingCount >= 20 ? 1 : Math.min(20, 20 - currentListingCount);
+    currentListingCount >= MAX_RESOURCE_LISTINGS
+      ? 1
+      : Math.min(
+          MAX_RESOURCE_LISTINGS,
+          MAX_RESOURCE_LISTINGS - currentListingCount,
+        );
 
   // Otherwise show the list item UI
   const submitListing = () => {

--- a/src/features/marketplace/components/TradeableList.tsx
+++ b/src/features/marketplace/components/TradeableList.tsx
@@ -137,7 +137,7 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
     return count - totalListed;
   };
 
-  // For resources: cap at 20 listings per resource; when at 20, only 1 more allowed.
+  // For resources: cap at 20 listings per resource.
   const currentListingCount = isResource
     ? Object.values(state.trades.listings ?? {}).filter(
         (listing) => (listing.items[display.name] ?? 0) > 0,
@@ -145,7 +145,7 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
     : 0;
   const maxMultiple =
     currentListingCount >= MAX_RESOURCE_LISTINGS
-      ? 1
+      ? 0
       : Math.min(
           MAX_RESOURCE_LISTINGS,
           MAX_RESOURCE_LISTINGS - currentListingCount,

--- a/src/features/marketplace/components/profile/MyListings.tsx
+++ b/src/features/marketplace/components/profile/MyListings.tsx
@@ -26,6 +26,7 @@ import {
 } from "features/game/types/marketplace";
 import { Button } from "components/ui/Button";
 import { BulkRemoveTrades } from "../BulkRemoveListings";
+import { MAX_RESOURCE_LISTINGS } from "../../lib/tradeLimits";
 
 const _isCancellingOffer = (state: MachineState) =>
   state.matches("marketplaceListingCancelling");
@@ -98,7 +99,18 @@ export const MyListings: React.FC<Props> = ({ fullHeight = false }) => {
         )
       : listings;
 
-  if (getKeys(filteredListings).length === 0) return null;
+  const filteredListingIds = getKeys(filteredListings);
+  const selectedListing = filteredListings[filteredListingIds[0]];
+  const selectedItemName = selectedListing
+    ? (getKeys(selectedListing.items ?? {})[0] as InventoryItemName)
+    : undefined;
+  const showResourceListingCount =
+    !!params.id &&
+    routeCollection === "collectibles" &&
+    !!selectedItemName &&
+    isTradeResource(selectedItemName);
+
+  if (filteredListingIds.length === 0) return null;
 
   const claim = () => {
     const listing = listings[claimId as string];
@@ -160,9 +172,16 @@ export const MyListings: React.FC<Props> = ({ fullHeight = false }) => {
           className={fullHeight ? "flex h-full min-h-0 flex-col p-2" : "p-2"}
         >
           <div className="flex items-center justify-between mb-2">
-            <Label type="default" icon={trade}>
-              {t("marketplace.myListings")}
-            </Label>
+            <div className="flex items-center gap-1">
+              <Label type="default" icon={trade}>
+                {t("marketplace.myListings")}
+              </Label>
+              {showResourceListingCount && (
+                <Label type="default">
+                  {`${filteredListingIds.length}/${MAX_RESOURCE_LISTINGS}`}
+                </Label>
+              )}
+            </div>
             <Button
               className="w-fit h-8 rounded-none"
               onClick={() => setBulkCancel(true)}
@@ -175,7 +194,7 @@ export const MyListings: React.FC<Props> = ({ fullHeight = false }) => {
           <div
             className={fullHeight ? "flex min-h-0 flex-1" : "flex flex-wrap"}
           >
-            {getKeys(filteredListings).length === 0 ? (
+            {filteredListingIds.length === 0 ? (
               <p className="text-sm">{t("marketplace.noMyListings")}</p>
             ) : (
               <div
@@ -183,7 +202,7 @@ export const MyListings: React.FC<Props> = ({ fullHeight = false }) => {
                   fullHeight ? "h-full min-h-0" : "max-h-[200px]"
                 }`}
               >
-                {getKeys(filteredListings).map((id, index) => {
+                {filteredListingIds.map((id, index) => {
                   const listing = listings[id];
                   const itemName = getKeys(
                     listing.items ?? {},

--- a/src/features/marketplace/components/profile/MyOffers.tsx
+++ b/src/features/marketplace/components/profile/MyOffers.tsx
@@ -24,6 +24,7 @@ import lock from "assets/icons/lock.png";
 import trade from "assets/icons/trade.png";
 import { BulkRemoveTrades } from "../BulkRemoveListings";
 import { Button } from "components/ui/Button";
+import { MAX_ITEM_OFFERS } from "../../lib/tradeLimits";
 
 const _authToken = (state: AuthMachineState) =>
   state.context.user.rawToken as string;
@@ -87,9 +88,20 @@ export const MyOffers: React.FC<Props> = ({ fullHeight = false }) => {
         )
       : offers;
 
+  const filteredOfferIds = getKeys(filteredOffers);
+  const selectedOffer = filteredOffers[filteredOfferIds[0]];
+  const selectedItemName = selectedOffer
+    ? (getKeys(selectedOffer.items ?? {})[0] as InventoryItemName)
+    : undefined;
+  const showResourceOfferCount =
+    !!params.id &&
+    routeCollection === "collectibles" &&
+    !!selectedItemName &&
+    isTradeResource(selectedItemName);
+
   const navigate = useNavigate();
 
-  if (getKeys(filteredOffers).length === 0) return null;
+  if (filteredOfferIds.length === 0) return null;
 
   const escrowedSFL = getKeys(offers).reduce(
     (total, id) => total + offers[id].sfl,
@@ -164,9 +176,16 @@ export const MyOffers: React.FC<Props> = ({ fullHeight = false }) => {
         >
           <div className="flex justify-between flex-col mb-2">
             <div className="flex items-center justify-between mb-1">
-              <Label type="default" icon={trade}>
-                {t("marketplace.myOffers")}
-              </Label>
+              <div className="flex items-center gap-1">
+                <Label type="default" icon={trade}>
+                  {t("marketplace.myOffers")}
+                </Label>
+                {showResourceOfferCount && (
+                  <Label type="default">
+                    {`${filteredOfferIds.length}/${MAX_ITEM_OFFERS}`}
+                  </Label>
+                )}
+              </div>
               <Button
                 className="w-fit h-8 rounded-none"
                 onClick={() => setBulkCancel(true)}
@@ -185,7 +204,7 @@ export const MyOffers: React.FC<Props> = ({ fullHeight = false }) => {
           <div
             className={fullHeight ? "flex min-h-0 flex-1" : "flex flex-wrap"}
           >
-            {getKeys(filteredOffers).length === 0 ? (
+            {filteredOfferIds.length === 0 ? (
               <p className="text-sm">{t("marketplace.noMyOffers")}</p>
             ) : (
               <div
@@ -193,7 +212,7 @@ export const MyOffers: React.FC<Props> = ({ fullHeight = false }) => {
                   fullHeight ? "h-full min-h-0" : "max-h-[200px]"
                 }`}
               >
-                {getKeys(filteredOffers).map((id, index) => {
+                {filteredOfferIds.map((id, index) => {
                   const offer = filteredOffers[id];
                   const itemName = getKeys(
                     offer.items ?? {},

--- a/src/features/marketplace/lib/tradeLimits.ts
+++ b/src/features/marketplace/lib/tradeLimits.ts
@@ -1,0 +1,2 @@
+export const MAX_RESOURCE_LISTINGS = 20;
+export const MAX_ITEM_OFFERS = 5;


### PR DESCRIPTION
## Summary

<img width="846" height="572" alt="telegram-cloud-photo-size-2-5210717283892798111-y" src="https://github.com/user-attachments/assets/03b72441-06fa-487c-a82a-53d6d638b295" />


- show **active listing and offer** counts beside the corresponding marketplace profile headings
- scope count badges to the currently opened trade resource only
- share the resource listing and per-item offer limits with the existing creation flows

## Behavior

- `Your listings` shows a neutral `current/20` badge when the player has active listings for the opened resource
- `Your offers` shows a neutral `current/5` badge when the player has active offers for the opened resource
- badges are hidden on the general profile page and for non-resource collectibles, wearables, buds, pets, and economies
- sections with no matching active trades remain hidden as before

## Validation

- `tsc --noEmit`
- targeted ESLint for all changed files
- Prettier for all changed files
- `git diff --check`
- visually reviewed in an isolated Community Farm DevStand


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added marketplace counters showing current resource listings and item offers against their limits.
  * Added consistent limits for resource listings and item offers.
* **Bug Fixes**
  * Standardized marketplace limit enforcement across listing and offer creation.
  * Prevented additional listings or offers when the maximum capacity is reached.
  * Improved handling of filtered marketplace listings and offers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->