### PR TITLE
[FIX] Stop surfacing aborted requests as errors

### DIFF
--- a/src/features/game/actions/autosave.ts
+++ b/src/features/game/actions/autosave.ts
@@ -95,7 +95,9 @@ export async function autosaveRequest(
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => {
-    controller.abort();
+    // Abort with a reason so the rejection says why it was cancelled instead of
+    // the anonymous, browser-specific "signal is aborted without reason".
+    controller.abort(new Error(ERRORS.AUTOSAVE_TIMEOUT));
   }, AUTO_SAVE_INTERVAL);
 
   try {

--- a/src/lib/errorLogger.test.ts
+++ b/src/lib/errorLogger.test.ts
@@ -4,6 +4,7 @@ import {
   isExternalDomMutationError,
   isNetworkError,
 } from "./errorLogger";
+import { ERRORS } from "./errors";
 
 describe("buildErrorReport", () => {
   it("sends the legacy modal shape as a code + transaction id", () => {
@@ -72,8 +73,27 @@ describe("isNetworkError", () => {
     ).toBe(true);
   });
 
+  it("recognises aborted requests by name and by each browser's message", () => {
+    const aborted = new Error("whatever this browser says");
+    aborted.name = "AbortError";
+    expect(isNetworkError(aborted)).toBe(true);
+
+    expect(isNetworkError("signal is aborted without reason")).toBe(true);
+    expect(isNetworkError("The operation was aborted.")).toBe(true);
+    expect(isNetworkError("The user aborted a request.")).toBe(true);
+  });
+
+  it("recognises our own autosave timeout abort reason", () => {
+    expect(isNetworkError(new Error(ERRORS.AUTOSAVE_TIMEOUT))).toBe(true);
+    expect(isNetworkError(ERRORS.AUTOSAVE_TIMEOUT)).toBe(true);
+  });
+
   it("does not match real errors", () => {
     expect(isNetworkError("EF-001")).toBe(false);
+    expect(isNetworkError("The operation completed")).toBe(false);
+    expect(isNetworkError(new Error("Autosave aborted the transaction"))).toBe(
+      false,
+    );
     expect(isNetworkError(new Error("Failed to fetch liquidity data"))).toBe(
       false,
     );

--- a/src/lib/errorLogger.ts
+++ b/src/lib/errorLogger.ts
@@ -117,6 +117,23 @@ const NETWORK_ERROR_MESSAGES = [
   /^cancelled$/i, // iOS aborted request
 ];
 
+/**
+ * Aborted requests. The player navigated away, refreshed, or backgrounded the
+ * tab mid-flight, or we cancelled the request ourselves on a timeout. Like the
+ * failures above, the request never got a response — there is nothing for the
+ * API to act on, so these are shown as a connection problem and never reported.
+ *
+ * An abort surfaces as a DOMException named "AbortError" (matched by name in
+ * `isNetworkError`), but by the time an error reaches the modal it is often
+ * only the message string, and each browser words it differently.
+ */
+const ABORT_ERROR_MESSAGES = [
+  /^signal is aborted without reason$/i, // Chrome / Edge
+  /^the operation was aborted/i, // Firefox / Safari
+  /^the user aborted a request/i, // Older Firefox / node-fetch
+  new RegExp(`^${ERRORS.AUTOSAVE_TIMEOUT}$`), // Our own abort reason, see autosaveRequest
+];
+
 /** Pulls the message out of anything `createErrorLogger` accepts. */
 const getErrorMessage = (input: unknown): unknown =>
   input instanceof Error
@@ -129,15 +146,27 @@ const getErrorMessage = (input: unknown): unknown =>
         : undefined;
 
 /**
- * True when the error is a browser-level network failure. Accepts anything
- * `createErrorLogger` accepts (Error, string, or the report object).
+ * True when the error is a browser-level network failure or an aborted
+ * request. Accepts anything `createErrorLogger` accepts (Error, string, or
+ * the report object).
  */
 export const isNetworkError = (input: unknown): boolean => {
+  // The message of an aborted fetch varies by browser; the name does not.
+  if (
+    input &&
+    typeof input === "object" &&
+    (input as { name?: unknown }).name === "AbortError"
+  ) {
+    return true;
+  }
+
   const message = getErrorMessage(input);
 
   return (
     typeof message === "string" &&
-    NETWORK_ERROR_MESSAGES.some((re) => re.test(message.trim()))
+    [...NETWORK_ERROR_MESSAGES, ...ABORT_ERROR_MESSAGES].some((re) =>
+      re.test(message.trim()),
+    )
   );
 };
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -24,6 +24,10 @@ export const ERRORS = {
   MULTIPLE_DEVICES_OPEN: "MULTIPLE_DEVICES_OPEN",
   UNAUTHORIZED: "UNAUTHORIZED",
 
+  // We aborted the autosave ourselves after AUTO_SAVE_INTERVAL - used as the
+  // AbortController reason so the failure is self-describing, see autosave.ts
+  AUTOSAVE_TIMEOUT: "AUTOSAVE_TIMEOUT",
+
   // Trade errors
   TRADE_NOT_FOUND: "TRADE_NOT_FOUND",
 


### PR DESCRIPTION
## Summary

Aborted requests are no longer treated as bugs. When a request is aborted — the player navigates away, refreshes, backgrounds the tab mid-flight, or our own autosave timeout fires — it never gets an HTTP response, so there is nothing for the API to act on. These now behave like the other browser-level network failures already handled in `isNetworkError`: no report to `/support/errors`, and the player sees `ConnectionError` ("check your connection") instead of `SomethingWentWrong`.

## Context / motivation

`isNetworkError` already recognised `Failed to fetch` and friends, but not aborts, so every abort was reported as an error and shown to the player as an unexplained failure. Separately, `autosaveRequest` called `controller.abort()` with no reason, which made the resulting rejection anonymous and browser-specific — Chrome's wording is literally `signal is aborted without reason` — and impossible to grep for when triaging.

### Note on how the two changes interact

Aborting with a reason means the rejection is *our* `Error`, not a `DOMException`: `name` is `"Error"` and the message is `"AUTOSAVE_TIMEOUT"`. Neither the `AbortError` name check nor the browser message patterns would match it, so on its own the abort reason would have routed autosave timeouts straight back to `SomethingWentWrong` — exactly what the first change exists to prevent.

This matters because of how errors reach the modal: `gameMachine.ts` sets `errorCode` to `event.data.message`, so by the time `SomethingWentWrong` calls `isNetworkError` it only has a bare string and the `AbortError` name is gone.

So `AUTOSAVE_TIMEOUT` was added to `ERRORS` and a matching pattern built from that constant. The reason stays greppable and self-describing, and it still routes to `ConnectionError`. It went in the abort list rather than `EXPECTED_ERROR_CODES` deliberately — the latter only suppresses the support report, it does not change which screen the player sees.

## Changes

- `src/lib/errorLogger.ts` — new `ABORT_ERROR_MESSAGES` list alongside `NETWORK_ERROR_MESSAGES`; `isNetworkError` short-circuits on `name === "AbortError"` before falling through to message matching.
- `src/features/game/actions/autosave.ts` — `controller.abort(new Error(ERRORS.AUTOSAVE_TIMEOUT))`.
- `src/lib/errors.ts` — added `AUTOSAVE_TIMEOUT`.
- `src/lib/errorLogger.test.ts` — coverage for the name check, each browser's abort wording, our own timeout reason, and near-miss strings that must *not* match.

## How to test

1. `npx jest src/lib/errorLogger.test.ts` — 11 passing.
2. In a running client, throttle the network to Offline in devtools and let an autosave run past `AUTO_SAVE_INTERVAL`. The timeout fires, and the modal shows `ConnectionError` rather than `SomethingWentWrong`. No `POST /support/errors` in the network tab.
3. Trigger a save and refresh the page mid-flight — same result, via the browser's own `AbortError`.

## Screenshots or screen recording

N/A — no visual change beyond which existing modal is selected.

## Related issues

None.

---

## Checklist

### PR and scope

- [x] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [x] I have read the contributing guidelines and agree to the T&Cs

### Code quality

- [x] I have performed a self-review of my own code
- [x] I have commented code only where it helps future readers (non-obvious logic, invariants, gotchas)
- [x] I have updated documentation if behaviour or public APIs changed
- [x] My changes do not introduce new warnings

### Tests

- [x] I have added or updated tests that cover this change
- [x] New and existing unit tests pass locally

### Dependencies and coordination

- [x] Any required changes in other repos (e.g. API) are merged or linked in the description
- [x] Any dependent packages or downstream modules are already published / coordinated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved autosave timeout handling with a descriptive cancellation reason.
  - Aborted requests are now correctly recognized as network errors across supported browsers.
  - Enhanced error reporting for autosave cancellations, making failures easier to identify.
  - Improved handling and categorization of React display errors caused by browser extensions or page translation tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->