### PR TITLE
[FIX] Hide known water trap catch modal

### DIFF
--- a/src/features/island/fisherman/WaterTrapSpot.tsx
+++ b/src/features/island/fisherman/WaterTrapSpot.tsx
@@ -94,17 +94,20 @@ export const WaterTrapSpot: React.FC<Props> = ({ id }) => {
         caught = caughtCrustacean(waterTrap.type, waterTrap.chum);
       }
       const [caughtItem, caughtAmount] = getObjectEntries(caught)[0];
+      const isNewCatch = (farmActivity[`${caughtItem} Caught`] ?? 0) === 0;
 
       gameService.send({
         type: "waterTrap.collected",
         trapId: id,
       });
 
-      setCollectedCatch({
-        item: caughtItem as CrustaceanName,
-        amount: caughtAmount ?? 1,
-      });
-      setShowCatchModal(true);
+      if (isNewCatch) {
+        setCollectedCatch({
+          item: caughtItem as CrustaceanName,
+          amount: caughtAmount ?? 1,
+        });
+        setShowCatchModal(true);
+      }
     }
   };
 


### PR DESCRIPTION
## Problem

<img width="593" height="298" alt="image" src="https://github.com/user-attachments/assets/1df5fbf7-7bdf-492f-80ac-49378357447c" />

Known trap and chum combinations already reveal their expected catch while the trap is active. Showing the same discovery modal again on collection is redundant. The activity check happens before `waterTrap.collected` because that event records the current catch and would otherwise make a first-time discovery appear known.


## What changed

- Check whether the caught crustacean already exists in farm activity before collecting the water trap.
- Show the catch discovery modal only when the caught item has never been collected before.
- Continue collecting the trap and awarding the catch normally for known items, without interrupting the player with the repeated modal.

## Checks

- `yarn tsc --noEmit`
- Targeted ESLint for `WaterTrapSpot.tsx`
- Prettier
- `git diff --check`

Browser verification was not performed.