### PR TITLE
[FIX] Stop UI sending fractional amounts to integer-guarded events

### DIFF
--- a/src/features/island/buildings/components/building/BuildingOilTank.tsx
+++ b/src/features/island/buildings/components/building/BuildingOilTank.tsx
@@ -63,7 +63,7 @@ export const BuildingOilTank: React.FC<OilTankProps> = ({
     BUILDING_DAILY_OIL_CAPACITY[buildingName as CookingBuildingName] -
     oilRemainingInBuilding;
   const incrementMaxOil = () => {
-    setTotalOilToAdd(amountToFull);
+    setTotalOilToAdd(Math.floor(amountToFull));
   };
 
   function getOilTimeInMillis(oil: number): number {

--- a/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
@@ -137,9 +137,10 @@ export const CropMachineModalContent: React.FC<Props> = ({
   const seedBalance = selectedSeed
     ? (inventory[selectedSeed] ?? new Decimal(0))
     : new Decimal(0);
-  const maxSupplyable = Math.min(
-    seedBalance.toNumber(),
-    packSeedLimit.toNumber(),
+  // Seed balances can carry a fractional remainder; the machine only
+  // accepts whole seeds, so the "All" button must not send a fraction.
+  const maxSupplyable = Math.floor(
+    Math.min(seedBalance.toNumber(), packSeedLimit.toNumber()),
   );
 
   useLayoutEffect(() => {

--- a/src/features/island/buildings/components/building/market/SeasonalCrops.tsx
+++ b/src/features/island/buildings/components/building/market/SeasonalCrops.tsx
@@ -95,9 +95,13 @@ export const SeasonalCrops: React.FC = () => {
       ? crop.sellPrice
       : getSellPrice({ item: crop, game: state }).price;
 
+  // Exotic crops sell through `treasure.sold`, which only accepts whole
+  // amounts; regular crops go through `crop.sold`, which allows fractions.
+  const sellDecimalPlaces = isExoticCrop(selected.name) ? 0 : 2;
+
   const cropAmount = setPrecision(
     getCountAndType(state, selected.name).count,
-    2,
+    sellDecimalPlaces,
   );
   const coinAmount = setPrecision(
     new Decimal(displaySellPrice(selected)).mul(
@@ -320,7 +324,7 @@ export const SeasonalCrops: React.FC = () => {
         setCustomAmount={setCustomAmount}
         itemAmount={cropAmount}
         bumpkinParts={NPC_WEARABLES.betty}
-        maxDecimalPlaces={2}
+        maxDecimalPlaces={sellDecimalPlaces}
         onCancel={closeBulkSellModal}
         onSell={openConfirmationModal}
         coinAmount={coinAmount}


### PR DESCRIPTION
# Pull request description

Follow-up to #7599, which added integer / positive guards to several event handlers. Three UI paths could send a fractional amount to those handlers and now throw `Invalid ... quantity` inside the client reducer, crashing the game state machine:

1. **Cooking oil "Max" button** sent `capacity - building.oil`. Cooking deducts fractional oil per recipe, so the result is almost never a whole number. The button now floors the amount.
2. **Crop Machine "All" button** sent the raw seed balance, which can carry a fractional remainder. The supplyable count is now floored (also fixes the "available inventory" label).
3. **Exotic crops in the bulk-sell modal** route to `treasure.sold` (whole amounts only) but shared the two-decimal modal used for `crop.sold`. The 50% button on an odd balance, or a typed `7.5`, threw. The modal now uses zero decimal places when the selected crop is exotic; regular crops are unchanged.

Cases 2 and 3 were already rejected by the API's Joi schemas before #7599, so they used to fail as a rejected save. #7599 moved that failure into the client. Oil was the only one whose schema allowed fractions, which is why it surfaced first.

Audited the remaining senders for `tool.crafted`, `garbage.sold`, `clutter.burned`, `factionKitchen.delivered`, `factionPet.fed`, `optionPurchaseItem.bought` and `minigame.scoreSubmitted`: all send literals or already round down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented fractional oil quantities when filling tanks to capacity.
  - Updated the crop machine’s “All” option to select only whole seeds.
  - Corrected seasonal crop selling precision: exotic crops now require whole-number quantities, while regular crops continue to support decimal amounts.
  - Applied the correct quantity limits consistently in bulk selling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->