### PR TITLE
[FIX] Petal Blessed completes windowed flowers

### DIFF
--- a/src/features/game/events/landExpansion/skillUsed.test.ts
+++ b/src/features/game/events/landExpansion/skillUsed.test.ts
@@ -3,6 +3,7 @@ import { skillUse, getSkillCooldown } from "./skillUsed";
 import { CROPS } from "features/game/types/crops";
 import { COOKABLES } from "features/game/types/consumables";
 import { FLOWER_SEEDS, FLOWERS } from "features/game/types/flowers";
+import { getFlowerReadyAt } from "features/game/lib/flowerBedReadiness";
 
 describe("skillUse", () => {
   const dateNow = Date.now();
@@ -669,6 +670,60 @@ describe("skillUse", () => {
       expect(state.flowers.flowerBeds["789"].flower?.plantedAt).toEqual(
         expectedTime,
       );
+    });
+
+    it("makes windowed flowers ready at the use instant, even with a grow-time debuff", () => {
+      // Yellow Carnation (Sunpetal Seed) base = 24h. Flowery Abode's +50%
+      // growth-time debuff is baked into `baseDurationMs` at plant, so a
+      // windowed flower's duration can EXCEED the base grow time — back-dating
+      // `plantedAt` by the base time (the legacy fix-up) leaves the debuff
+      // excess still on the clock.
+      const growTimeMs =
+        FLOWER_SEEDS[FLOWERS["Yellow Carnation"].seed].plantSeconds * 1000;
+
+      const state = skillUse({
+        state: {
+          ...INITIAL_FARM,
+          bumpkin: {
+            ...INITIAL_FARM.bumpkin,
+            skills: { "Petal Blessed": 1 },
+          },
+          flowers: {
+            flowerBeds: {
+              debuffed: {
+                x: 1,
+                y: -10,
+                createdAt: 0,
+                flower: {
+                  name: "Yellow Carnation",
+                  plantedAt: dateNow - 60 * 60 * 1000,
+                  baseDurationMs: growTimeMs * 1.5,
+                },
+              },
+              plain: {
+                x: 1,
+                y: -9,
+                createdAt: 0,
+                flower: {
+                  name: "Yellow Carnation",
+                  plantedAt: dateNow - 60 * 60 * 1000,
+                  baseDurationMs: growTimeMs,
+                },
+              },
+            },
+            discovered: {},
+          },
+        },
+        action: { type: "skill.used", skill: "Petal Blessed" },
+        createdAt: dateNow,
+      });
+
+      // Ready exactly at the use instant (mirrors the legacy branch's
+      // `plantedAt + growTime === createdAt`, so beehives credit honey up to now).
+      const debuffed = state.flowers.flowerBeds["debuffed"].flower;
+      const plain = state.flowers.flowerBeds["plain"].flower;
+      expect(getFlowerReadyAt(debuffed!, state)).toEqual(dateNow);
+      expect(getFlowerReadyAt(plain!, state)).toEqual(dateNow);
     });
 
     it("updates the beehives after a flower is instagrown", () => {

--- a/src/features/game/events/landExpansion/skillUsed.ts
+++ b/src/features/game/events/landExpansion/skillUsed.ts
@@ -146,9 +146,21 @@ function usePetalBlessed({
     .forEach((bed) => {
       const { flower } = bed;
       if (flower) {
-        const growTime =
-          FLOWER_SEEDS[FLOWERS[flower.name].seed].plantSeconds * 1000;
-        flower.plantedAt = createdAt - growTime;
+        if (flower.baseDurationMs !== undefined) {
+          // Windowed (speed-rate model): zero the remaining work AND re-anchor
+          // the start to now so readyAt resolves to `createdAt` exactly.
+          // Back-dating plantedAt by the BASE grow time would instead re-price
+          // the grow against past boost windows — and leave a flower whose
+          // baked `baseDurationMs` EXCEEDS the base time (Flowery Abode's
+          // +growth-time debuff) still growing (mirrors instaGrowFlower).
+          flower.baseDurationMs = 0;
+          flower.plantedAt = createdAt;
+        } else {
+          // Legacy: back-date so plantedAt + base grow time === createdAt.
+          const growTime =
+            FLOWER_SEEDS[FLOWERS[flower.name].seed].plantSeconds * 1000;
+          flower.plantedAt = createdAt - growTime;
+        }
       }
     });
   return flowerBeds;


### PR DESCRIPTION
## Problem

Beta (SPEED_BOOSTS) players reported Petal Blessed consuming its use while flowers kept growing — it "took the days off but left the hours" (Discord report).

`usePetalBlessed` was the only insta-grow power skill never migrated to the windowed speed-rate model: it still only back-dates `plantedAt` by the seed's **base** grow time. For a windowed flower, readiness is derived from `plantedAt` + `baseDurationMs`, and `baseDurationMs` can **exceed** the base grow time when Flowery Abode's +growth-time debuff was baked at plant — so the back-date leaves exactly the debuff excess on the clock (the reporter's beehive farm matches: ~10h left on a Bloom, ~5h on a Sunpetal). Even without the debuff, the back-date re-prices the grow against past boost windows instead of completing it at the use instant.

## Fix

Mirror `instaGrowFlower`: windowed flowers get `baseDurationMs = 0` and `plantedAt = createdAt`, so `computeReadyAt` resolves to exactly the use instant and `updateBeehives` credits honey up to now. Legacy flowers keep the old back-date, unchanged.

## Testing

- New test (written first, confirmed red): two windowed beds, one with `baseDurationMs = 1.5×` base (Flowery Abode case), one plain — both must be ready exactly at the use instant.
- Full `skillUsed` suite passes (41/41); `tsc --noEmit` clean.
- Audited the other power skills: Instant Growth / Tree Blitz (epoch anchor) are safe under the windowed model; Greenhouse Guru, Grease Lightning, Instant Gratification and Barnyard Rouse already handle `baseDurationMs`.

Mirrors sunflower-land-api PR (same fix + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Petal Blessed so windowed flowers become ready exactly when the skill is used, including flowers affected by growth-rate debuffs.
  * Preserved existing readiness behavior for legacy flowers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->