### PR TITLE
[FIX] Flaky CI: replace esbuild-runner jest transformer

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       ".+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$": "identity-obj-proxy"
     },
     "transform": {
-      "^.+\\.(js|jsx|ts|tsx)$": "esbuild-runner/jest"
+      "^.+\\.(js|jsx|ts|tsx)$": "<rootDir>/test/esbuildTransformer.js"
     },
     "testPathIgnorePatterns": [
       "/node_modules/",

--- a/test/esbuildTransformer.js
+++ b/test/esbuildTransformer.js
@@ -1,0 +1,39 @@
+/**
+ * Jest transformer calling esbuild directly, replacing `esbuild-runner/jest`.
+ *
+ * esbuild-runner's transform path funnels every file through its own disk cache
+ * (`/tmp/esbuild-runner-cache`), which is shared across jest workers, keyed by
+ * file PATH + mtime (not content), and written with a non-atomic
+ * `fs.writeFileSync`. On a cold cache (every CI run), parallel workers race on
+ * hot shared modules: a worker reading between the write's truncate and its
+ * completion loads an EMPTY module, and the whole consuming test suite fails
+ * with `TypeError: X is not a function`. Rerunning "fixed" it.
+ *
+ * Calling esbuild directly needs no disk cache of its own — jest's built-in
+ * transform cache is content-keyed and written atomically.
+ */
+/* eslint-env node */
+/* eslint-disable @typescript-eslint/no-require-imports */
+const path = require("path");
+const { transformSync } = require("esbuild");
+
+const loaders = {
+  ".js": "js",
+  ".jsx": "jsx",
+  ".ts": "ts",
+  ".tsx": "tsx",
+};
+
+module.exports = {
+  process(src, filename) {
+    const { code } = transformSync(src, {
+      format: "cjs",
+      target: `node${process.version.slice(1)}`,
+      loader: loaders[path.extname(filename)],
+      sourcefile: filename,
+      sourcemap: "inline",
+      logLevel: "error",
+    });
+    return { code };
+  },
+};


### PR DESCRIPTION
## Problem

CI intermittently fails with a whole test suite dying at once on `TypeError: (0, import_X.someExport) is not a function` (e.g. `claimProduce.test.ts` on #7596's first run, `sell-animals-ux-improvement` on Aug 31). A rerun always passes. It's not the tests.

`esbuild-runner/jest` funnels every transform through its own disk cache (`/tmp/esbuild-runner-cache`), which is:

- **shared across all parallel jest workers** with no locking,
- keyed by **file path + mtime, not content**,
- written with a plain non-atomic `fs.writeFileSync` (truncate, then write).

On a cold cache — i.e. every CI run — workers race on hot shared modules. A worker reading between the truncate and the completed write loads an **empty module**: it parses fine, exports nothing, and every call site in that worker's test file throws `X is not a function`. Hence: always a random suite, always the whole suite, always green on rerun.

**Reproduced deterministically**: planting an empty cache entry for `placeCollectible.ts` and running `claimProduce.test.ts --no-cache` produces the exact CI failure (65/65 tests, `isPetCollectible is not a function`).

## Fix

Replace the transformer with a small local one (`test/esbuildTransformer.js`) calling `esbuild.transformSync` directly with the same options (cjs, node target, inline sourcemap, loader by extension). No disk cache of its own — jest's built-in transform cache is content-keyed and written atomically, so caching is preserved without the race. `esbuild` is already a direct devDependency; `esbuild-runner` is unmaintained (last release 2022) and can be dropped from devDependencies in a follow-up lockfile change.

Behaviour parity: like esbuild-runner, this transformer does not hoist `jest.mock` — the existing explicit-mock workarounds in `deliver.test.ts` / `requestToken.test.ts` are unchanged.

## Testing

- Full suite with the new transformer: 342/342 suites, 5,240 tests, ~22s.
- The poisoned-cache repro above passes with the new transformer (the racy cache is no longer consulted).
- CI on this PR will be re-run several times to exercise the cold-cache path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by preventing intermittent empty module loads during parallel test runs.
  * Updated JavaScript and TypeScript test transformation to use a more stable local processing method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->