### PR TITLE
[CHORE] Align amounts with API logic

### DIFF
--- a/src/features/game/events/landExpansion/burnClutter.ts
+++ b/src/features/game/events/landExpansion/burnClutter.ts
@@ -28,6 +28,7 @@ export function burnClutter({ state, action }: Options) {
 
     if (
       !new Decimal(amount).isInteger() ||
+      amount <= 0 ||
       amount % CLUTTER[item].sellUnit !== 0
     ) {
       throw new Error("Invalid amount");

--- a/src/features/game/events/landExpansion/craftTool.test.ts
+++ b/src/features/game/events/landExpansion/craftTool.test.ts
@@ -681,3 +681,23 @@ describe("craftTool", () => {
     });
   });
 });
+
+describe("craftTool exploit guards", () => {
+  it("rejects a negative amount (would otherwise credit coins and mint ingredients)", () => {
+    expect(() =>
+      craftTool({
+        state: { ...GAME_STATE, coins: 0 },
+        action: { type: "tool.crafted", tool: "Axe", amount: -100 },
+      }),
+    ).toThrow("Invalid amount");
+  });
+
+  it("rejects a non-integer amount", () => {
+    expect(() =>
+      craftTool({
+        state: { ...GAME_STATE, coins: 1000 },
+        action: { type: "tool.crafted", tool: "Axe", amount: 1.5 },
+      }),
+    ).toThrow("Invalid amount");
+  });
+});

--- a/src/features/game/events/landExpansion/craftTool.ts
+++ b/src/features/game/events/landExpansion/craftTool.ts
@@ -122,6 +122,10 @@ export function craftTool({ state, action }: Options) {
     throw new Error("Tool does not exist");
   }
 
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new Error("Invalid amount");
+  }
+
   const { disabled, requiredIsland, requiredLevel, ingredients } = tool;
 
   if (disabled) {

--- a/src/features/game/events/landExpansion/deliverFactionKitchen.test.ts
+++ b/src/features/game/events/landExpansion/deliverFactionKitchen.test.ts
@@ -650,3 +650,53 @@ describe("factionKitchenDeliver", () => {
     expect(state.inventory["Mark"]?.toNumber()).toBe(1 * 5);
   });
 });
+
+describe("deliverFactionKitchen exploit guards", () => {
+  it("rejects a negative amount (would otherwise mint free resources)", () => {
+    expect(() =>
+      deliverFactionKitchen({
+        state: {
+          ...GAME_STATE,
+          inventory: { Honey: new Decimal(5) },
+          faction: {
+            ...(GAME_STATE.faction as Faction),
+            kitchen: {
+              week,
+              requests: [{ item: "Honey", amount: 1, dailyFulfilled: {} }],
+            },
+          },
+        },
+        action: {
+          type: "factionKitchen.delivered",
+          resourceIndex: 0,
+          amount: -1000,
+        },
+        createdAt: startTime,
+      }),
+    ).toThrow("Invalid amount");
+  });
+
+  it("rejects a non-integer amount", () => {
+    expect(() =>
+      deliverFactionKitchen({
+        state: {
+          ...GAME_STATE,
+          inventory: { Honey: new Decimal(5) },
+          faction: {
+            ...(GAME_STATE.faction as Faction),
+            kitchen: {
+              week,
+              requests: [{ item: "Honey", amount: 1, dailyFulfilled: {} }],
+            },
+          },
+        },
+        action: {
+          type: "factionKitchen.delivered",
+          resourceIndex: 0,
+          amount: 1.5,
+        },
+        createdAt: startTime,
+      }),
+    ).toThrow("Invalid amount");
+  });
+});

--- a/src/features/game/events/landExpansion/deliverFactionKitchen.ts
+++ b/src/features/game/events/landExpansion/deliverFactionKitchen.ts
@@ -17,6 +17,7 @@ export enum DELIVER_FACTION_KITCHEN_ERRORS {
   NO_KITCHEN_DATA = "No kitchen data available",
   NO_RESOURCE_FOUND = "No requested resource found at index",
   INSUFFICIENT_RESOURCES = "Insufficient resources",
+  INVALID_AMOUNT = "Invalid amount",
 }
 
 export const BASE_POINTS = 20;
