### PR TITLE
[FIX] Recover a blocked signer load within the page session

### DIFF
--- a/src/lib/requestToken/index.ts
+++ b/src/lib/requestToken/index.ts
@@ -25,6 +25,12 @@
  * the sentinel is one of our own players whose browser could not run the
  * module. The API logs the two separately so the second group can be sized
  * before enforcement is turned on.
+ *
+ * A load that failed because the module never arrived — a blocker, a
+ * captive portal, a mobile connection that dropped — is retried lazily on
+ * a later request rather than written off for the whole page session (see
+ * ensureSigner). A load that failed because the engine will not run wasm
+ * is not: that answer does not change before the next reload.
  */
 
 import { fetchWithRetry, type FetchWithRetryOptions } from "lib/fetchWithRetry";
@@ -152,6 +158,49 @@ function failureDetail(e: unknown): string {
     .slice(0, 256);
 }
 
+/**
+ * Failure codes worth trying again inside the same page session.
+ *
+ * Only the ones where nothing about the engine is wrong and the module
+ * simply never arrived: an ad-blocker or DNS filter, a captive portal, a
+ * mobile connection that dropped mid-fetch. Every one of those can be true
+ * when `/session` completes and false a minute later.
+ *
+ * `compile-failed`, `link-failed`, `wasm-unavailable`, `no-wasm-global`,
+ * `bad-mime` and `csp-blocked` are deliberately excluded: the bytes
+ * arrived and this engine will not run them, so refetching is pure waste
+ * on exactly the devices least able to afford it. So is `sign-*` — there
+ * the module loaded and traps when used, which reloading does not fix.
+ */
+function isTransientFailure(code: string): boolean {
+  if (code === "fetch-failed" || code === "import-failed") return true;
+
+  // Unmatched failures keep their stage and error type
+  // (`init-unknown-typeerror`). A fetch failing in wording the classifier
+  // has not seen still surfaces as a TypeError or a NetworkError, so treat
+  // those as network-ish; any other unknown is left alone.
+  return /^(?:(?:import|init)-)?unknown(?:-(?:typeerror|networkerror))?$/.test(
+    code,
+  );
+}
+
+/**
+ * How hard the layer tries to recover a transient load failure without a
+ * reload: a handful of attempts, the first no sooner than the interval
+ * below and each subsequent one twice as far out. The bound is the point —
+ * a player behind a captive portal must not refetch the module on every
+ * autosave.
+ */
+const MAX_SIGNER_RETRIES = 3;
+const SIGNER_RETRY_INTERVAL_MS = 30_000;
+/**
+ * How long a request will wait on a retry before going out with the
+ * sentinel anyway. The attempt carries on in the background and a later
+ * request picks up its result; this one is not held behind a module fetch
+ * on the sort of connection that failed it in the first place.
+ */
+const SIGNER_RETRY_WAIT_MS = 2_000;
+
 let signer: TokenModule | undefined;
 let expiresAt: number | undefined;
 /**
@@ -180,6 +229,21 @@ let signerFailureDetail = "";
 let initInFlight: Promise<void> | undefined;
 
 /**
+ * The session the layer was last given a code for. Kept because the code
+ * itself goes into the signer and is not stored anywhere else — on the
+ * failure path there is no signer, so without this there would be nothing
+ * to re-initialise with.
+ */
+let lastSession:
+  | { sessionCode: string; sessionCodeExpiresAt: number }
+  | undefined;
+/** Retries spent since the last `/session`, and when the next may run. */
+let retries = 0;
+let retryAfter = 0;
+/** The in-flight retry, shared by every request that arrives during it. */
+let retryInFlight: Promise<void> | undefined;
+
+/**
  * Initialise the token layer from the `/session` response. Safe to call on
  * every session start — a fresh session replaces the code.
  */
@@ -187,6 +251,10 @@ export async function initRequestTokens(params: {
   sessionCode?: string;
   sessionCodeExpiresAt?: number;
 }): Promise<void> {
+  // A fresh session is a fresh start: whatever the last one spent on
+  // retries, this one gets the full budget.
+  retries = 0;
+  retryAfter = 0;
   initInFlight = init(params);
   return initInFlight;
 }
