### PR TITLE
[FIX] Prevent browser page translation from crashing React

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,15 @@
 <!doctype html>
-<html lang="en" class="h-full w-full">
+<!--
+  translate="no" / notranslate: the game ships its own translations, so browser
+  page translation adds nothing. It also rewrites React-owned text nodes into
+  <font> wrappers, which makes React's commit phase throw
+  "Failed to execute 'insertBefore' on 'Node'". `lang` is kept in sync with the
+  selected language in lib/i18n so the browser stops offering to translate.
+-->
+<html lang="en" class="h-full w-full notranslate" translate="no">
   <head>
     <meta charset="UTF-8" />
+    <meta name="google" content="notranslate" />
     <link rel="icon" href="/pwa/icons/favicon.ico" sizes="48x48" />
     <link
       rel="icon"

--- a/rsbuild.html
+++ b/rsbuild.html
@@ -1,7 +1,15 @@
 <!doctype html>
-<html lang="en" class="h-full w-full">
+<!--
+  translate="no" / notranslate: the game ships its own translations, so browser
+  page translation adds nothing. It also rewrites React-owned text nodes into
+  <font> wrappers, which makes React's commit phase throw
+  "Failed to execute 'insertBefore' on 'Node'". `lang` is kept in sync with the
+  selected language in lib/i18n so the browser stops offering to translate.
+-->
+<html lang="en" class="h-full w-full notranslate" translate="no">
   <head>
     <meta charset="UTF-8" />
+    <meta name="google" content="notranslate" />
     <link rel="icon" href="/pwa/icons/favicon.ico" sizes="48x48" />
     <link
       rel="icon"

--- a/src/features/auth/components/ErrorBoundary.tsx
+++ b/src/features/auth/components/ErrorBoundary.tsx
@@ -4,6 +4,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { BoundaryError } from "./SomethingWentWrong";
 import { Modal } from "components/ui/Modal";
 import { Panel } from "components/ui/Panel";
