### PR TITLE
[FIX] Report what actually failed instead of a bare FAILED_REQUEST

### DIFF
--- a/src/features/auth/components/ErrorBoundary.tsx
+++ b/src/features/auth/components/ErrorBoundary.tsx
@@ -5,6 +5,7 @@ import { BoundaryError } from "./SomethingWentWrong";
 import { Modal } from "components/ui/Modal";
 import { Panel } from "components/ui/Panel";
 import { isExternalDomMutationError } from "lib/errorLogger";
+import { getApiErrorDetail } from "lib/apiError";
 
 interface Props {
   children?: ReactNode;
@@ -67,6 +68,11 @@ class ErrorBoundary extends Component<Props, State> {
 
   public render() {
     if (this.state.error !== null) {
+      // API failures arrive carrying the status, endpoint and transaction
+      // id of the request that failed (see lib/apiError). Forward them, or
+      // the report is just the word "FAILED_REQUEST".
+      const detail = getApiErrorDetail(this.state.error);
+
       return (
         <>
           <div
@@ -82,6 +88,11 @@ class ErrorBoundary extends Component<Props, State> {
               <BoundaryError
                 error={this.state.error.message}
                 stack={this.state.error.stack}
+                transactionId={detail?.transactionId}
+                errorId={detail?.errorId}
+                endpoint={detail?.endpoint}
+                status={detail?.status}
+                meta={detail?.meta}
                 onAcknowledge={this.refreshPage}
               />
             </Panel>

--- a/src/features/auth/components/SomethingWentWrong.tsx
+++ b/src/features/auth/components/SomethingWentWrong.tsx
@@ -8,6 +8,7 @@ import { Context } from "features/game/GameProvider";
 import { useActor } from "@xstate/react";
 import { CONFIG } from "lib/config";
 import { createErrorLogger, isNetworkError } from "lib/errorLogger";
+import { ERRORS } from "lib/errors";
 import { ConnectionError } from "./ConnectionError";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { SystemMessageWidget } from "features/announcements/SystemMessageWidget";
@@ -45,6 +46,14 @@ interface BoundaryErrorProps {
   error?: string;
   stack?: string;
   transactionId?: string;
+  /** errorId the API returned for the failed request, if any. */
+  errorId?: string;
+  /** Failed endpoint, e.g. "GET /marketplace". */
+  endpoint?: string;
+  /** HTTP status of the failed request. */
+  status?: number;
+  /** Extra context from the failed request (filters, signer state, …). */
+  meta?: Record<string, unknown>;
   onAcknowledge?: () => void;
 }
 
@@ -56,6 +65,10 @@ export const BoundaryError: React.FC<BoundaryErrorProps> = ({
   farmId,
   error,
   transactionId,
+  errorId,
+  endpoint,
+  status,
+  meta,
   onAcknowledge,
   stack,
 }) => {
@@ -67,7 +80,15 @@ export const BoundaryError: React.FC<BoundaryErrorProps> = ({
   useEffect(() => {
     // Known backend rejections and network failures are filtered inside the logger.
     const errorLogger = createErrorLogger("react_error_modal", farmId ?? 0);
-    errorLogger({ error, transactionId, stack, meta: { date } });
+    errorLogger({
+      error,
+      transactionId,
+      errorId,
+      endpoint,
+      status,
+      stack,
+      meta: { date, ...meta },
+    });
   }, []);
 
   // "Failed to fetch" & friends: the request never reached the server. Tell
@@ -80,6 +101,23 @@ export const BoundaryError: React.FC<BoundaryErrorProps> = ({
         transactionId={transactionId}
         onAcknowledge={onAcknowledge}
       />
+    );
+  }
+
+  // A 401 on a read: the JWT expired while the tab sat open, or the player
+  // signed out elsewhere. "Something went wrong" is misleading — and the
+  // logger deliberately doesn't report these, so the modal has to say it.
+  if (error === ERRORS.UNAUTHORIZED) {
+    return (
+      <>
+        <div className="p-2 py-1 space-y-2 mb-2">
+          <h1 className="text-base text-center">{t("session.expired")}</h1>
+          <p className="text-xs">{t("statements.session.expired")}</p>
+        </div>
+        {onAcknowledge && (
+          <Button onClick={onAcknowledge}>{t("refresh")}</Button>
+        )}
+      </>
     );
   }
 
@@ -130,6 +168,12 @@ export const BoundaryError: React.FC<BoundaryErrorProps> = ({
               {t("error")}
               {": "}
               {error}
+            </p>
+          )}
+          {endpoint && (
+            <p className="select-all">
+              {endpoint}
+              {status ? ` (${status})` : ""}
             </p>
           )}
           <p className="select-all">

--- a/src/features/marketplace/actions/loadEconomiesMarketplaceData.ts
+++ b/src/features/marketplace/actions/loadEconomiesMarketplaceData.ts
@@ -8,7 +8,8 @@ import type {
 } from "features/game/types/marketplace";
 import { CONFIG } from "lib/config";
 import { fetchWithRetry } from "lib/fetchWithRetry";
-import { ERRORS } from "lib/errors";
+import { apiError } from "lib/apiError";
+import { randomID } from "lib/utils/random";
 
 const API_URL = CONFIG.API_URL;
 
@@ -244,20 +245,22 @@ export async function loadMarketplaceEconomiesPage({
   const url = new URL(`${API_URL}/data`);
   url.searchParams.set("type", "marketplaceEconomies");
 
+  const transactionId = randomID();
   const response = await fetchWithRetry(url.toString(), {
     method: "GET",
     headers: {
       "content-type": "application/json;charset=UTF-8",
+      "X-Transaction-ID": transactionId,
       Authorization: `Bearer ${token}`,
     },
   });
 
-  if (response.status === 429) {
-    throw new Error(ERRORS.TOO_MANY_REQUESTS);
-  }
-
   if (response.status >= 400) {
-    throw new Error(ERRORS.FAILED_REQUEST);
+    throw await apiError(response, {
+      endpoint: "GET /data?type=marketplaceEconomies",
+      transactionId,
+      meta: { hasToken: !!token },
+    });
   }
 
   const body = (await response.json()) as {
@@ -303,20 +306,22 @@ export async function loadEconomiesListPage({
   url.searchParams.set("type", "economies");
   url.searchParams.set("farmId", String(farmId));
 
+  const transactionId = randomID();
   const response = await fetchWithRetry(url.toString(), {
     method: "GET",
     headers: {
       "content-type": "application/json;charset=UTF-8",
+      "X-Transaction-ID": transactionId,
       Authorization: `Bearer ${token}`,
     },
   });
 
-  if (response.status === 429) {
-    throw new Error(ERRORS.TOO_MANY_REQUESTS);
-  }
-
   if (response.status >= 400) {
-    throw new Error(ERRORS.FAILED_REQUEST);
+    throw await apiError(response, {
+      endpoint: "GET /data?type=economies",
+      transactionId,
+      meta: { farmId, hasToken: !!token },
+    });
   }
 
   const body = (await response.json()) as {

--- a/src/features/marketplace/actions/loadMarketplace.ts
+++ b/src/features/marketplace/actions/loadMarketplace.ts
@@ -1,7 +1,8 @@
 import type { Marketplace } from "features/game/types/marketplace";
 import { secureFetch } from "lib/requestToken";
 import { CONFIG } from "lib/config";
-import { ERRORS } from "lib/errors";
+import { apiError } from "lib/apiError";
+import { randomID } from "lib/utils/random";
 
 const API_URL = CONFIG.API_URL;
 
@@ -13,21 +14,23 @@ export async function loadMarketplace({
   token: string;
 }): Promise<Marketplace> {
   const url = new URL(`${API_URL}/marketplace?filters=${filters}`);
+  const transactionId = randomID();
 
   const response = await secureFetch(url.toString(), {
     method: "GET",
     headers: {
       "content-type": "application/json;charset=UTF-8",
+      "X-Transaction-ID": transactionId,
       Authorization: `Bearer ${token}`,
     },
   });
 
-  if (response.status === 429) {
-    throw new Error(ERRORS.TOO_MANY_REQUESTS);
-  }
-
   if (response.status >= 400) {
-    throw new Error(ERRORS.FAILED_REQUEST);
+    throw await apiError(response, {
+      endpoint: "GET /marketplace",
+      transactionId,
+      meta: { filters, hasToken: !!token },
+    });
   }
 
   return await response.json();

--- a/src/features/marketplace/actions/loadProfile.ts
+++ b/src/features/marketplace/actions/loadProfile.ts
@@ -1,7 +1,8 @@
 import type { MarketplaceProfile } from "features/game/types/marketplace";
 import { secureFetch } from "lib/requestToken";
 import { CONFIG } from "lib/config";
-import { ERRORS } from "lib/errors";
+import { apiError } from "lib/apiError";
+import { randomID } from "lib/utils/random";
 
 const API_URL = CONFIG.API_URL;
 
@@ -13,21 +14,23 @@ export async function loadProfile({
   token: string;
 }): Promise<MarketplaceProfile> {
   const url = new URL(`${API_URL}/marketplace/profile/${id}`);
+  const transactionId = randomID();
 
   const response = await secureFetch(url.toString(), {
     method: "GET",
     headers: {
       "content-type": "application/json;charset=UTF-8",
+      "X-Transaction-ID": transactionId,
       Authorization: `Bearer ${token}`,
     },
   });
 
-  if (response.status === 429) {
-    throw new Error(ERRORS.TOO_MANY_REQUESTS);
-  }
-
   if (response.status >= 400) {
-    throw new Error(ERRORS.FAILED_REQUEST);
+    throw await apiError(response, {
+      endpoint: "GET /marketplace/profile/:id",
+      transactionId,
+      meta: { profileId: id, hasToken: !!token },
+    });
   }
 
   return await response.json();

--- a/src/features/marketplace/actions/loadTradeable.ts
+++ b/src/features/marketplace/actions/loadTradeable.ts
@@ -5,6 +5,8 @@ import type {
 import { CONFIG } from "lib/config";
 import { secureFetch } from "lib/requestToken";
 import { ERRORS } from "lib/errors";
+import { apiError } from "lib/apiError";
+import { randomID } from "lib/utils/random";
 
 const API_URL = CONFIG.API_URL;
 
@@ -48,10 +50,12 @@ export async function loadTradeable({
     url.searchParams.set("economy", economy);
   }
 
+  const transactionId = randomID();
   const response = await secureFetch(url.toString(), {
     method: "GET",
     headers: {
       "content-type": "application/json;charset=UTF-8",
+      "X-Transaction-ID": transactionId,
       Authorization: `Bearer ${token}`,
     },
   });
@@ -72,7 +76,11 @@ export async function loadTradeable({
   }
 
   if (response.status >= 400) {
-    throw new Error(ERRORS.FAILED_REQUEST);
+    throw await apiError(response, {
+      endpoint: `GET /collection/:type/:id`,
+      transactionId,
+      meta: { collection: type, itemId: id, economy, hasToken: !!token },
+    });
   }
 
   return await response.json();

--- a/src/features/marketplace/actions/loadTrends.ts
+++ b/src/features/marketplace/actions/loadTrends.ts
@@ -1,7 +1,8 @@
 import type { MarketplaceTrends } from "features/game/types/marketplace";
 import { secureFetch } from "lib/requestToken";
 import { CONFIG } from "lib/config";
-import { ERRORS } from "lib/errors";
+import { apiError } from "lib/apiError";
+import { randomID } from "lib/utils/random";
 
 const API_URL = CONFIG.API_URL;
 
@@ -11,21 +12,23 @@ export async function loadTrends({
   token: string;
 }): Promise<MarketplaceTrends> {
   const url = new URL(`${API_URL}/marketplace/trends`);
+  const transactionId = randomID();
 
   const response = await secureFetch(url.toString(), {
     method: "GET",
     headers: {
       "content-type": "application/json;charset=UTF-8",
+      "X-Transaction-ID": transactionId,
       Authorization: `Bearer ${token}`,
     },
   });
 
-  if (response.status === 429) {
-    throw new Error(ERRORS.TOO_MANY_REQUESTS);
-  }
-
   if (response.status >= 400) {
-    throw new Error(ERRORS.FAILED_REQUEST);
+    throw await apiError(response, {
+      endpoint: "GET /marketplace/trends",
+      transactionId,
+      meta: { hasToken: !!token },
+    });
   }
 
   return await response.json();

--- a/src/lib/apiError.test.ts
+++ b/src/lib/apiError.test.ts
@@ -1,0 +1,157 @@
+import { apiError, createApiError, getApiErrorDetail } from "./apiError";
+import { ERRORS } from "./errors";
+import { buildErrorReport, isExpectedErrorCode } from "./errorLogger";
+
+const response = ({
+  status,
+  body,
+  headers = {},
+}: {
+  status: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+}) =>
+  ({
+    status,
+    headers: new Headers(headers),
+    clone: () => ({
+      json: async () => {
+        if (body === undefined) throw new SyntaxError("Unexpected end of JSON");
+
+        return body;
+      },
+    }),
+  }) as unknown as Response;
+
+describe("apiError", () => {
+  it("keeps the status, endpoint and transaction id of the failed request", async () => {
+    const error = await apiError(response({ status: 500 }), {
+      endpoint: "GET /marketplace",
+      transactionId: "tx-1",
+      meta: { filters: "resources" },
+    });
+
+    expect(error.message).toBe(ERRORS.FAILED_REQUEST);
+    expect(error.code).toBe(ERRORS.FAILED_REQUEST);
+    expect(error.status).toBe(500);
+    expect(error.endpoint).toBe("GET /marketplace");
+    expect(error.transactionId).toBe("tx-1");
+    expect(error.meta).toMatchObject({ filters: "resources" });
+  });
+
+  it("attaches client context that a status code cannot show", async () => {
+    const error = await apiError(response({ status: 502 }), {
+      endpoint: "GET /marketplace",
+    });
+
+    // The signer state is the one that matters on mobile WebViews.
+    expect(error.meta).toMatchObject({ signer: expect.any(String) });
+    expect(error.meta).toHaveProperty("online");
+    expect(error.meta).toHaveProperty("visibility");
+  });
+
+  it("prefers the code the backend returned", async () => {
+    const error = await apiError(
+      response({ status: 400, body: { errorCode: "TRADE_NOT_FOUND" } }),
+      { endpoint: "GET /collection/:type/:id" },
+    );
+
+    expect(error.code).toBe("TRADE_NOT_FOUND");
+    expect(error.status).toBe(400);
+  });
+
+  it("maps an expired session to UNAUTHORIZED so it is not reported", async () => {
+    const error = await apiError(response({ status: 401 }), {
+      endpoint: "GET /marketplace",
+    });
+
+    expect(error.code).toBe(ERRORS.UNAUTHORIZED);
+    expect(isExpectedErrorCode(error.code)).toBe(true);
+  });
+
+  it("still reports an unexpected 403 rather than treating it as a login problem", async () => {
+    const error = await apiError(response({ status: 403 }), {
+      endpoint: "GET /marketplace",
+    });
+
+    expect(error.code).toBe(ERRORS.FAILED_REQUEST);
+    expect(isExpectedErrorCode(error.code)).toBe(false);
+  });
+
+  it("maps throttling to the existing rate limit code", async () => {
+    const error = await apiError(response({ status: 429 }), {
+      endpoint: "GET /marketplace",
+    });
+
+    expect(error.code).toBe(ERRORS.TOO_MANY_REQUESTS);
+  });
+
+  it("survives a response body that is not JSON", async () => {
+    const error = await apiError(response({ status: 504 }), {
+      endpoint: "GET /marketplace",
+    });
+
+    expect(error.code).toBe(ERRORS.FAILED_REQUEST);
+    expect(error.status).toBe(504);
+  });
+
+  it("falls back to correlation ids the response carries", async () => {
+    const error = await apiError(
+      response({
+        status: 500,
+        headers: {
+          "x-transaction-id": "server-tx",
+          "x-amzn-requestid": "amzn-1",
+        },
+      }),
+      { endpoint: "GET /marketplace" },
+    );
+
+    expect(error.transactionId).toBe("server-tx");
+    expect(error.meta).toMatchObject({ requestId: "amzn-1" });
+  });
+});
+
+describe("getApiErrorDetail", () => {
+  it("reads the detail back off an error rethrown through a boundary", () => {
+    const thrown: unknown = createApiError({
+      code: ERRORS.FAILED_REQUEST,
+      status: 500,
+      endpoint: "GET /marketplace",
+      transactionId: "tx-1",
+    });
+
+    expect(getApiErrorDetail(thrown)).toMatchObject({
+      code: ERRORS.FAILED_REQUEST,
+      status: 500,
+      endpoint: "GET /marketplace",
+      transactionId: "tx-1",
+    });
+  });
+
+  it("ignores errors that carry no detail", () => {
+    expect(getApiErrorDetail(new Error("FAILED_REQUEST"))).toBeUndefined();
+    expect(getApiErrorDetail(undefined)).toBeUndefined();
+  });
+
+  it("produces a support row that says which request failed", async () => {
+    const error = await apiError(response({ status: 500 }), {
+      endpoint: "GET /marketplace",
+      transactionId: "tx-1",
+      meta: { filters: "resources" },
+    });
+
+    const report = buildErrorReport("react_error_modal", 1, {
+      error: error.message,
+      ...getApiErrorDetail(error),
+    });
+
+    expect(report).toMatchObject({
+      code: ERRORS.FAILED_REQUEST,
+      status: 500,
+      endpoint: "GET /marketplace",
+      transactionId: "tx-1",
+    });
+    expect(report.meta).toMatchObject({ filters: "resources" });
+  });
+});

--- a/src/lib/apiError.ts
+++ b/src/lib/apiError.ts
@@ -1,0 +1,161 @@
+/**
+ * Turns a failed API `Response` into an error that still says something
+ * useful by the time it reaches /support/errors.
+ *
+ * Every read endpoint used to collapse `status >= 400` into
+ * `new Error("FAILED_REQUEST")`. That message is all the support tool ever
+ * received: a session that expired overnight, a signer the browser could
+ * not run, and a 500 out of the marketplace lambda all arrived as the same
+ * unactionable row — no status, no endpoint, nothing to join against the
+ * API's own logs.
+ *
+ * The message stays the error code (a lot of call sites compare
+ * `err.message === ERRORS.X`, and the modal renders it), and everything
+ * worth knowing rides alongside it on the error object.
+ */
+
+import { CONFIG } from "./config";
+import { ERRORS } from "./errors";
+import { requestTokenDiagnostics } from "./requestToken";
+
+export type ApiErrorDetail = {
+  /** Client error code, e.g. FAILED_REQUEST — also the error's message. */
+  code: string;
+  /** HTTP status of the response that failed. */
+  status?: number;
+  /** Method + path, e.g. "GET /marketplace". Never the query string. */
+  endpoint?: string;
+  /** The X-Transaction-ID we sent, so the API can join this to its own row. */
+  transactionId?: string;
+  /** errorId returned in the response body, if any. */
+  errorId?: string;
+  meta?: Record<string, unknown>;
+};
+
+export type ApiError = Error & ApiErrorDetail;
+
+/**
+ * Statuses that mean something more specific than "the request failed".
+ * Anything not listed keeps the caller's fallback code, with the status
+ * carried separately — a 403 stays FAILED_REQUEST on purpose, because an
+ * unexpected 403 on a protected read (a rejected request token, say) is a
+ * regression we want reported, not a routine expired session.
+ */
+const STATUS_CODES: Record<number, string> = {
+  401: ERRORS.UNAUTHORIZED,
+  429: ERRORS.TOO_MANY_REQUESTS,
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+/** True for an error carrying the fields below (duck-typed, so it survives
+ * being rethrown through SWR and React's error boundary). */
+export const getApiErrorDetail = (
+  error: unknown,
+): ApiErrorDetail | undefined => {
+  if (!isRecord(error) || typeof error.code !== "string") return undefined;
+
+  const { code, status, endpoint, transactionId, errorId, meta } =
+    error as Partial<ApiErrorDetail>;
+
+  return {
+    code: code as string,
+    status: typeof status === "number" ? status : undefined,
+    endpoint: typeof endpoint === "string" ? endpoint : undefined,
+    transactionId:
+      typeof transactionId === "string" ? transactionId : undefined,
+    errorId: typeof errorId === "string" ? errorId : undefined,
+    meta: isRecord(meta) ? meta : undefined,
+  };
+};
+
+export const createApiError = (detail: ApiErrorDetail): ApiError =>
+  Object.assign(new Error(detail.code), detail);
+
+/**
+ * Client-side context that is invisible in a bare status code but explains
+ * a good share of the failures we see: a tab that was backgrounded when
+ * the request went out, a device that had already dropped off the network,
+ * or a request-token signer that never loaded (common in third-party
+ * mobile WebViews, where WASM is often unavailable).
+ */
+const clientContext = () => ({
+  online: typeof navigator !== "undefined" ? navigator.onLine : undefined,
+  visibility:
+    typeof document !== "undefined" ? document.visibilityState : undefined,
+  signer: requestTokenDiagnostics(),
+  release: CONFIG.RELEASE_VERSION,
+});
+
+/**
+ * Response headers worth keeping. The API echoes the transaction id, and
+ * API Gateway stamps its own request id — either one turns a support row
+ * into something that can be looked up server-side.
+ */
+const responseContext = (response: Response) => {
+  const header = (name: string) => response.headers?.get?.(name) ?? undefined;
+
+  return {
+    transactionId: header("x-transaction-id"),
+    requestId: header("x-amzn-requestid"),
+    retryAfter: header("retry-after"),
+  };
+};
+
+/**
+ * Build the error for a failed response. The API returns
+ * `{ errorCode, errorId }` on rejections it knows about; that code wins
+ * over anything we can infer from the status.
+ */
+export async function apiError(
+  response: Response,
+  {
+    endpoint,
+    transactionId,
+    fallbackCode = ERRORS.FAILED_REQUEST,
+    meta,
+  }: {
+    endpoint: string;
+    transactionId?: string;
+    /** Code used when the status and body say nothing more specific. */
+    fallbackCode?: string;
+    meta?: Record<string, unknown>;
+  },
+): Promise<ApiError> {
+  // Cloned so the caller can still read the response, and defensively:
+  // an HTML error page from a proxy, or an empty 502, must not turn a
+  // failed request into a parse crash on the way to the report.
+  const body = await (async () => {
+    try {
+      const source =
+        typeof response.clone === "function" ? response.clone() : response;
+
+      return await source.json();
+    } catch {
+      return undefined;
+    }
+  })();
+
+  const errorCode = isRecord(body) ? body.errorCode : undefined;
+  const errorId = isRecord(body) ? body.errorId : undefined;
+  const fromResponse = responseContext(response);
+
+  return createApiError({
+    // The backend's own code beats anything we can infer from the status.
+    code:
+      (typeof errorCode === "string" ? errorCode : undefined) ??
+      STATUS_CODES[response.status] ??
+      fallbackCode,
+    status: response.status,
+    endpoint,
+    transactionId: transactionId ?? fromResponse.transactionId,
+    errorId: typeof errorId === "string" ? errorId : undefined,
+    meta: {
+      ...clientContext(),
+      requestId: fromResponse.requestId,
+      retryAfter: fromResponse.retryAfter,
+      ...meta,
+    },
+  });
+}

--- a/src/lib/errorLogger.ts
+++ b/src/lib/errorLogger.ts
@@ -83,6 +83,10 @@ export const EXPECTED_ERROR_CODES: ReadonlySet<string> = new Set([
   "TWITTER_NOT_SHOWCASED",
   // Session / rate limiting / maintenance — handled with dedicated UI
   ERRORS.SESSION_EXPIRED,
+  // A 401 on a read endpoint: the JWT expired while the tab sat open, or
+  // the player signed out in another tab. The answer is always "log in
+  // again", never a code change, so it is an outcome like the rest here.
+  ERRORS.UNAUTHORIZED,
   ERRORS.MULTIPLE_DEVICES_OPEN,
   ERRORS.TOO_MANY_REQUESTS,
   ERRORS.EFFECT_TOO_MANY_REQUESTS,

--- a/src/lib/requestToken/index.ts
+++ b/src/lib/requestToken/index.ts
@@ -235,6 +235,19 @@ export function requestTokensActive(): boolean {
   return !!expiresAt && !!signer?.hasSession();
 }
 
+/**
+ * What this client would put in `X-Token` right now — "ready",
+ * "unsigned:not-initialised", "incompatible_wasm:csp-blocked", …
+ *
+ * Attached to API failure reports. Without it a protected endpoint
+ * rejecting a player whose signer never loaded is indistinguishable from a
+ * server fault, and the browsers where the signer fails (third-party
+ * mobile WebViews especially) are exactly the ones we hear about second-hand.
+ */
+export function requestTokenDiagnostics(): string {
+  return requestTokensActive() ? "ready" : sentinelHeaders()["X-Token"];
+}
+
 function tokenHeaders(
   url: string,
   init?: RequestInit,


### PR DESCRIPTION
## The problem

A production error came in from the support tracker:

```
Error: Request failed · FAILED_REQUEST
URL:   https://sunflower-land.com/play/#/world/marketplace/collection?filters=resources
Stack: loadMarketplace@…
Meta:  { "date": "2026-09-02T04:33:43.244Z" }
```

That row is unactionable, and it can't be made actionable after the fact. `loadMarketplace` collapsed **everything ≥ 400** into `new Error("FAILED_REQUEST")` — status, response body and endpoint discarded — and sent no `X-Transaction-ID`, so there was nothing to join against the API's own log row. A session that expired overnight, a 502 out of the gateway and a genuine 500 in the marketplace lambda all arrive as the identical report. 401 vs 500 is the difference between "nothing to do" and "we have an outage".

The path: `Collection.tsx` rethrows the SWR error during render → the app-root `ErrorBoundary` → `BoundaryError` → `createErrorLogger`, and the boundary forwarded only `error.message` and `error.stack`.

## The change

Rather than mute `FAILED_REQUEST` wholesale (which would hide real server faults), split it by what the failure actually is and give the rest some detail.

**`lib/apiError`** builds the error from the failed `Response`, keeping `status`, `endpoint`, the `X-Transaction-ID` we now send, and the backend's own `errorCode`/`errorId` from the body. Alongside it goes client context a status code can't show: `online`, `visibilityState`, release, and the **request-token signer state**.

That last one matters for this report specifically — it came from a MetaMask iOS WebView, exactly the class of browser where the WASM signer fails to load and requests go out as `X-Token: incompatible_wasm:<reason>`. Harmless in log mode; under enforcement it produces precisely this symptom, and nothing in the current report would say so.

The error's `message` stays the code, so existing `err.message === ERRORS.X` comparisons are unaffected.

**Suppressed:** 401 → `UNAUTHORIZED`, added to `EXPECTED_ERROR_CODES`. The answer is always "log in again", never a code change. Since these no longer reach the tracker, `BoundaryError` now tells the player their session expired instead of "Something went wrong". **403 deliberately stays `FAILED_REQUEST` and stays reported** — an unexpected 403 on a protected read is a regression, not a routine logout.

**Wired through:** `ErrorBoundary` → `BoundaryError` → logger now forward `status` / `endpoint` / `transactionId` / `errorId` / `meta`, and the Get Help panel shows the failed endpoint and status so a Discord paste is useful.

Applied to all five marketplace loaders (`loadMarketplace`, `loadTradeable`, `loadTrends`, `loadProfile`, `loadEconomiesMarketplaceData`).

## What the next occurrence looks like

```
code: FAILED_REQUEST · status: 502 · endpoint: GET /marketplace · transactionId: a3f9…
meta: { filters: "resources", hasToken: true, online: true, visibility: "visible",
        signer: "incompatible_wasm:no-wasm-global", requestId: "…", release: "…" }
```

## Testing

- 11 new tests in `src/lib/apiError.test.ts` covering status mapping, backend `errorCode` precedence, non-JSON bodies, header fallbacks, and the round trip through `getApiErrorDetail` → `buildErrorReport`.
- 185 tests pass across `src/lib`, `src/features/marketplace`, `src/features/auth`.
- `tsc --noEmit` clean apart from a pre-existing `virtual:pwa-register` error unrelated to this branch.
- eslint: 0 errors on all changed files.

## Not in this PR

One failed marketplace list request currently takes down the **entire game** — `Collection.tsx` rethrows during render and the only React boundary is at the app root, so the player gets a full-screen modal and has to reload. That's a blast-radius bug independent of logging and wants either a route-level boundary around `marketplace/*` or inline error handling in `Collection`. Left alone here to keep this change reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved API error handling with clearer status information and more reliable reporting when responses are incomplete or malformed.
  - Error support details now include request context and tracking information, helping diagnose failed requests more effectively.
  - Unauthorized sessions now display a session-expired message with an option to refresh instead of a generic error screen.
  - Expected authentication failures are no longer reported as unexpected application errors.
- **Tests**
  - Added coverage for API error details, status handling, metadata, tracking identifiers, and support-report generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->