@@ -197,12 +265,18 @@ async function init(params: {
 }): Promise<void> {
   if (!params.sessionCode || !params.sessionCodeExpiresAt) {
     signer?.clearSession();
+    lastSession = undefined;
     expiresAt = undefined;
     state = "no-session-code";
     signerFailure = "";
     signerFailureDetail = "";
     return;
   }
+
+  lastSession = {
+    sessionCode: params.sessionCode,
+    sessionCodeExpiresAt: params.sessionCodeExpiresAt,
+  };
 
   try {
     signer ??= await loadTokenModule();
@@ -219,16 +293,23 @@ async function init(params: {
     state = "signer-failed";
     signerFailure = failureCode(e);
     signerFailureDetail = failureDetail(e);
+    // Arm the next lazy retry (see ensureSigner), but not immediately: the
+    // failure has only just happened and the next protected request is
+    // often milliseconds away.
+    retryAfter = Date.now() + SIGNER_RETRY_INTERVAL_MS * 2 ** retries;
   }
 }
 
 /** Forget the session code (logout). */
 export function clearRequestTokens() {
   signer?.clearSession();
+  lastSession = undefined;
   expiresAt = undefined;
   state = "logged-out";
   signerFailure = "";
   signerFailureDetail = "";
+  retries = 0;
+  retryAfter = 0;
 }
 
 export function requestTokensActive(): boolean {
@@ -307,6 +388,71 @@ function sentinelHeaders(): Record<string, string> {
 }
 
 /**
+ * Starts a signer retry if one is due, and returns it. Everything up to
+ * storing the attempt is synchronous, so concurrent requests share one
+ * attempt rather than each starting their own.
+ */
+function beginSignerRetry(): Promise<void> | undefined {
+  if (
+    state !== "signer-failed" ||
+    !lastSession ||
+    !isTransientFailure(signerFailure) ||
+    retries >= MAX_SIGNER_RETRIES ||
+    Date.now() < retryAfter
+  ) {
+    return undefined;
+  }
+
+  retries += 1;
+
+  // `init` never rejects and rearms `retryAfter` itself if this fails.
+  const attempt = init(lastSession).finally(() => {
+    if (retryInFlight === attempt) retryInFlight = undefined;
+  });
+  retryInFlight = attempt;
+
+  return attempt;
+}
+
+/** Races `promise` against a timer, cleaning the timer up if it wins. */
+function withTimeout(promise: Promise<void>, ms: number): Promise<void> {
+  let timer!: ReturnType<typeof setTimeout>;
+
+  return Promise.race([
+    promise.finally(() => clearTimeout(timer)),
+    new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, ms);
+    }),
+  ]);
+}
+
+/**
+ * Give the signer its chance before a request goes out.
+ *
+ * Two cases. The cold load is still running — wait for it rather than
+ * racing it. Or a previous load failed for a reason that may no longer be
+ * true: those get a bounded number of lazy retries, so a page session that
+ * began behind a blocker or on a dropped connection can start signing
+ * without the player reloading the game.
+ *
+ * Either way this settles, and quickly: a request is never failed, and
+ * never held for long, because the token layer could not sort itself out.
+ */
+async function ensureSigner(): Promise<void> {
+  if (requestTokensActive()) return;
+
+  // `initRequestTokens` always settles (it swallows its own failures), so
+  // this cannot hang. Nothing in flight means nothing to wait for.
+  if (initInFlight) await initInFlight;
+
+  // Coordinated with the cold load above, and shared between callers: a
+  // burst of autosaves triggers one module fetch between them, not one
+  // each.
+  const attempt = retryInFlight ?? beginSignerRetry();
+  if (attempt) await withTimeout(attempt, SIGNER_RETRY_WAIT_MS);
+}
+
+/**
  * Drop-in replacement for `fetchWithRetry` on protected endpoints — both
  * the state-mutating ones and the read-only ones we don't want scraped.
  *
@@ -323,12 +469,10 @@ export async function secureFetch(
 ): Promise<Response> {
   const url = typeof input === "string" ? input : String(input);
 
-  // If the signer is still loading, wait for it rather than racing it.
-  // `initRequestTokens` always settles (it swallows its own failures), so
-  // this cannot hang. Nothing in flight means nothing to wait for.
-  if (initInFlight && !requestTokensActive()) {
-    await initInFlight;
-  }
+  // Wait on a signer that is still loading, and retry one that failed for
+  // a reason that might have passed. Never blocks for long, and never
+  // throws: a request that cannot be signed still goes, with the sentinel.
+  await ensureSigner();
 
   return fetchWithRetry(
     input,

--- a/src/lib/requestToken/requestToken.test.ts
+++ b/src/lib/requestToken/requestToken.test.ts
@@ -440,6 +440,135 @@ describe("requestToken signer load failures", () => {
   });
 });
 
+describe("requestToken retrying a failed signer load", () => {
+  let fetchMock: jest.Mock;
+  let now: number;
+
+  beforeEach(() => {
+    jest.resetModules();
+    fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    (window as unknown as { fetch: unknown }).fetch = fetchMock;
+    // The retry is gated on a minimum interval, so the clock has to move.
+    now = Date.now();
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const sentHeaders = (call: number) =>
+    (fetchMock.mock.calls[call][1]?.headers ?? {}) as Record<string, string>;
+
+  /** Past the cooldown, whichever attempt we are on. */
+  const waitOutBackoff = () => {
+    now += 10 * 60 * 1000;
+  };
+
+  const bootWithLoader = (loadTokenModule: jest.Mock) => {
+    jest.doMock("./loader", () => ({ loadTokenModule }));
+
+    /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports */
+    return require("./index") as typeof import("./index");
+    /* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports */
+  };
+
+  const save = (tokens: ReturnType<typeof bootWithLoader>) =>
+    tokens.secureFetch("https://api.test/autosave/1", { method: "POST" });
+
+  it("recovers from a transient failure and signs from then on", async () => {
+    // The 84 accounts this is for: the module never arrived — a blocker, a
+    // captive portal, a dropped mobile connection — and the connection is
+    // fine again a minute later.
+    const loadTokenModule = jest
+      .fn()
+      .mockRejectedValueOnce({
+        stage: "init",
+        cause: new TypeError("Failed to fetch"),
+      })
+      .mockResolvedValue({
+        initSession: () => undefined,
+        clearSession: () => undefined,
+        hasSession: () => true,
+        signRequest,
+      });
+
+    const tokens = bootWithLoader(loadTokenModule);
+
+    await tokens.initRequestTokens(session);
+    await save(tokens);
+
+    // Flagged, and no retry yet: the failure is seconds old, and an
+    // autosave must not refetch the module the moment one fails.
+    expect(sentHeaders(0)["X-Token"]).toBe("incompatible_wasm:fetch-failed");
+    expect(loadTokenModule).toHaveBeenCalledTimes(1);
+
+    waitOutBackoff();
+    await save(tokens);
+
+    // Previously every request for the rest of the page's life carried the
+    // sentinel; now the session heals itself without a reload.
+    expect(loadTokenModule).toHaveBeenCalledTimes(2);
+    expect(tokens.requestTokensActive()).toBe(true);
+    expect(sentHeaders(1)["X-Token"]).toBe("tok(POST|/autosave/1|0)");
+    expect(sentHeaders(1)["X-Expires"]).toBe(String(EXPIRES_AT));
+    expect(sentHeaders(1)["X-Token-Detail"]).toBeUndefined();
+  });
+
+  it("does not retry a failure this engine will never resolve", async () => {
+    const loadTokenModule = jest
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          "Refused to compile or instantiate WebAssembly module because " +
+            "'unsafe-eval' is not an allowed source of script in the " +
+            "following Content Security Policy directive: \"script-src 'self'\"",
+        ),
+      );
+
+    const tokens = bootWithLoader(loadTokenModule);
+
+    await tokens.initRequestTokens(session);
+    for (let i = 0; i < 3; i++) {
+      waitOutBackoff();
+      await save(tokens);
+    }
+
+    // The bytes arrived and the engine refused them. Refetching costs a
+    // request on every save and cannot change the answer.
+    expect(loadTokenModule).toHaveBeenCalledTimes(1);
+    expect(sentHeaders(2)["X-Token"]).toBe("incompatible_wasm:csp-blocked");
+  });
+
+  it("shares one attempt across concurrent requests, and stops at the cap", async () => {
+    const loadTokenModule = jest
+      .fn()
+      .mockRejectedValue(new TypeError("Failed to fetch"));
+
+    const tokens = bootWithLoader(loadTokenModule);
+
+    await tokens.initRequestTokens(session);
+
+    // Six rounds of five simultaneous saves, each round well past the
+    // backoff. A burst must cost one module fetch between them, not one
+    // each — a player on a captive portal is the worst place to spend
+    // five.
+    for (let round = 0; round < 6; round++) {
+      waitOutBackoff();
+      await Promise.all(Array.from({ length: 5 }, () => save(tokens)));
+
+      expect(loadTokenModule.mock.calls.length).toBeLessThanOrEqual(round + 2);
+    }
+
+    // The cold load plus the retry budget, however long the page lives.
+    expect(loadTokenModule).toHaveBeenCalledTimes(4);
+    // And every one of those saves still went out, still flagged with the
+    // real cause.
+    expect(fetchMock).toHaveBeenCalledTimes(30);
+    expect(sentHeaders(29)["X-Token"]).toBe("incompatible_wasm:fetch-failed");
+  });
+});
+
 describe("requestToken while the signer is still loading", () => {
   let fetchMock: jest.Mock;
 


### PR DESCRIPTION
## Summary

A request-token signer load that fails because the module never arrived — an ad-blocker, a DNS filter, a captive portal, a dropped mobile connection — currently writes the layer off for the rest of the page's life. Every request from then on carries the `incompatible_wasm` sentinel, autosaves included, which under enforcement would be a 403 on every save. `secureFetch` now retries such a load lazily, so a session that started behind a blocker can start signing again without the player reloading the game.

## Context / motivation

24h of production API logs (2026-09-01→02) showed 238 accounts sending the sentinel. 154 were a defect in the signer module itself, already fixed in the private wasm-token repo. The other 84 never received the module at all — reason codes `fetch-failed` (69) and `import-failed` (15), 54 of them on Android Chrome — and they sent the sentinel on *every* request afterwards, covering 228 accounts' worth of autosave traffic. Once the module fix ships, this group is the entire residual.

`loader.ts` already clears its cached promise on failure so a later call retries; it was `init()` in `index.ts` that gave up, and it also dropped the session code on the failure path, so there was nothing to re-init with.

## What changed

- **`lastSession`** retains the code and expiry whenever `/session` supplies one. The code otherwise lives only inside the signer, which on this path does not exist. Cleared on logout and on a session that issues no code.
- **Only transient causes retry.** `fetch-failed`, `import-failed`, and unknowns whose error type is network-ish (`unknown`, `init-unknown-typeerror`, …). `compile-failed`, `link-failed`, `wasm-unavailable`, `no-wasm-global`, `bad-mime`, `csp-blocked` and `sign-*` are excluded — that engine will not run the module, and refetching is pure waste on the devices least able to afford it.
- **Bounded.** 3 attempts per `/session`, with the cooldown armed in the failure handler (30s, doubling) so the request immediately after a failure never triggers a refetch. A new session resets the budget.
- **No races.** The retry waits on the existing `initInFlight` cold-load promise rather than running alongside it, and stores its attempt synchronously, so a burst of autosaves costs one module fetch between them rather than one each.
- **Never blocks or breaks a request.** A request waits at most 2s on a retry, then goes out with the sentinel exactly as today; the attempt carries on in the background for a later request to pick up. `init` still swallows its own failures, so `secureFetch` cannot throw from this path.

Header names, sentinel strings (`UNSUPPORTED_SIGNER_TOKEN`, `UNSIGNED_TOKEN`), reason codes and the signing path are untouched — the API and `sunflower-land-api`'s `requestToken.ts` still match exactly.

## How to test

1. `npx jest src/lib/requestToken` — 27 tests, including three new cases: a transient failure that recovers on a later request and then signs properly; a CSP failure that is never retried; and six rounds of five concurrent `secureFetch` calls against a permanently failing loader, which produce exactly 4 module loads (cold + 3) and 30 sent requests, all flagged with the real cause.
2. In a browser, block `sunflower-land.com/wasm` (uBlock or devtools request blocking) and load the game. Early saves go out with `X-Token: incompatible_wasm:fetch-failed`. Unblock, wait ~30s, trigger another save: it now carries a real `X-Token`/`X-Timestamp`/`X-Expires`.
3. Leave the block in place instead and keep playing: at most three further requests for the module, then nothing for the rest of the session.

## Screenshots or screen recording

N/A — no UI change.

---

## Checklist

### PR and scope

- [x] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [x] I have read the contributing guidelines and agree to the T&Cs

### Code quality

- [x] I have performed a self-review of my own code
- [x] I have commented code only where it helps future readers (non-obvious logic, invariants, gotchas)
- [x] I have updated documentation if behaviour or public APIs changed — none changed; the module header in `index.ts` now describes the retry
- [x] My changes do not introduce new warnings

### Tests

- [x] I have added or updated tests that cover this change
- [x] New and existing unit tests pass locally (180 tests across `src/lib`)

### Dependencies and coordination

- [x] Any required changes in other repos (e.g. API) are merged or linked in the description — none; the wire contract is unchanged
- [x] Any dependent packages or downstream modules are already published / coordinated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Signer loading now retries transient failures during the same session.
  * Concurrent requests share retry attempts, reducing duplicate loading work.
  * Permanent failures are not retried.
  * Retry attempts are limited and use increasing wait intervals.
  * Requests continue safely with a fallback token when loading cannot complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->