@@ -78,6 +79,11 @@ export function deliverFactionKitchen({
 
     const request = resources[action.resourceIndex];
     const { amount = 1 } = action;
+
+    if (!Number.isInteger(amount) || amount <= 0) {
+      throw new Error(DELIVER_FACTION_KITCHEN_ERRORS.INVALID_AMOUNT);
+    }
+
     const resourceBalance = inventory[request.item] ?? new Decimal(0);
     const requestAmount = request.amount * amount;
 

--- a/src/features/game/events/landExpansion/feedFactionPet.ts
+++ b/src/features/game/events/landExpansion/feedFactionPet.ts
@@ -135,6 +135,11 @@ export function feedFactionPet({
     const request = requests[action.requestIndex];
     const foodBalance = stateCopy.inventory[request.food] ?? new Decimal(0);
     const { amount = 1 } = action;
+
+    if (!Number.isInteger(amount) || amount <= 0) {
+      throw new Error("Invalid amount");
+    }
+
     const requestAmount = request.quantity * amount;
     const week = getWeekKey({ date: new Date(createdAt) });
     const day = getFactionWeekday(createdAt);

--- a/src/features/game/events/landExpansion/garbageSold.ts
+++ b/src/features/game/events/landExpansion/garbageSold.ts
@@ -78,7 +78,7 @@ export function sellGarbage({ state, action }: Options) {
       throw new Error("Not for sale");
     }
 
-    if (!new Decimal(amount).isInteger()) {
+    if (!new Decimal(amount).isInteger() || amount <= 0) {
       throw new Error("Invalid amount");
     }
     const isCollectibleItem = isCollectible(item);

--- a/src/features/game/events/landExpansion/supplyCookingOil.test.ts
+++ b/src/features/game/events/landExpansion/supplyCookingOil.test.ts
@@ -227,3 +227,50 @@ describe("supplyCookingOil", () => {
     ).toThrow("Oil capacity exceeded");
   });
 });
+
+describe("supplyCookingOil exploit guards", () => {
+  const withFirePit: GameState = {
+    ...GAME_STATE,
+    inventory: { ...GAME_STATE.inventory, Oil: new Decimal(0) },
+    buildings: {
+      ...GAME_STATE.buildings,
+      "Fire Pit": [
+        {
+          id: "1",
+          createdAt: 0,
+          readyAt: 0,
+          coordinates: { x: 0, y: 0 },
+          oil: 0,
+        },
+      ],
+    },
+  };
+
+  it("rejects a negative oilQuantity (would otherwise mint free Oil)", () => {
+    expect(() =>
+      supplyCookingOil({
+        state: withFirePit,
+        action: {
+          type: "cookingOil.supplied",
+          building: "Fire Pit",
+          buildingId: "1",
+          oilQuantity: -1000,
+        },
+      }),
+    ).toThrow("Invalid oil quantity");
+  });
+
+  it("rejects a non-integer oilQuantity", () => {
+    expect(() =>
+      supplyCookingOil({
+        state: withFirePit,
+        action: {
+          type: "cookingOil.supplied",
+          building: "Fire Pit",
+          buildingId: "1",
+          oilQuantity: 1.5,
+        },
+      }),
+    ).toThrow("Invalid oil quantity");
+  });
+});

--- a/src/features/game/events/landExpansion/supplyCookingOil.ts
+++ b/src/features/game/events/landExpansion/supplyCookingOil.ts
@@ -57,6 +57,10 @@ export function supplyCookingOil({
       throw new Error(translate("error.buildingNotExist"));
     }
 
+    if (!Number.isInteger(action.oilQuantity) || action.oilQuantity <= 0) {
+      throw new Error("Invalid oil quantity");
+    }
+
     const oilInInventory = stateCopy.inventory["Oil"] || new Decimal(0);
 
     if (oilInInventory.lessThan(action.oilQuantity)) {

--- a/src/features/game/events/landExpansion/supplyCropMachine.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.ts
@@ -329,7 +329,7 @@ export function supplyCropMachine({
 }: SupplyCropMachineOptions): GameState {
   const seedsAdded = action.seeds;
 
-  if (seedsAdded.amount < 1) {
+  if (!Number.isInteger(seedsAdded.amount) || seedsAdded.amount < 1) {
     throw new Error("Invalid amount supplied");
   }
 

--- a/src/features/game/events/landExpansion/treasureSold.ts
+++ b/src/features/game/events/landExpansion/treasureSold.ts
@@ -61,7 +61,7 @@ export function sellTreasure({ state, action }: Options) {
       throw new Error("Not for sale");
     }
 
-    if (!new Decimal(amount).isInteger()) {
+    if (!new Decimal(amount).isInteger() || amount <= 0) {
       throw new Error("Invalid amount");
     }
 

--- a/src/features/game/events/minigames/submitMinigameScore.ts
+++ b/src/features/game/events/minigames/submitMinigameScore.ts
@@ -27,6 +27,10 @@ export function submitMinigameScore({
       throw new Error(`${action.id} is not a valid minigame`);
     }
 
+    if (!Number.isFinite(action.score) || action.score < 0) {
+      throw new Error("Invalid score");
+    }
+
     const minigames = (game.minigames ??
       {}) as Required<GameState>["minigames"];
 

--- a/src/features/game/types/buyOptionPurchaseItem.ts
+++ b/src/features/game/types/buyOptionPurchaseItem.ts
@@ -55,6 +55,10 @@ export function buyOptionPurchaseItem({ state, action }: Options) {
       throw new Error("Invalid action type");
     }
 
+    if (!Number.isInteger(amount) || amount <= 0) {
+      throw new Error("Invalid amount");
+    }
+
     const itemDetails = MULTIPLE_PURCHASE_ITEMS[item];
     if (!itemDetails) {
       throw new Error("Item does not exist");


### PR DESCRIPTION
# Pull request description

Event logic was not matching the API implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid zero, negative, fractional, or non-integer quantities are now rejected across crafting, trading, deliveries, feeding, resource supplies, and purchases.
  * Cooking oil and crop seed actions now require valid positive whole-number quantities.
  * Minigame submissions now reject negative or non-finite scores.
  * Invalid actions are blocked before resources, rewards, coins, or items are changed.
* **Tests**
  * Added coverage for invalid quantity and score safeguards, including exploit-prone inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->