+import { isExternalDomMutationError } from "lib/errorLogger";
 
 interface Props {
   children?: ReactNode;
@@ -12,6 +13,30 @@ interface Props {
 interface State {
   error: Error | null;
 }
+
+/**
+ * Set once we have auto-reloaded this tab. A browser extension that keeps
+ * mutating the DOM would otherwise put the player in a reload loop.
+ */
+const RELOAD_FLAG = "sfl.external-dom-mutation-reload";
+
+const hasAlreadyReloaded = () => {
+  try {
+    return sessionStorage.getItem(RELOAD_FLAG) !== null;
+  } catch {
+    // Private mode / locked-down WebViews throw on sessionStorage access.
+    // Treat as "already reloaded" so we never loop.
+    return true;
+  }
+};
+
+const markReloaded = () => {
+  try {
+    sessionStorage.setItem(RELOAD_FLAG, "1");
+  } catch {
+    // Ignored - hasAlreadyReloaded() has already bailed out in this case.
+  }
+};
 
 class ErrorBoundary extends Component<Props, State> {
   public state: State = {
@@ -25,6 +50,19 @@ class ErrorBoundary extends Component<Props, State> {
   public static getDerivedStateFromError(error: Error): State {
     // Update state so the next render will show the fallback UI.
     return { error };
+  }
+
+  public componentDidCatch(error: Error) {
+    // Not a game bug: something outside React (an extension, or the browser
+    // translating the page) moved the nodes React was tracking. A remount
+    // recovers the player rather than parking them behind the error modal.
+    if (!isExternalDomMutationError(error) || hasAlreadyReloaded()) return;
+
+    markReloaded();
+
+    // Deferred so BoundaryError's mount effect can fire its keepalive report
+    // before the page goes away - otherwise we lose the telemetry.
+    window.setTimeout(() => window.location.reload(), 500);
   }
 
   public render() {

--- a/src/lib/errorLogger.test.ts
+++ b/src/lib/errorLogger.test.ts
@@ -1,6 +1,7 @@
 import {
   buildErrorReport,
   createErrorLogger,
+  isExternalDomMutationError,
   isNetworkError,
 } from "./errorLogger";
 
@@ -115,5 +116,47 @@ describe("createErrorLogger", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.code).toBe("EF-001");
+  });
+
+  it("reports extension/translation crashes under their own code", async () => {
+    const log = createErrorLogger("react_error_modal", 1);
+    await log({
+      error:
+        "Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
+      transactionId: "t-dom-mutation",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.code).toBe("EXTERNAL_DOM_MUTATION");
+    expect(body.error.code).toBe("EXTERNAL_DOM_MUTATION");
+  });
+});
+
+describe("isExternalDomMutationError", () => {
+  it("matches the DOM exceptions React throws after outside mutation", () => {
+    expect(
+      isExternalDomMutationError(
+        new Error(
+          "Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isExternalDomMutationError(
+        "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+      ),
+    ).toBe(true);
+    // Firefox wording
+    expect(isExternalDomMutationError(new Error("Node was not found"))).toBe(
+      true,
+    );
+  });
+
+  it("does not match ordinary game errors", () => {
+    expect(isExternalDomMutationError(new Error("Failed to fetch"))).toBe(
+      false,
+    );
+    expect(isExternalDomMutationError({ error: "EF-001" })).toBe(false);
+    expect(isExternalDomMutationError(undefined)).toBe(false);
   });
 });

--- a/src/lib/errorLogger.ts
+++ b/src/lib/errorLogger.ts
@@ -117,24 +117,56 @@ const NETWORK_ERROR_MESSAGES = [
   /^cancelled$/i, // iOS aborted request
 ];
 
+/** Pulls the message out of anything `createErrorLogger` accepts. */
+const getErrorMessage = (input: unknown): unknown =>
+  input instanceof Error
+    ? input.message
+    : typeof input === "string"
+      ? input
+      : input && typeof input === "object"
+        ? ((input as { message?: unknown; error?: unknown }).message ??
+          (input as { error?: unknown }).error)
+        : undefined;
+
 /**
  * True when the error is a browser-level network failure. Accepts anything
  * `createErrorLogger` accepts (Error, string, or the report object).
  */
 export const isNetworkError = (input: unknown): boolean => {
-  const message =
-    input instanceof Error
-      ? input.message
-      : typeof input === "string"
-        ? input
-        : input && typeof input === "object"
-          ? ((input as { message?: unknown; error?: unknown }).message ??
-            (input as { error?: unknown }).error)
-          : undefined;
+  const message = getErrorMessage(input);
 
   return (
     typeof message === "string" &&
     NETWORK_ERROR_MESSAGES.some((re) => re.test(message.trim()))
+  );
+};
+
+/**
+ * React's commit phase throws these when something outside React has moved the
+ * DOM nodes it is tracking — a browser extension, or the browser's own page
+ * translation replacing text nodes with <font> wrappers. React then calls
+ * insertBefore/removeChild with a reference node that is no longer a child of
+ * its parent. Nothing in the fiber tree can be fixed to prevent it, so these
+ * are reported under their own code rather than as game crashes.
+ */
+const EXTERNAL_DOM_MUTATION_MESSAGES = [
+  /Failed to execute '(insertBefore|removeChild|appendChild)' on 'Node'/i,
+  /The node (before which the new node is to be inserted|to be removed) is not a child of this node/i,
+  // Firefox / Safari wording for the same DOM exception
+  /Node was not found/i,
+  /The object can not be found here/i,
+];
+
+/**
+ * True when the error came from external DOM mutation rather than the game.
+ * Accepts anything `createErrorLogger` accepts (Error, string, report object).
+ */
+export const isExternalDomMutationError = (input: unknown): boolean => {
+  const message = getErrorMessage(input);
+
+  return (
+    typeof message === "string" &&
+    EXTERNAL_DOM_MUTATION_MESSAGES.some((re) => re.test(message))
   );
 };
 
@@ -217,6 +249,15 @@ export const createErrorLogger = (source: Source, farmId: number) => {
       if (isNetworkError(input)) return;
 
       const report = buildErrorReport(source, farmId, input);
+
+      // Crashes caused by extensions / browser page translation are not game
+      // bugs. Still reported — we want to see whether the notranslate opt-out
+      // is working — but under their own code so they group separately
+      // instead of drowning out real crashes.
+      if (isExternalDomMutationError(input)) {
+        report.code = ERRORS.EXTERNAL_DOM_MUTATION;
+        report.error.code = ERRORS.EXTERNAL_DOM_MUTATION;
+      }
 
       // Deliberate backend rejections (already_bought, trade_not_found, …)
       // are outcomes the API already knows about — don't pollute the log.

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -77,6 +77,10 @@ export const ERRORS = {
   // Player has disabled Google as a login method on this farm
   GOOGLE_LOGIN_DISABLED: "GOOGLE_LOGIN_DISABLED",
 
+  // A browser extension or the browser's own page translation moved the DOM
+  // nodes React tracks, blowing up its commit phase. Not a game bug.
+  EXTERNAL_DOM_MUTATION: "EXTERNAL_DOM_MUTATION",
+
   // Twitter showcase (Community feed) errors
   TWITTER_NOT_CONNECTED: "TWITTER_NOT_CONNECTED",
   TWITTER_ALREADY_SHOWCASED: "TWITTER_ALREADY_SHOWCASED",

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -11,6 +11,13 @@ if (process.env.NODE_ENV !== "metadata") {
     localStorage.setItem("language", lng);
   }
 
+  // LanguageCode values are valid BCP-47 tags ("pt-BR", "zh-CN", …). Without
+  // this the document permanently claims to be English while rendering one of
+  // the other languages, which is what makes the browser offer to translate
+  // the page — and browser translation moves the DOM nodes React tracks.
+  // Also lets screen readers pronounce the UI correctly.
+  document.documentElement.setAttribute("lang", lng);
+
   i18n.use(initReactI18next).init(
     {
       resources,


### PR DESCRIPTION
## Summary

Android Chrome players were crashing into the "Something Went Wrong" modal with `Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.` The cause is outside React: the browser's page translation replaces React-owned text nodes with `<font>` wrappers, so when React's commit phase calls `insertBefore` with a reference node it recorded earlier, that node is no longer a child of its parent. This PR stops the browser translating the page, and makes the crash recoverable and diagnosable if anything else ever does the same thing.

## Context / motivation

From the support error tracker (production, mainnet, `2026-09-02T04:25:53Z`, `Mozilla/5.0 (Linux; Android 10; K) … Chrome/151.0.0.0 Mobile Safari`). The stack is entirely React internals — `insertOrAppendPlacementNode` → `commitReconciliationEffects` → `commitMutationEffectsOnFiber` — with no game frames, which is the signature of the DOM being mutated out from under React.

Three things in the repo made this near-inevitable for non-English mobile players:

1. **No translation opt-out anywhere.** Both HTML entry points were plain `<html lang="en">` — no `translate="no"`, no `notranslate`, no `<meta name="google" content="notranslate">`.
2. **The document permanently claimed to be English while rendering 11 other languages.** `lib/i18n` read the language from `localStorage` but never touched `document.documentElement.lang`. A pt-BR player got Portuguese content on a page declared `lang="en"`; Chrome's content-based language detection sees the mismatch and offers "Translate to Portuguese". Once the player taps "Always translate", it fires automatically on every later visit.
3. **The HUD re-renders once per second.** `useNow({ live: true })` drives `SpecialEventCountdown`, `StreamCountdown`, `VIPExpiryWidget`, `Transaction` and others. Countdowns mount and unmount conditional children beside translated text every tick, so a translated page hits a bad placement within seconds — matching a crash at 04:25 UTC with no user action behind it.

App-side suspects were ruled out: `ReactPortal` is defined but never imported; `useSafeAreaPaddingTop` and the CSV/Twitter download helpers add and remove their nodes synchronously so React never tracks them; `TelegramLogin` injects a script into a React div, but that div has no React children.

## What changed

- **`index.html` / `rsbuild.html`** — `translate="no"`, `notranslate`, and `<meta name="google" content="notranslate">`. The game ships its own translations, so browser translation is pure downside. Commented so it doesn't get "cleaned up" later.
- **`lib/i18n/index.ts`** — keep `<html lang>` in sync with the selected language. `LanguageCode` values are already valid BCP-47 tags (`pt-BR`, `zh-CN`, …), so no mapping table. This removes the trigger; the `notranslate` opt-out is the actual guard. Also fixes screen reader pronunciation.
- **`lib/errorLogger.ts`** — new exported `isExternalDomMutationError`, matching the Chrome, Firefox and Safari wordings of these DOM exceptions. Message extraction pulled out of `isNetworkError` into a shared `getErrorMessage` helper.
- **Reporting** — these are **still reported**, not dropped, but re-coded to `EXTERNAL_DOM_MUTATION`. They group under one code, and since the dedupe key is built from the code, you get at most one per page load instead of a stream. Dropping them silently would have meant no way to tell whether this fix worked.
- **`ErrorBoundary`** — new `componentDidCatch` reloads the tab once instead of parking the player behind the modal, guarded by a `sessionStorage` flag so a persistently misbehaving extension can't loop them. The `sessionStorage` access is wrapped in try/catch (locked-down WebViews throw) failing closed to "already reloaded". The reload is deferred 500 ms: `componentDidCatch` runs in the commit's layout phase, *before* `BoundaryError`'s mount effect fires the keepalive POST, so reloading synchronously would silently destroy the telemetry for exactly the errors we want to measure.

## How to test

Reproducing the original crash:

1. Open the game on Android Chrome (or desktop Chrome, right-click → Translate to…).
2. Before this change: force a translation and let a HUD countdown tick. React throws `insertBefore` and the error modal appears.
3. After this change: Chrome no longer offers to translate the page, and the game keeps running.

Verifying the `lang` sync:

1. Change the in-game language via Settings → General → Change Language (this reloads the browser).
2. Inspect `<html>` — `lang` should match the chosen language (e.g. `pt-BR`), not `en`.

Verifying the reporting path:

1. `npx jest src/lib/errorLogger.test.ts` — 12/12 pass, including new coverage for the detector and the `EXTERNAL_DOM_MUTATION` re-coding.

## Screenshots or screen recording

N/A — no visual change.

## Notes for the reviewer

- I could not reproduce the production crash on a real device, so this is diagnosis from the stack shape plus the three repo findings above, not a verified fix. The `EXTERNAL_DOM_MUTATION` code is what confirms it: if the volume of that code drops to near-zero after this ships, the translate hypothesis was right. If it stays flat, the mutation is coming from something else on those devices and we'll have the reports to look at.
- `npx tsc --noEmit` reports 3 pre-existing errors in `src/lib/utils/hooks/useServiceWorkerUpdate.ts` about `virtual:pwa-register/react` — a Vite plugin virtual module that bare `tsc` can't resolve. Unrelated to this PR; nothing in the touched files errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
