### PR TITLE
[FEAT] Windowed speed boosts for the Crop Machine

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
 
 # One review per PR. A push supersedes the run it replaces rather than
 # stacking beside it, which also stops a slow older run posting a stale

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 # One review per PR. A push supersedes the run it replaces rather than
 # stacking beside it, which also stops a slow older run posting a stale

--- a/src/components/ui/layouts/SeedRequirements.tsx
+++ b/src/components/ui/layouts/SeedRequirements.tsx
@@ -21,7 +21,15 @@ import { SquareIcon } from "../SquareIcon";
 import { formatDateRange, secondsToString } from "lib/utils/time";
 import { SUNNYSIDE } from "assets/sunnyside";
 import classNames from "classnames";
-import { isPreActionBoosted } from "features/game/lib/timerDisplay";
+import {
+  getPreActionDisplay,
+  isPreActionBoosted,
+} from "features/game/lib/timerDisplay";
+import { getCropMachineBoostWindows } from "features/game/lib/boostWindows";
+import {
+  getBoostContributionEntries,
+  getCropMachineBoostContributions,
+} from "features/game/lib/boostContributions";
 import emptyPot from "assets/greenhouse/greenhouse_pot.webp";
 import flowerBed from "assets/flowers/empty_flowerbed.webp";
 
@@ -42,6 +50,7 @@ import {
 } from "features/game/events/landExpansion/supplyCropMachine";
 import { useActiveBuff } from "features/game/types/buffs";
 import { useNow } from "lib/utils/hooks/useNow";
+import { hasFeatureAccess } from "lib/flags";
 
 /**
  * The props for the details for items.
@@ -292,29 +301,69 @@ export const SeedRequirements: React.FC<Props> = ({
     const RequirementLabels: React.FC = () => {
       if (isSeedCropMachine(details.item)) {
         const cropMachinePackSize = CROP_MACHINE_PLOTS(gameState);
-        const cropMachineBoostedTime = calculateCropTime(
+
+        // A pack supplied now WILL be windowed under SPEED_BOOSTS — the supply
+        // event converts the machine — so this pre-action preview gates on the
+        // FLAG (there is no pack yet to carry a marker). The Tortoise is then a
+        // live window rather than a baked ×0.9, so it must come out of the
+        // duration here and be credited over the grow instead.
+        const isCropMachineWindowed = hasFeatureAccess(
+          gameState,
+          "SPEED_BOOSTS",
+        );
+        const cropMachineTime = calculateCropTime(
           { type: details.item, amount: cropMachinePackSize },
           gameState,
           now,
+          { windowed: isCropMachineWindowed },
         );
+        const cropMachineSeconds = cropMachineTime.milliSeconds / 1000;
         const cropMachineBaseTime = baseTimeSeconds;
-        const isCropMachineTimeBoosted =
-          cropMachineBoostedTime.milliSeconds / 1000 !== cropMachineBaseTime;
+
+        // Name the windowed Tortoise by the time it actually saves ("-1hr
+        // 12mins Tortoise Shrine"), matching every other windowed boost in the
+        // seed shop, instead of the legacy "x0.9" multiplier.
+        const cropMachineBoostsUsed = [
+          ...cropMachineTime.boostUsed,
+          ...getBoostContributionEntries({
+            contributions: getCropMachineBoostContributions(gameState),
+            seconds: cropMachineSeconds,
+            at: now,
+            formatSeconds: (seconds) =>
+              secondsToString(seconds, { length: "medium" }),
+          }),
+        ];
+
+        const {
+          displaySeconds: cropMachineDisplaySeconds,
+          hasNamedBoosts: cropMachineHasNamedBoosts,
+          isBoosted: isCropMachineTimeBoosted,
+        } = getPreActionDisplay({
+          seconds: cropMachineSeconds,
+          baseSeconds: cropMachineBaseTime,
+          namedBoostCount: cropMachineBoostsUsed.length,
+          windows: isCropMachineWindowed
+            ? getCropMachineBoostWindows(gameState)
+            : [],
+          at: now,
+        });
 
         return (
           <div
-            className="flex flex-col items-center cursor-pointer"
+            className={classNames("flex flex-col items-center", {
+              "cursor-pointer": cropMachineHasNamedBoosts,
+            })}
             onClick={
-              isCropMachineTimeBoosted
+              cropMachineHasNamedBoosts
                 ? () => setShowBoosts(!showBoosts)
                 : undefined
             }
           >
             <p className="text-xxs">{`Time to grow ${cropMachinePackSize}x: `}</p>
-            {!!cropMachineBoostedTime && isCropMachineTimeBoosted && (
+            {isCropMachineTimeBoosted && (
               <RequirementLabel
                 type="time"
-                waitSeconds={cropMachineBoostedTime.milliSeconds / 1000}
+                waitSeconds={cropMachineDisplaySeconds}
                 boosted
               />
             )}
@@ -326,7 +375,7 @@ export const SeedRequirements: React.FC<Props> = ({
               />
             )}
             <BoostsDisplay
-              boosts={cropMachineBoostedTime.boostUsed ?? []}
+              boosts={cropMachineBoostsUsed}
               show={showBoosts}
               state={gameState}
               onClick={() => setShowBoosts(!showBoosts)}

--- a/src/features/game/events/landExpansion/harvestCropMachine.test.ts
+++ b/src/features/game/events/landExpansion/harvestCropMachine.test.ts
@@ -4,8 +4,20 @@ import type { GameState } from "features/game/types/game";
 import { CROP_MACHINE_PLOTS } from "./supplyCropMachine";
 import { KNOWN_IDS } from "features/game/types";
 import { prngChance } from "lib/prng";
+import { CONFIG } from "lib/config";
 
 const GAME_STATE: GameState = { ...TEST_FARM, bumpkin: INITIAL_BUMPKIN };
+
+// These suites assert the LEGACY crop machine (boosts baked at supply time,
+// oil earmarked per pack). FE jest runs on amoy where SPEED_BOOSTS is on, so
+// force the flag off here; the windowed model is covered in its own describes.
+const originalNetwork = CONFIG.NETWORK;
+beforeEach(() => {
+  (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = "mainnet";
+});
+afterEach(() => {
+  (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = originalNetwork;
+});
 
 describe("harvestCropMachine", () => {
   it("throws an error if Crop Machine does not exist", () => {
@@ -535,5 +547,144 @@ describe("harvestCropMachine", () => {
       expect(stellarSunflowerHits).toBeGreaterThanOrEqual(1);
       expect(amount).toEqual(expectedAmount);
     });
+  });
+});
+
+describe("harvestCropMachine (windowed SPEED_BOOSTS)", () => {
+  beforeEach(() => {
+    (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = "amoy";
+  });
+
+  const HOUR = 60 * 60 * 1000;
+  const now = Date.now();
+  const farmId = 1;
+
+  const stateWithMachine = (
+    machine: Record<string, unknown>,
+    overrides: Partial<GameState> = {},
+  ): GameState => ({
+    ...GAME_STATE,
+    buildings: {
+      "Crop Machine": [
+        {
+          coordinates: { x: 0, y: 0 },
+          createdAt: 0,
+          id: "1",
+          readyAt: 0,
+          ...machine,
+        },
+      ],
+    },
+    ...overrides,
+  });
+
+  it("gates on the DERIVED readiness: a shrine placed after the last settlement makes a pack harvestable before its stale cached readyAt", () => {
+    // Anchored 1h ago with 65min of work: unboosted it would be ready in 5min
+    // (the stored readyAt cache says so). A Tortoise Shrine placed right after
+    // the anchor makes the whole grow 65 × 0.9 = 58.5min — derived-ready 6.5
+    // minutes ago.
+    const state = harvestCropMachine({
+      state: stateWithMachine(
+        {
+          oilSettledAt: now - HOUR,
+          unallocatedOilTime: 10 * HOUR,
+          queue: [
+            {
+              crop: "Sunflower",
+              seeds: 10,
+              growTimeRemaining: 0,
+              totalGrowTime: 65 * 60 * 1000,
+              baseDurationMs: 65 * 60 * 1000,
+              startTime: now - HOUR,
+              readyAt: now + 5 * 60 * 1000, // stale cache
+            },
+          ],
+        },
+        {
+          collectibles: {
+            "Tortoise Shrine": [
+              {
+                coordinates: { x: -1, y: -1 },
+                createdAt: now - HOUR,
+                readyAt: 0,
+                id: "shrine",
+              },
+            ],
+          },
+        },
+      ),
+      action: { type: "cropMachine.harvested", packIndex: 0, machineId: "1" },
+      createdAt: now,
+      farmId,
+    });
+
+    expect(state.buildings["Crop Machine"]?.[0]?.queue).toHaveLength(0);
+    expect(state.inventory["Sunflower"]?.toNumber()).toBeGreaterThan(0);
+  });
+
+  it("throws for a windowed pack that is not ready yet, even when its stale cache says otherwise", () => {
+    expect(() =>
+      harvestCropMachine({
+        state: stateWithMachine({
+          oilSettledAt: now - HOUR,
+          unallocatedOilTime: 10 * HOUR,
+          queue: [
+            {
+              crop: "Sunflower",
+              seeds: 10,
+              growTimeRemaining: 0,
+              totalGrowTime: 2 * HOUR,
+              baseDurationMs: 2 * HOUR,
+              startTime: now - HOUR,
+              // A stale-PAST readyAt cache must not make it harvestable:
+              // the derived time (1h of the 2h remains) is the truth.
+              readyAt: now - 1,
+            },
+          ],
+        }),
+        action: { type: "cropMachine.harvested", packIndex: 0, machineId: "1" },
+        createdAt: now,
+        farmId,
+      }),
+    ).toThrow("The pack is not ready yet");
+  });
+
+  it("leaves the downstream pack's banked progress undisturbed when the head is harvested", () => {
+    const state = harvestCropMachine({
+      state: stateWithMachine({
+        oilSettledAt: now - 2 * HOUR,
+        unallocatedOilTime: 10 * HOUR,
+        queue: [
+          {
+            crop: "Sunflower",
+            seeds: 10,
+            growTimeRemaining: 0,
+            totalGrowTime: HOUR,
+            baseDurationMs: HOUR,
+          },
+          {
+            crop: "Sunflower",
+            seeds: 10,
+            growTimeRemaining: 0,
+            totalGrowTime: 4 * HOUR,
+            baseDurationMs: 4 * HOUR,
+          },
+        ],
+      }),
+      action: { type: "cropMachine.harvested", packIndex: 0, machineId: "1" },
+      createdAt: now,
+      farmId,
+    });
+
+    const machine = state.buildings["Crop Machine"]?.[0];
+    const survivor = machine?.queue?.[0];
+
+    // Head completed at anchor+1h; the survivor then grew [anchor+1h, now] =
+    // 1h of its 4h, banked by the settle. Its remaining 3h resumes from `now`.
+    expect(machine?.queue).toHaveLength(1);
+    expect(survivor?.baseDurationMs).toBe(3 * HOUR);
+    expect(survivor?.readyAt).toBe(now + 3 * HOUR);
+    // Fuel: 2h burned (1h head + 1h survivor).
+    expect(machine?.unallocatedOilTime).toBe(8 * HOUR);
   });
 });

--- a/src/features/game/events/landExpansion/harvestCropMachine.ts
+++ b/src/features/game/events/landExpansion/harvestCropMachine.ts
@@ -8,6 +8,13 @@ import type {
 import { produce } from "immer";
 import { getCropYieldAmount } from "./harvest";
 import { updateBoostUsed } from "features/game/types/updateBoostUsed";
+import { hasFeatureAccess } from "lib/flags";
+import { getCropMachineBoostWindows } from "features/game/lib/boostWindows";
+import {
+  convertCropMachineToWindowed,
+  refreshCropMachineCaches,
+  settleCropMachine,
+} from "features/game/lib/cropMachineReadiness";
 
 export type HarvestCropMachineAction = {
   type: "cropMachine.harvested";
@@ -88,7 +95,33 @@ export function harvestCropMachine({
 
     const pack = cropMachine.queue[action.packIndex];
 
-    if (!pack.readyAt || (pack.readyAt && pack.readyAt > createdAt)) {
+    const windowed =
+      cropMachine.oilSettledAt !== undefined ||
+      hasFeatureAccess(stateCopy, "SPEED_BOOSTS");
+    const windows = windowed ? getCropMachineBoostWindows(stateCopy) : [];
+
+    if (windowed) {
+      convertCropMachineToWindowed({
+        machine: cropMachine,
+        windows,
+        now: createdAt,
+      });
+      // Settle BEFORE gating: it finalises every pack whose DERIVED ready time
+      // has passed — a shrine placed since the last settlement can make a pack
+      // harvestable earlier than its stale cached readyAt — and banks every
+      // other pack's progress and the fuel burn through `createdAt`.
+      settleCropMachine({ machine: cropMachine, windows, now: createdAt });
+
+      // A completed pack was just finalised (marker dropped, readyAt stamped);
+      // one still carrying `baseDurationMs` is by definition not ready.
+      if (
+        pack.baseDurationMs !== undefined ||
+        !pack.readyAt ||
+        pack.readyAt > createdAt
+      ) {
+        throw new Error("The pack is not ready yet");
+      }
+    } else if (!pack.readyAt || (pack.readyAt && pack.readyAt > createdAt)) {
       throw new Error("The pack is not ready yet");
     }
 
@@ -117,6 +150,17 @@ export function harvestCropMachine({
     cropMachine.queue = cropMachine.queue.filter(
       (_, index) => index !== action.packIndex,
     );
+
+    if (windowed) {
+      // Everything downstream was settled to `createdAt` above, so removing a
+      // finalised pack cannot disturb it — this only re-derives the caches for
+      // the new queue shape.
+      refreshCropMachineCaches({
+        machine: cropMachine,
+        windows,
+        now: createdAt,
+      });
+    }
 
     stateCopy.boostsUsedAt = updateBoostUsed({
       game: stateCopy,

--- a/src/features/game/events/landExpansion/placeBuilding.test.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.test.ts
@@ -1502,3 +1502,96 @@ describe("Place building", () => {
     expect(isAnimalNeedingLove(animal, readyAt - 1, readyAt)).toBe(false);
   });
 });
+
+describe("placeBuilding (windowed crop machine)", () => {
+  const HOUR = 60 * 60 * 1000;
+  const at = Date.now();
+
+  const liftedMachine = (
+    overrides: Record<string, unknown> = {},
+  ): GameState => ({
+    ...GAME_STATE,
+    inventory: {
+      ...GAME_STATE.inventory,
+      "Crop Machine": new Decimal(1),
+      "Basic Land": new Decimal(10),
+    },
+    buildings: {
+      "Crop Machine": [
+        {
+          id: "123",
+          createdAt: 0,
+          readyAt: 0,
+          coordinates: undefined,
+          removedAt: at - 2 * HOUR,
+          // Settled at the lift by removeBuilding: 1h of work already banked.
+          oilSettledAt: at - 2 * HOUR,
+          unallocatedOilTime: 9 * HOUR,
+          queue: [
+            {
+              crop: "Sunflower",
+              seeds: 10,
+              growTimeRemaining: 3 * HOUR,
+              totalGrowTime: 4 * HOUR,
+              baseDurationMs: 3 * HOUR,
+            },
+          ],
+          ...overrides,
+        },
+      ],
+    },
+  });
+
+  it("re-anchors the fuel ledger across the downtime: the lifted interval costs neither fuel nor credit", () => {
+    const state = placeBuilding({
+      farmId: 1,
+      state: liftedMachine(),
+      action: {
+        type: "building.placed",
+        name: "Crop Machine",
+        id: "123",
+        coordinates: { x: 0, y: 1 },
+      },
+      createdAt: at,
+    });
+
+    const machine = state.buildings["Crop Machine"]?.[0];
+    const pack = machine?.queue?.[0];
+
+    expect(machine?.removedAt).toBeUndefined();
+    expect(machine?.oilSettledAt).toBe(at);
+    expect(machine?.unallocatedOilTime).toBe(9 * HOUR);
+    // The banked work is untouched; the remainder resumes from placement.
+    expect(pack?.baseDurationMs).toBe(3 * HOUR);
+    expect(pack?.readyAt).toBe(at + 3 * HOUR);
+    expect(pack?.growTimeRemaining).toBe(0);
+  });
+
+  it("keeps a completed pack harvestable across the lift", () => {
+    const state = placeBuilding({
+      farmId: 1,
+      state: liftedMachine({
+        queue: [
+          {
+            crop: "Sunflower",
+            seeds: 10,
+            growTimeRemaining: 0,
+            totalGrowTime: HOUR,
+            readyAt: at - 3 * HOUR,
+          },
+        ],
+      }),
+      action: {
+        type: "building.placed",
+        name: "Crop Machine",
+        id: "123",
+        coordinates: { x: 0, y: 1 },
+      },
+      createdAt: at,
+    });
+
+    const pack = state.buildings["Crop Machine"]?.[0]?.queue?.[0];
+    // Finalised history is never shifted forward.
+    expect(pack?.readyAt).toBe(at - 3 * HOUR);
+  });
+});

--- a/src/features/game/events/landExpansion/placeBuilding.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.ts
@@ -13,12 +13,14 @@ import { createInitialAgingShed } from "features/game/lib/agingShed";
 import {
   getCookingBoostWindows,
   getCraftingBoostWindows,
+  getCropMachineBoostWindows,
   getGreenhouseBoostWindows,
   getGreenhouseGlowWindows,
   pauseWindowedTimer,
 } from "features/game/lib/boostWindows";
 import { pauseCookingQueue } from "features/game/lib/cookingReadiness";
 import { pauseCraftingQueue } from "features/game/lib/craftingReadiness";
+import { refreshCropMachineCaches } from "features/game/lib/cropMachineReadiness";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { mfTrack } from "lib/moonforgeAnalytics";
 
@@ -116,7 +118,23 @@ export function placeBuilding({
       // Update the readyAt for Crop Machine
       if (action.name === "Crop Machine") {
         const existingCropMachine = existingBuilding as CropMachineBuilding;
-        if (existingCropMachine.queue) {
+        if (existingCropMachine.oilSettledAt !== undefined) {
+          // Windowed machine: removeBuilding settled at the lift (banking the
+          // accrued work and fuel burn), so resuming is just moving the fuel
+          // anchor across the downtime — the lifted interval costs neither fuel
+          // nor credit, and boost windows that expired mid-lift keep the credit
+          // banked before it. No timestamp shifting: the legacy shift re-exposes
+          // packs to a different slice of the windows (see pauseCookingQueue).
+          // removedAt is the resolver's pause clamp, so clear it before
+          // refreshing the caches (the generic delete below is then a no-op).
+          existingCropMachine.oilSettledAt = createdAt;
+          delete existingCropMachine.removedAt;
+          refreshCropMachineCaches({
+            machine: existingCropMachine,
+            windows: getCropMachineBoostWindows(stateCopy),
+            now: createdAt,
+          });
+        } else if (existingCropMachine.queue) {
           existingCropMachine.queue.forEach((pack) => {
             if (pack.readyAt) {
               pack.readyAt = createdAt + (pack.pausedTimeRemaining ?? 0);

--- a/src/features/game/events/landExpansion/placeBuilding.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.ts
@@ -127,7 +127,13 @@ export function placeBuilding({
           // packs to a different slice of the windows (see pauseCookingQueue).
           // removedAt is the resolver's pause clamp, so clear it before
           // refreshing the caches (the generic delete below is then a no-op).
-          existingCropMachine.oilSettledAt = createdAt;
+          // Monotonic, like `settleCropMachine`: the anchor may only move
+          // forward, so a replayed event stamped before the machine's current
+          // anchor cannot rewind the ledger.
+          existingCropMachine.oilSettledAt = Math.max(
+            createdAt,
+            existingCropMachine.oilSettledAt,
+          );
           delete existingCropMachine.removedAt;
           refreshCropMachineCaches({
             machine: existingCropMachine,

--- a/src/features/game/events/landExpansion/removeBuilding.test.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.test.ts
@@ -571,3 +571,52 @@ describe("removeBuilding", () => {
     ).toEqual(200000000);
   });
 });
+
+describe("removeBuilding (windowed crop machine)", () => {
+  const HOUR = 60 * 60 * 1000;
+
+  it("settles a windowed machine at the lift: work banked, fuel burned, no pausedTimeRemaining", () => {
+    const at = Date.now();
+    const state = removeBuilding({
+      state: {
+        ...GAME_STATE,
+        buildings: {
+          "Crop Machine": [
+            {
+              id: "123",
+              createdAt: 0,
+              readyAt: 0,
+              coordinates: { x: 1, y: 1 },
+              oilSettledAt: at - HOUR,
+              unallocatedOilTime: 10 * HOUR,
+              queue: [
+                {
+                  crop: "Sunflower",
+                  seeds: 10,
+                  growTimeRemaining: 0,
+                  totalGrowTime: 4 * HOUR,
+                  baseDurationMs: 4 * HOUR,
+                },
+              ],
+            },
+          ],
+        },
+      },
+      action: { type: "building.removed", name: "Crop Machine", id: "123" },
+      createdAt: at,
+    });
+
+    const machine = state.buildings["Crop Machine"]?.[0];
+    const pack = machine?.queue?.[0];
+
+    expect(machine?.removedAt).toBe(at);
+    expect(machine?.oilSettledAt).toBe(at);
+    // 1h of the 4h banked; 1h of fuel burned.
+    expect(pack?.baseDurationMs).toBe(3 * HOUR);
+    expect(machine?.unallocatedOilTime).toBe(9 * HOUR);
+    expect(pack?.pausedTimeRemaining).toBeUndefined();
+    // Paused caches: no projected finish while lifted.
+    expect(pack?.readyAt).toBeUndefined();
+    expect(pack?.growsUntil).toBeUndefined();
+  });
+});

--- a/src/features/game/events/landExpansion/removeBuilding.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.ts
@@ -2,6 +2,8 @@ import type { BuildingName } from "features/game/types/buildings";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 import type { CropMachineBuilding, GameState } from "features/game/types/game";
 import { produce } from "immer";
+import { getCropMachineBoostWindows } from "features/game/lib/boostWindows";
+import { settleCropMachine } from "features/game/lib/cropMachineReadiness";
 export enum REMOVE_BUILDING_ERRORS {
   INVALID_BUILDING = "This building does not exist",
   NO_BUMPKIN = "You do not have a Bumpkin",
@@ -61,7 +63,20 @@ export function removeBuilding({
 
     if (action.name === "Crop Machine") {
       const cropMachine = buildingToRemove as CropMachineBuilding;
-      if (cropMachine.queue) {
+      if (cropMachine.oilSettledAt !== undefined) {
+        // Windowed machine: bank every in-flight pack's accrued work and the
+        // fuel burn through the lift instant. `removedAt` (set above) is the
+        // pause marker — the resolver accrues nothing past it — so no
+        // pausedTimeRemaining scalar is needed; placeBuilding re-anchors
+        // `oilSettledAt` across the downtime. Banking here (not shifting
+        // timestamps on place) keeps boost credit earned before the lift even
+        // if the shrine expires while the machine sits in the inventory.
+        settleCropMachine({
+          machine: cropMachine,
+          windows: getCropMachineBoostWindows(stateCopy),
+          now: createdAt,
+        });
+      } else if (cropMachine.queue) {
         cropMachine.queue.forEach((pack) => {
           if (pack.readyAt) {
             pack.pausedTimeRemaining = pack.readyAt - createdAt;

--- a/src/features/game/events/landExpansion/removeCropMachinePack.test.ts
+++ b/src/features/game/events/landExpansion/removeCropMachinePack.test.ts
@@ -7,16 +7,26 @@ import type {
   CropMachineBuilding,
   CropMachineQueueItem,
 } from "features/game/types/game";
+import { CONFIG } from "lib/config";
 
 const GAME_STATE: GameState = {
   ...TEST_FARM,
   bumpkin: INITIAL_BUMPKIN,
-  inventory: {
-    ...TEST_FARM.inventory,
-    "Beta Pass": new Decimal(1),
-  },
 };
 const now = Date.now();
+
+// These suites assert the LEGACY crop machine (boosts baked at supply time,
+// oil earmarked per pack). The event was flag-gated at introduction (hence the
+// Beta Pass fixtures this suite used to carry) but no longer is; FE jest runs
+// on amoy where SPEED_BOOSTS is on, so force the flag off here — a Beta Pass
+// would defeat the pin. The windowed model is covered in its own describes.
+const originalNetwork = CONFIG.NETWORK;
+beforeEach(() => {
+  (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = "mainnet";
+});
+afterEach(() => {
+  (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = originalNetwork;
+});
 
 const createCropMachineWithQueue = (
   queue: CropMachineQueueItem[],
@@ -50,7 +60,6 @@ describe("removeCropMachinePack", () => {
       removeCropMachinePack({
         state: {
           ...GAME_STATE,
-          inventory: { "Beta Pass": new Decimal(1) },
           buildings: {
             "Crop Machine": [
               {
@@ -848,6 +857,112 @@ describe("removeCropMachinePack", () => {
             ],
           },
         },
+        action: {
+          type: "cropMachine.packRemoved",
+          packIndex: 0,
+          machineId: "1",
+        },
+        createdAt: now,
+      }),
+    ).toThrow("Pack has already started");
+  });
+});
+
+describe("removeCropMachinePack (windowed SPEED_BOOSTS)", () => {
+  beforeEach(() => {
+    (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = "amoy";
+  });
+
+  const HOUR = 60 * 60 * 1000;
+
+  const stateWithMachine = (machine: Record<string, unknown>): GameState => ({
+    ...GAME_STATE,
+    buildings: {
+      "Crop Machine": [
+        {
+          coordinates: { x: 0, y: 0 },
+          createdAt: 0,
+          id: "1",
+          readyAt: 0,
+          ...machine,
+        },
+      ],
+    },
+  });
+
+  const queuedMachine = () => ({
+    oilSettledAt: now - HOUR,
+    unallocatedOilTime: 2 * HOUR,
+    queue: [
+      {
+        crop: "Sunflower" as const,
+        seeds: 10,
+        growTimeRemaining: 0,
+        totalGrowTime: 4 * HOUR,
+        baseDurationMs: 4 * HOUR,
+      },
+      {
+        crop: "Potato" as const,
+        seeds: 5,
+        growTimeRemaining: 0,
+        totalGrowTime: 2 * HOUR,
+        baseDurationMs: 2 * HOUR,
+      },
+    ],
+  });
+
+  it("removes a queued pack with a seed refund, no oil arithmetic, and the head undisturbed", () => {
+    const state = removeCropMachinePack({
+      state: stateWithMachine(queuedMachine()),
+      action: { type: "cropMachine.packRemoved", packIndex: 1, machineId: "1" },
+      createdAt: now,
+    });
+
+    const machine = state.buildings["Crop Machine"]?.[0];
+    const head = machine?.queue?.[0];
+
+    expect(state.inventory["Potato Seed"]?.toNumber()).toBe(5);
+    expect(machine?.queue).toHaveLength(1);
+    // The head grew [anchor, now] = 1h of its 4h (banked by the settle) and
+    // stalls when the remaining 1h of fuel runs out; nothing was refunded to
+    // or taken from the tank (fuel has no per-pack earmarks).
+    expect(head?.baseDurationMs).toBe(3 * HOUR);
+    expect(machine?.unallocatedOilTime).toBe(HOUR);
+    expect(head?.growsUntil).toBe(now + HOUR);
+  });
+
+  it("throws when removing the pack the fuel has reached", () => {
+    expect(() =>
+      removeCropMachinePack({
+        state: stateWithMachine(queuedMachine()),
+        action: {
+          type: "cropMachine.packRemoved",
+          packIndex: 0,
+          machineId: "1",
+        },
+        createdAt: now,
+      }),
+    ).toThrow("Pack has already started");
+  });
+
+  it("throws when removing a finalised (completed) pack", () => {
+    const state = stateWithMachine({
+      oilSettledAt: now,
+      unallocatedOilTime: 0,
+      queue: [
+        {
+          crop: "Sunflower" as const,
+          seeds: 10,
+          growTimeRemaining: 0,
+          totalGrowTime: HOUR,
+          readyAt: now - HOUR,
+        },
+      ],
+    });
+
+    expect(() =>
+      removeCropMachinePack({
+        state,
         action: {
           type: "cropMachine.packRemoved",
           packIndex: 0,

--- a/src/features/game/events/landExpansion/removeCropMachinePack.test.ts
+++ b/src/features/game/events/landExpansion/removeCropMachinePack.test.ts
@@ -945,6 +945,40 @@ describe("removeCropMachinePack (windowed SPEED_BOOSTS)", () => {
     ).toThrow("Pack has already started");
   });
 
+  it("throws when removing a pack that stalled part-grown", () => {
+    // The pack was anchored 2h ago with 1h of fuel: it grew 1h of its 4h and
+    // has been stalled dry since. `resolveCropMachine` gives a pack it cannot
+    // fund no `startsAt`, so the derived check alone reads it as never-started
+    // — but it has burned oil and banked progress, and legacy has always
+    // treated a started pack as a binding commitment.
+    const state = stateWithMachine({
+      oilSettledAt: now - 2 * HOUR,
+      unallocatedOilTime: HOUR,
+      queue: [
+        {
+          crop: "Sunflower" as const,
+          seeds: 10,
+          growTimeRemaining: 0,
+          totalGrowTime: 4 * HOUR,
+          baseDurationMs: 4 * HOUR,
+          startTime: now - 2 * HOUR,
+        },
+      ],
+    });
+
+    expect(() =>
+      removeCropMachinePack({
+        state,
+        action: {
+          type: "cropMachine.packRemoved",
+          packIndex: 0,
+          machineId: "1",
+        },
+        createdAt: now,
+      }),
+    ).toThrow("Pack has already started");
+  });
+
   it("throws when removing a finalised (completed) pack", () => {
     const state = stateWithMachine({
       oilSettledAt: now,

--- a/src/features/game/events/landExpansion/removeCropMachinePack.ts
+++ b/src/features/game/events/landExpansion/removeCropMachinePack.ts
@@ -3,6 +3,14 @@ import type { CropSeedName } from "features/game/types/crops";
 import type { GameState } from "features/game/types/game";
 import { produce } from "immer";
 import { updateCropMachine } from "./supplyCropMachine";
+import { hasFeatureAccess } from "lib/flags";
+import { getCropMachineBoostWindows } from "features/game/lib/boostWindows";
+import {
+  convertCropMachineToWindowed,
+  refreshCropMachineCaches,
+  resolveCropMachine,
+  settleCropMachine,
+} from "features/game/lib/cropMachineReadiness";
 
 export type RemoveCropMachinePackAction = {
   type: "cropMachine.packRemoved";
@@ -42,6 +50,54 @@ export function removeCropMachinePack({
     }
 
     const pack = cropMachine.queue[action.packIndex];
+
+    const windowed =
+      cropMachine.oilSettledAt !== undefined ||
+      hasFeatureAccess(stateCopy, "SPEED_BOOSTS");
+
+    if (windowed) {
+      const windows = getCropMachineBoostWindows(stateCopy);
+      convertCropMachineToWindowed({
+        machine: cropMachine,
+        windows,
+        now: createdAt,
+      });
+      settleCropMachine({ machine: cropMachine, windows, now: createdAt });
+
+      // Started-check on the DERIVED timeline: after settling, a pack the
+      // fuel has reached starts at (or before) `createdAt`; only packs still
+      // queued behind others or unfunded are removable. A finalised pack (no
+      // marker) has certainly started.
+      const timing = resolveCropMachine({ machine: cropMachine, windows })
+        .packs[action.packIndex];
+      if (
+        pack.baseDurationMs === undefined ||
+        (timing.startsAt !== undefined && timing.startsAt <= createdAt)
+      ) {
+        throw new Error("Pack has already started");
+      }
+
+      // Refund seeds to inventory
+      const seedName: CropSeedName = `${pack.crop} Seed`;
+      const seedsInInventory = stateCopy.inventory[seedName] ?? new Decimal(0);
+      stateCopy.inventory[seedName] = seedsInInventory.add(pack.seeds);
+
+      // No oil to refund: on a windowed machine fuel carries no per-pack
+      // earmarks, and an unstarted pack has burned nothing. Removing it needs
+      // no hand-rolled rescheduling either — the resolver re-chains whatever
+      // was queued behind it.
+      cropMachine.queue = cropMachine.queue.filter(
+        (_, index) => index !== action.packIndex,
+      );
+
+      refreshCropMachineCaches({
+        machine: cropMachine,
+        windows,
+        now: createdAt,
+      });
+
+      return;
+    }
 
     if (pack.startTime !== undefined && pack.startTime <= createdAt) {
       throw new Error("Pack has already started");

--- a/src/features/game/events/landExpansion/removeCropMachinePack.ts
+++ b/src/features/game/events/landExpansion/removeCropMachinePack.ts
@@ -68,10 +68,19 @@ export function removeCropMachinePack({
       // fuel has reached starts at (or before) `createdAt`; only packs still
       // queued behind others or unfunded are removable. A finalised pack (no
       // marker) has certainly started.
+      //
+      // The derived start is not sufficient on its own: `resolveCropMachine`
+      // gives a pack it cannot fund no `startsAt` at all, so a pack that grew
+      // for a while and then STALLED with a dry tank would read as
+      // never-started and be removable for a full seed refund. Its stamped
+      // `startTime` survives settlement precisely because a past start is
+      // history (see `refreshCropMachineCaches`), so check it too — that is
+      // also the exact condition the legacy branch below uses.
       const timing = resolveCropMachine({ machine: cropMachine, windows })
         .packs[action.packIndex];
       if (
         pack.baseDurationMs === undefined ||
+        (pack.startTime !== undefined && pack.startTime <= createdAt) ||
         (timing.startsAt !== undefined && timing.startsAt <= createdAt)
       ) {
         throw new Error("Pack has already started");

--- a/src/features/game/events/landExpansion/supplyCropMachine.test.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.test.ts
@@ -21,8 +21,20 @@ import type {
   GameState,
 } from "features/game/types/game";
 import { setPrecision } from "lib/utils/formatNumber";
+import { CONFIG } from "lib/config";
 
 const GAME_STATE: GameState = { ...TEST_FARM, bumpkin: INITIAL_BUMPKIN };
+
+// These suites assert the LEGACY crop machine (boosts baked at supply time,
+// oil earmarked per pack). FE jest runs on amoy where SPEED_BOOSTS is on, so
+// force the flag off here; the windowed model is covered in its own describes.
+const originalNetwork = CONFIG.NETWORK;
+beforeEach(() => {
+  (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = "mainnet";
+});
+afterEach(() => {
+  (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = originalNetwork;
+});
 
 describe("supplyCropMachine", () => {
   it("throws an error if Crop Machine does not exist", () => {
@@ -1907,6 +1919,61 @@ describe("calculateCropTime", () => {
     );
   });
 
+  it("reduces crop machine growth time by 10% with an active Tortoise Shrine (legacy baked)", () => {
+    const at = Date.now();
+    const { milliSeconds: result, boostUsed } = calculateCropTime(
+      { type: "Sunflower Seed", amount: 10 },
+      {
+        ...GAME_STATE,
+        collectibles: {
+          "Tortoise Shrine": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: at,
+              readyAt: 0,
+              id: "0",
+            },
+          ],
+        },
+      },
+      at,
+    );
+
+    expect(result).toBe(
+      (60 * 10 * 1000 * 0.9) / CROP_MACHINE_PLOTS(GAME_STATE),
+    );
+    expect(boostUsed).toContainEqual({
+      name: "Tortoise Shrine",
+      value: "x0.9",
+    });
+  });
+
+  it("does not reduce growth time with an expired Tortoise Shrine", () => {
+    const at = Date.now();
+    const { milliSeconds: result, boostUsed } = calculateCropTime(
+      { type: "Sunflower Seed", amount: 10 },
+      {
+        ...GAME_STATE,
+        collectibles: {
+          "Tortoise Shrine": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              readyAt: 0,
+              id: "0",
+            },
+          ],
+        },
+      },
+      at,
+    );
+
+    expect(result).toBe((60 * 10 * 1000) / CROP_MACHINE_PLOTS(GAME_STATE));
+    expect(boostUsed).not.toContainEqual(
+      expect.objectContaining({ name: "Tortoise Shrine" }),
+    );
+  });
+
   it("reduces crop machine growth time by 24% with Crop Processor Unit and Rapid Rig", () => {
     const { milliSeconds: result } = calculateCropTime(
       { type: "Sunflower Seed", amount: 10 },
@@ -2117,5 +2184,153 @@ describe("Machinery skill upgrades (ranks)", () => {
       (60 * 10 * 1000 * 0.85 * 0.6) / CROP_MACHINE_PLOTS(GAME_STATE),
       5,
     );
+  });
+});
+
+describe("supplyCropMachine (windowed SPEED_BOOSTS)", () => {
+  // The file-level pin above forces mainnet for the legacy suites; the
+  // windowed model runs on the amoy default.
+  beforeEach(() => {
+    (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = "amoy";
+  });
+
+  const now = Date.now();
+  const HOUR = 60 * 60 * 1000;
+  // 10 Sunflower Seeds over 10 plots = 60s of work.
+  const PACK_MS = (60 * 10 * 1000) / CROP_MACHINE_PLOTS(GAME_STATE);
+
+  const shrine = (createdAt: number) => ({
+    "Tortoise Shrine": [
+      { coordinates: { x: -1, y: -1 }, createdAt, readyAt: 0, id: "shrine" },
+    ],
+  });
+
+  const stateWithMachine = (
+    machine: Partial<CropMachineBuilding>,
+    overrides: Partial<GameState> = {},
+  ): GameState => ({
+    ...GAME_STATE,
+    buildings: {
+      "Crop Machine": [
+        {
+          coordinates: { x: 0, y: 0 },
+          createdAt: 0,
+          id: "1",
+          readyAt: 0,
+          ...machine,
+        },
+      ],
+    },
+    inventory: {
+      ...GAME_STATE.inventory,
+      "Sunflower Seed": new Decimal(100),
+      ...overrides.inventory,
+    },
+    ...overrides,
+  });
+
+  it("supplies a windowed pack: Tortoise excluded from the duration AND from boostsUsed, marker fields set", () => {
+    const state = supplyCropMachine({
+      state: {
+        ...stateWithMachine({}),
+        collectibles: shrine(now),
+      },
+      action: {
+        type: "cropMachine.supplied",
+        seeds: { type: "Sunflower Seed", amount: 10 },
+        machineId: "1",
+      },
+      createdAt: now,
+    });
+
+    const machine = state.buildings["Crop Machine"]?.[0];
+    const pack = machine?.queue?.[0];
+
+    // NOT ×0.9 — the shrine is a live window now, not a baked discount.
+    expect(pack?.baseDurationMs).toBe(PACK_MS);
+    expect(pack?.totalGrowTime).toBe(PACK_MS);
+    expect(machine?.oilSettledAt).toBe(now);
+    expect(state.boostsUsedAt?.["Tortoise Shrine"]).toBeUndefined();
+  });
+
+  it("derives the windowed readyAt cache under an active shrine when fuelled", () => {
+    const state = supplyCropMachine({
+      state: {
+        ...stateWithMachine({
+          oilSettledAt: now,
+          unallocatedOilTime: 10 * HOUR,
+        }),
+        collectibles: shrine(now),
+      },
+      action: {
+        type: "cropMachine.supplied",
+        seeds: { type: "Sunflower Seed", amount: 10 },
+        machineId: "1",
+      },
+      createdAt: now,
+    });
+
+    const pack = state.buildings["Crop Machine"]?.[0]?.queue?.[0];
+    expect(pack?.readyAt).toBeCloseTo(now + PACK_MS * 0.9, 5);
+    expect(pack?.startTime).toBe(now);
+    expect(pack?.growTimeRemaining).toBe(0);
+  });
+
+  it("converts a legacy machine atomically on a flag-on supply, reclaiming earmarks into the tank", () => {
+    const state = supplyCropMachine({
+      state: stateWithMachine({
+        unallocatedOilTime: 0,
+        queue: [
+          {
+            crop: "Sunflower",
+            seeds: 10,
+            growTimeRemaining: 0,
+            totalGrowTime: PACK_MS,
+            startTime: now - PACK_MS / 2,
+            readyAt: now + PACK_MS / 2,
+          },
+        ],
+      }),
+      action: {
+        type: "cropMachine.supplied",
+        seeds: { type: "Sunflower Seed", amount: 10 },
+        machineId: "1",
+      },
+      createdAt: now,
+    });
+
+    const machine = state.buildings["Crop Machine"]?.[0];
+    const [oldPack, newPack] = machine?.queue ?? [];
+
+    expect(machine?.oilSettledAt).toBe(now);
+    // The in-flight legacy pack froze at its remaining half...
+    expect(oldPack?.baseDurationMs).toBe(PACK_MS / 2);
+    // ...and keeps its legacy finish exactly (the reclaimed earmark funds it).
+    expect(oldPack?.readyAt).toBe(now + PACK_MS / 2);
+    // The reclaimed fuel covers only the old pack; the new one waits unfunded.
+    expect(newPack?.baseDurationMs).toBe(PACK_MS);
+    expect(newPack?.readyAt).toBeUndefined();
+    expect(newPack?.growTimeRemaining).toBe(PACK_MS);
+  });
+
+  it("keeps a marked machine windowed on mainnet (marker beats flag)", () => {
+    (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = "mainnet";
+
+    const state = supplyCropMachine({
+      state: stateWithMachine({
+        oilSettledAt: now - HOUR,
+        unallocatedOilTime: HOUR,
+      }),
+      action: {
+        type: "cropMachine.supplied",
+        seeds: { type: "Sunflower Seed", amount: 10 },
+        machineId: "1",
+      },
+      createdAt: now,
+    });
+
+    const machine = state.buildings["Crop Machine"]?.[0];
+    expect(machine?.queue?.[0]?.baseDurationMs).toBe(PACK_MS);
+    expect(machine?.oilSettledAt).toBe(now);
   });
 });

--- a/src/features/game/events/landExpansion/supplyCropMachine.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.ts
@@ -18,6 +18,13 @@ import {
 } from "features/game/lib/collectibleBuilt";
 import { INVENTORY_LIMIT } from "features/game/lib/constants";
 import { SKILL_RANKS, getSkillLevel } from "features/game/types/bumpkinSkills";
+import { hasFeatureAccess } from "lib/flags";
+import { getCropMachineBoostWindows } from "features/game/lib/boostWindows";
+import {
+  convertCropMachineToWindowed,
+  refreshCropMachineCaches,
+  settleCropMachine,
+} from "features/game/lib/cropMachineReadiness";
 
 export type AddSeedsInput = {
   type: CropSeedName;
@@ -110,6 +117,12 @@ export function calculateCropTime(
   },
   state: GameState,
   now: number,
+  // Under SPEED_BOOSTS the Tortoise Shrine is a live window credited over the
+  // pack's whole grow (see cropMachineReadiness.ts), so it must not ALSO be
+  // baked into the duration here — only the permanent boosts are. It is
+  // likewise excluded from boostUsed: a windowed boost isn't "consumed" at
+  // supply time, and the boost panel lists it via boostContributions instead.
+  { windowed = false }: { windowed?: boolean } = {},
 ): { milliSeconds: number; boostUsed: { name: BoostName; value: string }[] } {
   const boostUsed: { name: BoostName; value: string }[] = [];
   const cropName = seeds.type.split(" ")[0] as CropName;
@@ -140,6 +153,7 @@ export function calculateCropTime(
   }
 
   if (
+    !windowed &&
     isTemporaryCollectibleActive({ name: "Tortoise Shrine", game: state, now })
   ) {
     milliSeconds = milliSeconds * 0.9;
@@ -391,30 +405,64 @@ export function supplyCropMachine({
 
     const crop = seedName.split(" ")[0] as CropName;
 
+    // A machine already carrying the windowed marker stays windowed even on a
+    // flag rollback; a legacy machine converts the moment a flagged player
+    // touches it (normally the load migration got there first — this covers a
+    // mid-session flag flip, deterministically on both FE and BE).
+    const windowed =
+      cropMachine.oilSettledAt !== undefined ||
+      hasFeatureAccess(stateCopy, "SPEED_BOOSTS");
+
     const { milliSeconds, boostUsed } = calculateCropTime(
       seedsAdded,
       state,
       createdAt,
+      { windowed },
     );
 
-    queue.push({
-      seeds: seedsAdded.amount,
-      crop,
-      growTimeRemaining: milliSeconds,
-      totalGrowTime: milliSeconds,
-    });
-    cropMachine.queue = queue;
+    if (windowed) {
+      const windows = getCropMachineBoostWindows(stateCopy);
+      convertCropMachineToWindowed({
+        machine: cropMachine,
+        windows,
+        now: createdAt,
+      });
+      settleCropMachine({ machine: cropMachine, windows, now: createdAt });
 
-    const updatedCropMachine = updateCropMachine({
-      now: createdAt,
-      cropMachine,
-    });
+      queue.push({
+        seeds: seedsAdded.amount,
+        crop,
+        growTimeRemaining: milliSeconds,
+        totalGrowTime: milliSeconds,
+        baseDurationMs: milliSeconds,
+      });
+      cropMachine.queue = queue;
 
-    stateCopy.buildings["Crop Machine"] = stateCopy.buildings[
-      "Crop Machine"
-    ].map((machine) =>
-      machine.id === cropMachine.id ? updatedCropMachine : machine,
-    );
+      refreshCropMachineCaches({
+        machine: cropMachine,
+        windows,
+        now: createdAt,
+      });
+    } else {
+      queue.push({
+        seeds: seedsAdded.amount,
+        crop,
+        growTimeRemaining: milliSeconds,
+        totalGrowTime: milliSeconds,
+      });
+      cropMachine.queue = queue;
+
+      const updatedCropMachine = updateCropMachine({
+        now: createdAt,
+        cropMachine,
+      });
+
+      stateCopy.buildings["Crop Machine"] = stateCopy.buildings[
+        "Crop Machine"
+      ].map((machine) =>
+        machine.id === cropMachine.id ? updatedCropMachine : machine,
+      );
+    }
 
     stateCopy.boostsUsedAt = updateBoostUsed({
       game: stateCopy,

--- a/src/features/game/events/landExpansion/supplyCropMachineOil.test.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachineOil.test.ts
@@ -2,6 +2,7 @@ import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
 import {
   CROP_MACHINE_PLOTS,
   getOilTimeInMillis,
+  MAX_OIL_CAPACITY_IN_MILLIS,
   OIL_PER_HOUR_CONSUMPTION,
 } from "./supplyCropMachine";
 import {
@@ -14,8 +15,20 @@ import type {
   CropMachineQueueItem,
   GameState,
 } from "features/game/types/game";
+import { CONFIG } from "lib/config";
 
 const GAME_STATE: GameState = { ...TEST_FARM, bumpkin: INITIAL_BUMPKIN };
+
+// These suites assert the LEGACY crop machine (boosts baked at supply time,
+// oil earmarked per pack). FE jest runs on amoy where SPEED_BOOSTS is on, so
+// force the flag off here; the windowed model is covered in its own describes.
+const originalNetwork = CONFIG.NETWORK;
+beforeEach(() => {
+  (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = "mainnet";
+});
+afterEach(() => {
+  (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = originalNetwork;
+});
 
 describe("supplyCropMachineOil", () => {
   it("throws an error if Crop Machine does not exist", () => {
@@ -486,5 +499,78 @@ describe("supplyCropMachineOil", () => {
       const result = getTotalOilMillisInMachine(queue, unallocatedOilTime, now);
       expect(result).toBe(packGrowTime + 1000);
     });
+  });
+});
+
+describe("supplyCropMachineOil (windowed SPEED_BOOSTS)", () => {
+  beforeEach(() => {
+    (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = "amoy";
+  });
+
+  const now = Date.now();
+  const HOUR = 60 * 60 * 1000;
+
+  const stateWithMachine = (
+    machine: Partial<CropMachineBuilding>,
+  ): GameState => ({
+    ...GAME_STATE,
+    inventory: { ...GAME_STATE.inventory, Oil: new Decimal(100) },
+    buildings: {
+      "Crop Machine": [
+        {
+          coordinates: { x: 0, y: 0 },
+          createdAt: 0,
+          id: "1",
+          readyAt: 0,
+          ...machine,
+        },
+      ],
+    },
+  });
+
+  it("settles then checks capacity against the tank, and a stalled pack resumes from the refuel", () => {
+    // Pack ran [now - 2h, now - 1h] then stalled; 1 oil = 1h of fuel.
+    const state = supplyCropMachineOil({
+      state: stateWithMachine({
+        oilSettledAt: now - 2 * HOUR,
+        unallocatedOilTime: HOUR,
+        queue: [
+          {
+            crop: "Sunflower",
+            seeds: 10,
+            growTimeRemaining: 0,
+            totalGrowTime: 4 * HOUR,
+            baseDurationMs: 4 * HOUR,
+          },
+        ],
+      }),
+      action: { type: "cropMachine.oilSupplied", oil: 1, machineId: "1" },
+      createdAt: now,
+    });
+
+    const machine = state.buildings["Crop Machine"]?.[0];
+    const pack = machine?.queue?.[0];
+
+    expect(machine?.oilSettledAt).toBe(now);
+    // The settle banked the fuelled hour and burned it; the new oil is the tank.
+    expect(machine?.unallocatedOilTime).toBe(HOUR);
+    expect(pack?.baseDurationMs).toBe(3 * HOUR);
+    // The stall gap cost nothing; the remainder resumes here until the new
+    // fuel runs out again.
+    expect(pack?.growsUntil).toBe(now + HOUR);
+    expect(pack?.growTimeRemaining).toBe(2 * HOUR);
+  });
+
+  it("throws when the tank cannot hold the oil", () => {
+    expect(() =>
+      supplyCropMachineOil({
+        state: stateWithMachine({
+          oilSettledAt: now,
+          unallocatedOilTime: MAX_OIL_CAPACITY_IN_MILLIS(GAME_STATE),
+        }),
+        action: { type: "cropMachine.oilSupplied", oil: 1, machineId: "1" },
+        createdAt: now,
+      }),
+    ).toThrow("Oil capacity exceeded");
   });
 });

--- a/src/features/game/events/landExpansion/supplyCropMachineOil.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachineOil.ts
@@ -6,7 +6,20 @@ import {
   MAX_OIL_CAPACITY_IN_MILLIS,
   updateCropMachine,
 } from "./supplyCropMachine";
+import { hasFeatureAccess } from "lib/flags";
+import { getCropMachineBoostWindows } from "features/game/lib/boostWindows";
+import {
+  convertCropMachineToWindowed,
+  settleCropMachine,
+} from "features/game/lib/cropMachineReadiness";
 
+/**
+ * LEGACY MACHINES ONLY: reconstructs the tank from the per-pack earmarks the
+ * legacy allocator embedded in readyAt/growsUntil, in pure 1× wall-clock
+ * arithmetic. On a windowed machine (`oilSettledAt` set) there are no earmarks
+ * and wall clock ≠ work — after `settleCropMachine` the tank simply IS
+ * `unallocatedOilTime` (or `getCropMachineFuelAt` for a live reading).
+ */
 export function getTotalOilMillisInMachine(
   queue: CropMachineQueueItem[],
   unallocatedOilTime: number,
@@ -82,13 +95,48 @@ export function supplyCropMachineOil({
       throw new Error("Crop Machine not found");
     }
 
-    const { queue = [], unallocatedOilTime = 0 } = cropMachine;
-
     const previousOilInInventory = stateCopy.inventory["Oil"] ?? new Decimal(0);
 
     if (previousOilInInventory.lt(oilAdded)) {
       throw new Error("Missing requirements");
     }
+
+    const windowed =
+      cropMachine.oilSettledAt !== undefined ||
+      hasFeatureAccess(stateCopy, "SPEED_BOOSTS");
+
+    if (windowed) {
+      const windows = getCropMachineBoostWindows(stateCopy);
+      convertCropMachineToWindowed({
+        machine: cropMachine,
+        windows,
+        now: createdAt,
+      });
+      // After settling, the tank level IS unallocatedOilTime (no earmarks).
+      settleCropMachine({ machine: cropMachine, windows, now: createdAt });
+
+      if (
+        (cropMachine.unallocatedOilTime ?? 0) +
+          getOilTimeInMillis(oilAdded, state) >
+        MAX_OIL_CAPACITY_IN_MILLIS(state)
+      ) {
+        throw new Error("Oil capacity exceeded");
+      }
+
+      stateCopy.inventory["Oil"] = previousOilInInventory.minus(oilAdded);
+
+      cropMachine.unallocatedOilTime =
+        (cropMachine.unallocatedOilTime ?? 0) +
+        getOilTimeInMillis(oilAdded, state);
+
+      // Same instant, so this settle only refreshes the caches with the new
+      // fuel taken into account (a stalled pack resumes from here).
+      settleCropMachine({ machine: cropMachine, windows, now: createdAt });
+
+      return stateCopy;
+    }
+
+    const { queue = [], unallocatedOilTime = 0 } = cropMachine;
 
     const oilMillisInMachine = getTotalOilMillisInMachine(
       queue,

--- a/src/features/game/lib/boostContributions.test.ts
+++ b/src/features/game/lib/boostContributions.test.ts
@@ -3,6 +3,7 @@ import {
   getBoostContributionEntries,
   getCookingBoostContributions,
   getCraftingBoostContributions,
+  getCropMachineBoostContributions,
   getNodeBoostContributions,
   getSeedBoostContributions,
 } from "./boostContributions";
@@ -17,6 +18,7 @@ import {
   getAnimalBoostWindows,
   getCookingBoostWindows,
   getCraftingBoostWindows,
+  getCropMachineBoostWindows,
 } from "./boostWindows";
 import { CONFIG } from "lib/config";
 
@@ -113,6 +115,12 @@ describe("contributions match the window builders", () => {
   it("crafting", () => {
     expect(flatten(getCraftingBoostContributions(BOOSTED, at))).toEqual(
       getCraftingBoostWindows(BOOSTED),
+    );
+  });
+
+  it("crop machine", () => {
+    expect(flatten(getCropMachineBoostContributions(BOOSTED))).toEqual(
+      getCropMachineBoostWindows(BOOSTED),
     );
   });
 });
@@ -283,6 +291,10 @@ describe("without SPEED_BOOSTS", () => {
   it("names no boosters for cooking or an animal", () => {
     expect(getCookingBoostContributions(BOOSTED, at)).toEqual([]);
     expect(getAnimalBoostContributions(BOOSTED, "Chicken")).toEqual([]);
+  });
+
+  it("names no boosters for the crop machine", () => {
+    expect(getCropMachineBoostContributions(BOOSTED)).toEqual([]);
   });
 
   it("leaves the panel with nothing to add", () => {

--- a/src/features/game/lib/boostContributions.ts
+++ b/src/features/game/lib/boostContributions.ts
@@ -13,6 +13,7 @@ import {
   ANIMAL_BOOST_SPEED,
   COOKING_BOOST_SPEED,
   CRAFTING_BOOST_SPEED,
+  CROP_MACHINE_BOOST_SPEED,
   CROP_PLOT_BOOST_SPEED,
   FLOWER_BOOST_SPEED,
   FRUIT_BOOST_SPEED,
@@ -168,6 +169,19 @@ const oil = (game: GameState, at: number): BoostContribution[] => [
   collectible(game, "Stag Shrine", OIL_BOOST_SPEED["Stag Shrine"]),
 ];
 
+/**
+ * The crop machine's windowed boosts — mirrors `getCropMachineBoostWindows`:
+ * the Tortoise Shrine alone (no totems, no hourglasses). Only its crop-machine
+ * half is named here; the greenhouse half is listed by `greenhouse` above.
+ */
+const cropMachine = (game: GameState): BoostContribution[] => [
+  collectible(
+    game,
+    "Tortoise Shrine",
+    CROP_MACHINE_BOOST_SPEED["Tortoise Shrine"],
+  ),
+];
+
 const greenhouse = (
   game: GameState,
   plant: GreenHouseCropName | GreenHouseFruitName,
@@ -273,6 +287,15 @@ export function getCraftingBoostContributions(
   if (!hasFeatureAccess(game, "SPEED_BOOSTS")) return [];
 
   return crafting(game, at);
+}
+
+/** The named boosts that would speed up a crop machine pack — mirrors getCropMachineBoostWindows. */
+export function getCropMachineBoostContributions(
+  game: GameState,
+): BoostContribution[] {
+  if (!hasFeatureAccess(game, "SPEED_BOOSTS")) return [];
+
+  return cropMachine(game);
 }
 
 /** The named boosts that would speed up this animal's sleep. */

--- a/src/features/game/lib/boostWindows.test.ts
+++ b/src/features/game/lib/boostWindows.test.ts
@@ -385,6 +385,80 @@ describe("appendBoostHistory", () => {
     ]);
   });
 
+  it("keeps a window a windowed crop machine's ledger still needs", () => {
+    // A windowed machine banks work forward from `oilSettledAt`, so every
+    // window ending after that anchor is still load-bearing. The anchor only
+    // advances on a crop-machine event or a flagged load, so a flag rollback
+    // (migrateSpeedBoosts returns early) can leave it older than the prune
+    // horizon — and pruning then silently un-does completed growth.
+    const now = 100 * DAY;
+    const anchor = now - 30 * DAY;
+    const game = {
+      ...TEST_FARM,
+      buildings: {
+        "Crop Machine": [
+          {
+            coordinates: { x: 0, y: 0 },
+            createdAt: 0,
+            id: "1",
+            readyAt: 0,
+            oilSettledAt: anchor,
+            unallocatedOilTime: 0,
+            queue: [],
+          },
+        ],
+      },
+      boostHistory: {
+        "Tortoise Shrine": [{ from: anchor, to: anchor + HOUR }],
+      },
+    } as unknown as GameState;
+
+    appendBoostHistory(
+      game,
+      "Tortoise Shrine",
+      { from: now - 500, to: now },
+      now,
+    );
+
+    expect(game.boostHistory?.["Tortoise Shrine"]).toEqual([
+      { from: anchor, to: anchor + HOUR },
+      { from: now - 500, to: now },
+    ]);
+  });
+
+  it("still prunes a window that predates even the oldest ledger anchor", () => {
+    const now = 100 * DAY;
+    const anchor = now - 30 * DAY;
+    const game = {
+      ...TEST_FARM,
+      buildings: {
+        "Crop Machine": [
+          {
+            coordinates: { x: 0, y: 0 },
+            createdAt: 0,
+            id: "1",
+            readyAt: 0,
+            oilSettledAt: anchor,
+            unallocatedOilTime: 0,
+            queue: [],
+          },
+        ],
+      },
+      boostHistory: { "Tortoise Shrine": [{ from: 0, to: 1000 }] },
+    } as unknown as GameState;
+
+    appendBoostHistory(
+      game,
+      "Tortoise Shrine",
+      { from: now - 500, to: now },
+      now,
+    );
+
+    expect(game.boostHistory?.["Tortoise Shrine"]).toEqual([
+      { from: now - 500, to: now },
+    ]);
+  });
+
   it("records for any temporary collectible (future-proof, even if not windowed yet)", () => {
     const game = { ...TEST_FARM, boostHistory: {} } as GameState;
     appendBoostHistory(game, "Ore Hourglass", { from: 1000, to: 2000 }, 2000);

--- a/src/features/game/lib/boostWindows.ts
+++ b/src/features/game/lib/boostWindows.ts
@@ -703,6 +703,33 @@ export function getBoostWindows({
 const MAX_BOOST_HISTORY_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
+ * The earliest instant any windowed ledger still needs boost history for.
+ *
+ * A windowed crop machine banks work FORWARD from `oilSettledAt`, re-deriving
+ * it from the windows each time, so every window ending after that anchor is
+ * still load-bearing. The anchor normally tracks the last event or flagged
+ * load, but it can fall behind the prune horizon — `migrateSpeedBoosts`
+ * returns early when SPEED_BOOSTS is off, while the prune below is not
+ * flag-gated, so a rollback longer than `MAX_BOOST_HISTORY_AGE_MS` would
+ * otherwise drop windows a still-windowed machine depends on.
+ *
+ * The crop machine is the only activity that needs this: its packs can stall
+ * on an empty tank indefinitely, so its anchor can be arbitrarily old. Every
+ * other windowed node runs to completion on its own schedule.
+ */
+function getEarliestLedgerAnchor(game: GameState): number | undefined {
+  let earliest: number | undefined;
+
+  for (const machine of game.buildings?.["Crop Machine"] ?? []) {
+    const anchor = machine.oilSettledAt;
+    if (anchor === undefined) continue;
+    if (earliest === undefined || anchor < earliest) earliest = anchor;
+  }
+
+  return earliest;
+}
+
+/**
  * Record a finalised active window for a temporary boost collectible into
  * `game.boostHistory` so its contribution survives the placed record being burned
  * (deleted) or renewed (createdAt reset). Mutates `game` in place (immer-draft
@@ -720,9 +747,16 @@ export function appendBoostHistory(
   if (window.to <= window.from) return;
 
   if (!game.boostHistory) game.boostHistory = {};
-  const kept = (game.boostHistory[name] ?? []).filter(
-    (w) => w.to >= now - MAX_BOOST_HISTORY_AGE_MS,
+
+  // Never prune below a ledger anchor that still reads this history — losing
+  // such a window would silently un-do growth a machine already completed.
+  const anchor = getEarliestLedgerAnchor(game);
+  const horizon = Math.min(
+    now - MAX_BOOST_HISTORY_AGE_MS,
+    anchor ?? Number.POSITIVE_INFINITY,
   );
+
+  const kept = (game.boostHistory[name] ?? []).filter((w) => w.to >= horizon);
   kept.push({ from: window.from, to: window.to });
   game.boostHistory[name] = kept;
 }

--- a/src/features/game/lib/boostWindows.ts
+++ b/src/features/game/lib/boostWindows.ts
@@ -181,8 +181,8 @@ export const CRAFTING_BOOST_SPEED = {
  * (Grape). Orchard-on-Grape is a windowed-model ADDITION — the legacy baked
  * path never applied it to greenhouse fruit (hourglasses now cover their whole
  * activity, mirroring Harvest-on-greenhouse-crops). Tortoise Shrine is a
- * MIXED-activity boost: only its greenhouse half is windowed here; its
- * crop-machine ×0.9 stays baked in supplyCropMachine until that slice.
+ * MIXED-activity boost: this is only its greenhouse half; its crop-machine half
+ * is windowed separately in `CROP_MACHINE_BOOST_SPEED`.
  */
 export const GREENHOUSE_BOOST_SPEED = {
   "Super Totem": 2,
@@ -192,6 +192,20 @@ export const GREENHOUSE_BOOST_SPEED = {
   "Tortoise Shrine": 1.5,
   // Per-pot fertiliser (not a collectible); windowed via getGreenhouseGlowWindows.
   "Greenhouse Glow": 1.25,
+} as const;
+
+/**
+ * Speed multiplier for the windowed crop-machine growth boost. The Tortoise
+ * Shrine is the crop machine's ONLY temporary boost (no totems or hourglasses
+ * apply — the Harvest Hourglass does not cover the machine). The value is the
+ * exact reciprocal of the legacy baked ×0.9, so a shrine covering a whole pack
+ * reproduces the old time to the millisecond (deliberately NOT rounded, unlike
+ * the shrine's greenhouse half). Tortoise Shrine is a MIXED-activity boost:
+ * this is its crop-machine half; the greenhouse half lives in
+ * `GREENHOUSE_BOOST_SPEED`.
+ */
+export const CROP_MACHINE_BOOST_SPEED = {
+  "Tortoise Shrine": 10 / 9,
 } as const;
 
 /** Window for the Power Hour buff (1h from activation), if active. */
@@ -414,6 +428,22 @@ export const getCraftingBoostWindows = (game: GameState): BoostWindow[] => [
     speed: CRAFTING_BOOST_SPEED["Fox Shrine"],
   }),
 ];
+
+/**
+ * The windowed speed boost that applies to crop machine growth — the Tortoise
+ * Shrine alone (no totems, no hourglasses). Empty set (no shrine) makes
+ * `computeReadyAt` reduce to `start + baseDurationMs`. Like cooking, these
+ * windows are consumed by a QUEUE — see `resolveCropMachine` in
+ * `cropMachineReadiness.ts`, which additionally threads the machine's oil
+ * through the chain (fuel burns by the wall clock while a window accelerates
+ * the work, so a boost makes packs both faster and cheaper in oil).
+ */
+export const getCropMachineBoostWindows = (game: GameState): BoostWindow[] =>
+  getBoostWindows({
+    game,
+    name: "Tortoise Shrine",
+    speed: CROP_MACHINE_BOOST_SPEED["Tortoise Shrine"],
+  });
 
 /**
  * The Turbofruit Mix fertiliser's speed window for a fruit patch. Unlike the

--- a/src/features/game/lib/cropMachineReadiness.test.ts
+++ b/src/features/game/lib/cropMachineReadiness.test.ts
@@ -1,0 +1,648 @@
+import type {
+  CropMachineBuilding,
+  CropMachineQueueItem,
+} from "features/game/types/game";
+import type { BoostWindow } from "./boostWindows";
+import { CROP_MACHINE_BOOST_SPEED } from "./boostWindows";
+import {
+  convertCropMachineToWindowed,
+  getCropMachineFuelAt,
+  getCropMachinePackProgress,
+  getCropMachineSpeedAt,
+  resolveCropMachine,
+  settleCropMachine,
+} from "./cropMachineReadiness";
+
+const HOUR = 60 * 60 * 1000;
+const T0 = 1_700_000_000_000;
+
+const windowedPack = (
+  baseDurationMs: number,
+  overrides: Partial<CropMachineQueueItem> = {},
+): CropMachineQueueItem => ({
+  crop: "Sunflower",
+  seeds: 10,
+  growTimeRemaining: 0,
+  totalGrowTime: baseDurationMs,
+  baseDurationMs,
+  ...overrides,
+});
+
+const machine = (
+  queue: CropMachineQueueItem[],
+  unallocatedOilTime: number,
+  overrides: Partial<CropMachineBuilding> = {},
+): CropMachineBuilding => ({
+  coordinates: { x: 0, y: 0 },
+  createdAt: 0,
+  id: "1",
+  readyAt: 0,
+  queue,
+  unallocatedOilTime,
+  oilSettledAt: T0,
+  ...overrides,
+});
+
+const speed2 = (from: number, to: number): BoostWindow => ({
+  from,
+  to,
+  speed: 2,
+});
+
+describe("resolveCropMachine", () => {
+  it("resolves a single fuelled pack to start + baseDurationMs with no windows", () => {
+    const timings = resolveCropMachine({
+      machine: machine([windowedPack(2 * HOUR)], 10 * HOUR),
+      windows: [],
+    });
+
+    expect(timings.packs[0]).toEqual({
+      startsAt: T0,
+      readyAt: T0 + 2 * HOUR,
+      workRemainingMs: 0,
+    });
+    expect(timings.fuelRemainingMs).toBe(8 * HOUR);
+    expect(timings.fuelRunsOutAt).toBeUndefined();
+  });
+
+  it("chains packs sequentially", () => {
+    const timings = resolveCropMachine({
+      machine: machine(
+        [windowedPack(2 * HOUR), windowedPack(3 * HOUR)],
+        10 * HOUR,
+      ),
+      windows: [],
+    });
+
+    expect(timings.packs[0].readyAt).toBe(T0 + 2 * HOUR);
+    expect(timings.packs[1].startsAt).toBe(T0 + 2 * HOUR);
+    expect(timings.packs[1].readyAt).toBe(T0 + 5 * HOUR);
+    expect(timings.fuelRemainingMs).toBe(5 * HOUR);
+  });
+
+  it("stalls at anchor + fuel when the tank empties mid-pack", () => {
+    const timings = resolveCropMachine({
+      machine: machine([windowedPack(5 * HOUR), windowedPack(HOUR)], 2 * HOUR),
+      windows: [],
+    });
+
+    expect(timings.packs[0]).toEqual({
+      startsAt: T0,
+      growsUntil: T0 + 2 * HOUR,
+      workRemainingMs: 3 * HOUR,
+    });
+    // Everything behind the stall never starts.
+    expect(timings.packs[1]).toEqual({ workRemainingMs: HOUR });
+    expect(timings.fuelRunsOutAt).toBe(T0 + 2 * HOUR);
+    expect(timings.fuelRemainingMs).toBe(0);
+  });
+
+  it("never starts a pack on an empty tank", () => {
+    const timings = resolveCropMachine({
+      machine: machine([windowedPack(2 * HOUR)], 0),
+      windows: [],
+    });
+
+    expect(timings.packs[0]).toEqual({ workRemainingMs: 2 * HOUR });
+  });
+
+  it("completes a pack whose finish ties exactly with fuel-out", () => {
+    const timings = resolveCropMachine({
+      machine: machine([windowedPack(2 * HOUR), windowedPack(HOUR)], 2 * HOUR),
+      windows: [],
+    });
+
+    expect(timings.packs[0].readyAt).toBe(T0 + 2 * HOUR);
+    expect(timings.packs[0].growsUntil).toBeUndefined();
+    expect(timings.packs[1]).toEqual({ workRemainingMs: HOUR });
+    expect(timings.fuelRemainingMs).toBe(0);
+  });
+
+  it("makes a fully-covered pack faster AND cheaper in oil, the surplus flowing to the next pack", () => {
+    const timings = resolveCropMachine({
+      machine: machine(
+        [windowedPack(4 * HOUR), windowedPack(4 * HOUR)],
+        5 * HOUR,
+      ),
+      windows: [speed2(T0, T0 + 10 * HOUR)],
+    });
+
+    // 4h of work at 2× takes 2h of wall clock and burns 2h of fuel.
+    expect(timings.packs[0].readyAt).toBe(T0 + 2 * HOUR);
+    expect(timings.packs[1].startsAt).toBe(T0 + 2 * HOUR);
+    expect(timings.packs[1].readyAt).toBe(T0 + 4 * HOUR);
+    expect(timings.fuelRemainingMs).toBe(HOUR);
+  });
+
+  it("credits only the overlap of a window that expires mid-pack", () => {
+    const timings = resolveCropMachine({
+      machine: machine([windowedPack(4 * HOUR)], 10 * HOUR),
+      windows: [speed2(T0, T0 + HOUR)],
+    });
+
+    // 1h at 2× = 2h of work; the remaining 2h accrues at 1×.
+    expect(timings.packs[0].readyAt).toBe(T0 + 3 * HOUR);
+    expect(timings.fuelRemainingMs).toBe(7 * HOUR);
+  });
+
+  it("applies a window placed mid-grow to the remainder (retroactive speed-up saves fuel)", () => {
+    const timings = resolveCropMachine({
+      machine: machine([windowedPack(4 * HOUR)], 10 * HOUR),
+      windows: [speed2(T0 + HOUR, T0 + 10 * HOUR)],
+    });
+
+    // 1h at 1×, then 3h of work at 2× = 1.5h of wall clock.
+    expect(timings.packs[0].readyAt).toBe(T0 + 2.5 * HOUR);
+    expect(timings.fuelRemainingMs).toBe(7.5 * HOUR);
+  });
+
+  it("reproduces the legacy ×0.9 under a full-coverage Tortoise window", () => {
+    const speed = CROP_MACHINE_BOOST_SPEED["Tortoise Shrine"];
+    const timings = resolveCropMachine({
+      machine: machine([windowedPack(9 * HOUR)], 20 * HOUR),
+      windows: [{ from: T0, to: T0 + 20 * HOUR, speed }],
+    });
+
+    expect(timings.packs[0].readyAt).toBeCloseTo(T0 + 8.1 * HOUR, 5);
+  });
+
+  it("accrues nothing over a stall — a window covering the stalled interval is never intersected", () => {
+    const timings = resolveCropMachine({
+      machine: machine([windowedPack(4 * HOUR)], HOUR),
+      windows: [speed2(T0 + 2 * HOUR, T0 + 3 * HOUR)],
+    });
+
+    expect(timings.packs[0]).toEqual({
+      startsAt: T0,
+      growsUntil: T0 + HOUR,
+      workRemainingMs: 3 * HOUR,
+    });
+  });
+
+  it("accrues nothing past a lift (removedAt), without stamping growsUntil", () => {
+    const timings = resolveCropMachine({
+      machine: machine([windowedPack(4 * HOUR)], 10 * HOUR, {
+        removedAt: T0 + HOUR,
+      }),
+      windows: [],
+    });
+
+    expect(timings.packs[0].startsAt).toBe(T0);
+    expect(timings.packs[0].growsUntil).toBeUndefined();
+    expect(timings.packs[0].readyAt).toBeUndefined();
+    expect(timings.packs[0].workRemainingMs).toBe(3 * HOUR);
+    expect(timings.fuelRemainingMs).toBe(9 * HOUR);
+  });
+
+  it("passes a finalised pack through as immutable history", () => {
+    const done: CropMachineQueueItem = {
+      crop: "Sunflower",
+      seeds: 10,
+      growTimeRemaining: 0,
+      totalGrowTime: 2 * HOUR,
+      readyAt: T0 - HOUR,
+    };
+    const timings = resolveCropMachine({
+      machine: machine([done, windowedPack(2 * HOUR)], 5 * HOUR),
+      windows: [speed2(T0 - 2 * HOUR, T0 + 10 * HOUR)],
+    });
+
+    expect(timings.packs[0]).toEqual({
+      readyAt: T0 - HOUR,
+      workRemainingMs: 0,
+    });
+    // The windowed pack behind it still resolves from the anchor.
+    expect(timings.packs[1].startsAt).toBe(T0);
+    expect(timings.packs[1].readyAt).toBe(T0 + HOUR);
+  });
+});
+
+describe("getCropMachineFuelAt", () => {
+  it("drains 1:1 with wall clock only while growing", () => {
+    const m = machine([windowedPack(2 * HOUR), windowedPack(HOUR)], 10 * HOUR);
+
+    expect(getCropMachineFuelAt({ machine: m, windows: [], at: T0 })).toBe(
+      10 * HOUR,
+    );
+    expect(
+      getCropMachineFuelAt({ machine: m, windows: [], at: T0 + HOUR }),
+    ).toBe(9 * HOUR);
+    // Queue done after 3h; the tank stops draining once the machine idles.
+    expect(
+      getCropMachineFuelAt({ machine: m, windows: [], at: T0 + 5 * HOUR }),
+    ).toBe(7 * HOUR);
+  });
+
+  it("stops draining at a stall", () => {
+    const m = machine([windowedPack(4 * HOUR)], HOUR);
+
+    expect(
+      getCropMachineFuelAt({ machine: m, windows: [], at: T0 + 3 * HOUR }),
+    ).toBe(0);
+  });
+});
+
+describe("getCropMachinePackProgress", () => {
+  it("measures work done against totalGrowTime", () => {
+    const m = machine([windowedPack(4 * HOUR)], 10 * HOUR);
+
+    expect(
+      getCropMachinePackProgress({
+        machine: m,
+        index: 0,
+        windows: [],
+        at: T0 + HOUR,
+      }),
+    ).toBe(25);
+  });
+
+  it("fills faster under a window", () => {
+    const m = machine([windowedPack(4 * HOUR)], 10 * HOUR);
+    const windows = [speed2(T0, T0 + 10 * HOUR)];
+
+    expect(
+      getCropMachinePackProgress({
+        machine: m,
+        index: 0,
+        windows,
+        at: T0 + HOUR,
+      }),
+    ).toBe(50);
+  });
+
+  it("caps at the stall and counts pre-settlement banked work", () => {
+    // Half the work is already banked (totalGrowTime 4h, baseDurationMs 2h);
+    // fuel covers one more hour.
+    const m = machine(
+      [windowedPack(2 * HOUR, { totalGrowTime: 4 * HOUR })],
+      HOUR,
+    );
+
+    expect(
+      getCropMachinePackProgress({
+        machine: m,
+        index: 0,
+        windows: [],
+        at: T0 + 3 * HOUR,
+      }),
+    ).toBe(75);
+  });
+
+  it("reports a finalised pack as done", () => {
+    const m = machine(
+      [windowedPack(4 * HOUR, { baseDurationMs: undefined, readyAt: T0 - 1 })],
+      0,
+    );
+
+    expect(
+      getCropMachinePackProgress({ machine: m, index: 0, windows: [], at: T0 }),
+    ).toBe(100);
+  });
+});
+
+describe("getCropMachineSpeedAt", () => {
+  it("is the window product while growing and 1 while idle or stalled", () => {
+    const m = machine([windowedPack(2 * HOUR)], HOUR);
+    const windows = [speed2(T0 - HOUR, T0 + 10 * HOUR)];
+
+    expect(
+      getCropMachineSpeedAt({ machine: m, windows, at: T0 + 30 * 60 * 1000 }),
+    ).toBe(2);
+    // Stalled at T0 + 1h (fuel out): no growth, no speed.
+    expect(
+      getCropMachineSpeedAt({ machine: m, windows, at: T0 + 2 * HOUR }),
+    ).toBe(1);
+  });
+});
+
+describe("settleCropMachine", () => {
+  it("is behaviour-neutral: resolving a settled machine matches resolving the original", () => {
+    const windows = [speed2(T0 + HOUR, T0 + 2 * HOUR)];
+    const original = machine(
+      [windowedPack(3 * HOUR), windowedPack(2 * HOUR)],
+      10 * HOUR,
+    );
+    const reference = resolveCropMachine({ machine: original, windows });
+
+    const settled = machine(
+      [windowedPack(3 * HOUR), windowedPack(2 * HOUR)],
+      10 * HOUR,
+    );
+    settleCropMachine({ machine: settled, windows, now: T0 + 1.5 * HOUR });
+    const after = resolveCropMachine({ machine: settled, windows });
+
+    // Head: 1h at 1× + banked 30min at 2× = 2h of the 3h done by t1; the
+    // remaining 1h of work finishes at T0+2h under the window's tail.
+    expect(settled.oilSettledAt).toBe(T0 + 1.5 * HOUR);
+    expect(after.packs[0].readyAt).toBeCloseTo(reference.packs[0].readyAt!, 5);
+    expect(after.packs[1].readyAt).toBeCloseTo(reference.packs[1].readyAt!, 5);
+    expect(after.fuelRemainingMs).toBeCloseTo(reference.fuelRemainingMs, 5);
+  });
+
+  it("is behaviour-neutral across a stall", () => {
+    const original = machine([windowedPack(4 * HOUR)], HOUR);
+    const reference = resolveCropMachine({ machine: original, windows: [] });
+
+    const settled = machine([windowedPack(4 * HOUR)], HOUR);
+    // Settle well after the stall: only the fuelled hour may bank.
+    settleCropMachine({ machine: settled, windows: [], now: T0 + 3 * HOUR });
+    const after = resolveCropMachine({ machine: settled, windows: [] });
+
+    expect(settled.unallocatedOilTime).toBe(0);
+    expect(after.packs[0].workRemainingMs).toBe(
+      reference.packs[0].workRemainingMs,
+    );
+    // Post-settlement the anchor has moved past the stall; the pack simply
+    // waits (fuel 0) with the same work owed.
+    expect(after.packs[0].startsAt).toBeUndefined();
+  });
+
+  it("settling twice at the same instant changes nothing", () => {
+    const windows = [speed2(T0, T0 + 10 * HOUR)];
+    const m = machine(
+      [windowedPack(3 * HOUR), windowedPack(2 * HOUR)],
+      4 * HOUR,
+    );
+
+    settleCropMachine({ machine: m, windows, now: T0 + HOUR });
+    const once = JSON.parse(JSON.stringify(m));
+    settleCropMachine({ machine: m, windows, now: T0 + HOUR });
+
+    expect(JSON.parse(JSON.stringify(m))).toEqual(once);
+  });
+
+  it("finalises a completed pack into immutable history a later window cannot move", () => {
+    const m = machine([windowedPack(HOUR), windowedPack(2 * HOUR)], 10 * HOUR);
+
+    settleCropMachine({ machine: m, windows: [], now: T0 + 2 * HOUR });
+
+    const [head, tail] = m.queue!;
+    expect(head.readyAt).toBe(T0 + HOUR);
+    expect(head.baseDurationMs).toBeUndefined();
+    expect(head.growTimeRemaining).toBe(0);
+    expect(head.startTime).toBe(T0);
+    expect(tail.baseDurationMs).toBe(HOUR);
+
+    // A window over the whole past changes nothing for the finalised pack.
+    const timings = resolveCropMachine({
+      machine: m,
+      windows: [speed2(T0, T0 + 10 * HOUR)],
+    });
+    expect(timings.packs[0].readyAt).toBe(T0 + HOUR);
+  });
+
+  it("burns fuel through the settlement and advances the anchor", () => {
+    const m = machine([windowedPack(4 * HOUR)], 10 * HOUR);
+
+    settleCropMachine({ machine: m, windows: [], now: T0 + HOUR });
+
+    expect(m.unallocatedOilTime).toBe(9 * HOUR);
+    expect(m.oilSettledAt).toBe(T0 + HOUR);
+    expect(m.queue![0].baseDurationMs).toBe(3 * HOUR);
+    // Caches refreshed from the new anchor.
+    expect(m.queue![0].readyAt).toBe(T0 + 4 * HOUR);
+    expect(m.queue![0].growTimeRemaining).toBe(0);
+    expect(m.queue![0].startTime).toBe(T0);
+  });
+
+  it("resumes a stalled pack from the refuel settlement, the stall gap costing nothing", () => {
+    const m = machine([windowedPack(4 * HOUR)], HOUR);
+
+    // Tank ran dry at T0+1h; the player refuels at T0+2h (the oil event
+    // settles first, then adds fuel).
+    settleCropMachine({ machine: m, windows: [], now: T0 + 2 * HOUR });
+    m.unallocatedOilTime = (m.unallocatedOilTime ?? 0) + HOUR;
+
+    const timings = resolveCropMachine({ machine: m, windows: [] });
+    expect(m.queue![0].baseDurationMs).toBe(3 * HOUR);
+    expect(timings.packs[0].startsAt).toBe(T0 + 2 * HOUR);
+    expect(timings.packs[0].growsUntil).toBe(T0 + 3 * HOUR);
+    expect(timings.packs[0].workRemainingMs).toBe(2 * HOUR);
+  });
+
+  it("no-ops on a legacy machine", () => {
+    const legacy: CropMachineBuilding = {
+      coordinates: { x: 0, y: 0 },
+      createdAt: 0,
+      id: "1",
+      readyAt: 0,
+      queue: [
+        {
+          crop: "Sunflower",
+          seeds: 10,
+          growTimeRemaining: 0,
+          totalGrowTime: HOUR,
+          startTime: T0,
+          readyAt: T0 + HOUR,
+        },
+      ],
+      unallocatedOilTime: 2 * HOUR,
+    };
+    const before = JSON.parse(JSON.stringify(legacy));
+
+    settleCropMachine({
+      machine: legacy,
+      windows: [],
+      now: T0 + 30 * 60 * 1000,
+    });
+
+    expect(JSON.parse(JSON.stringify(legacy))).toEqual(before);
+  });
+});
+
+describe("convertCropMachineToWindowed", () => {
+  const legacyMachine = (
+    queue: CropMachineQueueItem[],
+    unallocatedOilTime = 0,
+  ): CropMachineBuilding => ({
+    coordinates: { x: 0, y: 0 },
+    createdAt: 0,
+    id: "1",
+    readyAt: 0,
+    queue,
+    unallocatedOilTime,
+  });
+
+  it("skips a ready pack, leaving it as legacy completed history", () => {
+    const m = legacyMachine([
+      {
+        crop: "Sunflower",
+        seeds: 10,
+        growTimeRemaining: 0,
+        totalGrowTime: HOUR,
+        startTime: T0 - 2 * HOUR,
+        readyAt: T0 - HOUR,
+      },
+    ]);
+
+    convertCropMachineToWindowed({ machine: m, windows: [], now: T0 });
+
+    expect(m.oilSettledAt).toBe(T0);
+    expect(m.queue![0].baseDurationMs).toBeUndefined();
+    expect(m.queue![0].readyAt).toBe(T0 - HOUR);
+  });
+
+  it("freezes a fully-allocated in-flight pack and reclaims its earmark (timing-neutral at 1×)", () => {
+    const m = legacyMachine(
+      [
+        {
+          crop: "Sunflower",
+          seeds: 10,
+          growTimeRemaining: 0,
+          totalGrowTime: 3 * HOUR,
+          startTime: T0 - HOUR,
+          readyAt: T0 + 2 * HOUR,
+        },
+      ],
+      HOUR,
+    );
+
+    convertCropMachineToWindowed({ machine: m, windows: [], now: T0 });
+
+    expect(m.queue![0].baseDurationMs).toBe(2 * HOUR);
+    expect(m.unallocatedOilTime).toBe(3 * HOUR);
+
+    const timings = resolveCropMachine({ machine: m, windows: [] });
+    expect(timings.packs[0].readyAt).toBe(T0 + 2 * HOUR);
+    expect(timings.fuelRemainingMs).toBe(HOUR);
+  });
+
+  it("freezes a scheduled future pack at its full remaining schedule, preserving the chain", () => {
+    const m = legacyMachine([
+      {
+        crop: "Sunflower",
+        seeds: 10,
+        growTimeRemaining: 0,
+        totalGrowTime: 2 * HOUR,
+        startTime: T0 - HOUR,
+        readyAt: T0 + HOUR,
+      },
+      {
+        crop: "Potato",
+        seeds: 10,
+        growTimeRemaining: 0,
+        totalGrowTime: 3 * HOUR,
+        startTime: T0 + HOUR,
+        readyAt: T0 + 4 * HOUR,
+      },
+    ]);
+
+    convertCropMachineToWindowed({ machine: m, windows: [], now: T0 });
+
+    expect(m.queue![0].baseDurationMs).toBe(HOUR);
+    expect(m.queue![1].baseDurationMs).toBe(3 * HOUR);
+    expect(m.unallocatedOilTime).toBe(4 * HOUR);
+
+    const timings = resolveCropMachine({ machine: m, windows: [] });
+    expect(timings.packs[0].readyAt).toBe(T0 + HOUR);
+    expect(timings.packs[1].readyAt).toBe(T0 + 4 * HOUR);
+    expect(timings.fuelRemainingMs).toBe(0);
+  });
+
+  it("freezes a partially-allocated pack, reclaiming only the funded remainder", () => {
+    const m = legacyMachine([
+      {
+        crop: "Sunflower",
+        seeds: 10,
+        growTimeRemaining: 2 * HOUR,
+        totalGrowTime: 4 * HOUR,
+        startTime: T0 - HOUR,
+        growsUntil: T0 + HOUR,
+      },
+    ]);
+
+    convertCropMachineToWindowed({ machine: m, windows: [], now: T0 });
+
+    expect(m.queue![0].baseDurationMs).toBe(3 * HOUR);
+    expect(m.unallocatedOilTime).toBe(HOUR);
+
+    const timings = resolveCropMachine({ machine: m, windows: [] });
+    expect(timings.packs[0].growsUntil).toBe(T0 + HOUR);
+    expect(timings.packs[0].workRemainingMs).toBe(2 * HOUR);
+  });
+
+  it("freezes a stalled pack with nothing to reclaim", () => {
+    const m = legacyMachine([
+      {
+        crop: "Sunflower",
+        seeds: 10,
+        growTimeRemaining: 2 * HOUR,
+        totalGrowTime: 4 * HOUR,
+        startTime: T0 - 3 * HOUR,
+        growsUntil: T0 - HOUR,
+      },
+    ]);
+
+    convertCropMachineToWindowed({ machine: m, windows: [], now: T0 });
+
+    expect(m.queue![0].baseDurationMs).toBe(2 * HOUR);
+    expect(m.queue![0].growsUntil).toBeUndefined();
+    expect(m.unallocatedOilTime).toBe(0);
+
+    const timings = resolveCropMachine({ machine: m, windows: [] });
+    expect(timings.packs[0].startsAt).toBeUndefined();
+    expect(timings.packs[0].workRemainingMs).toBe(2 * HOUR);
+  });
+
+  it("freezes an unstarted pack at its unfunded work", () => {
+    const m = legacyMachine([
+      {
+        crop: "Sunflower",
+        seeds: 10,
+        growTimeRemaining: 4 * HOUR,
+        totalGrowTime: 4 * HOUR,
+      },
+    ]);
+
+    convertCropMachineToWindowed({ machine: m, windows: [], now: T0 });
+
+    expect(m.queue![0].baseDurationMs).toBe(4 * HOUR);
+  });
+
+  it("is idempotent", () => {
+    const m = legacyMachine(
+      [
+        {
+          crop: "Sunflower",
+          seeds: 10,
+          growTimeRemaining: 0,
+          totalGrowTime: 3 * HOUR,
+          startTime: T0 - HOUR,
+          readyAt: T0 + 2 * HOUR,
+        },
+      ],
+      HOUR,
+    );
+
+    convertCropMachineToWindowed({ machine: m, windows: [], now: T0 });
+    const once = JSON.parse(JSON.stringify(m));
+    convertCropMachineToWindowed({ machine: m, windows: [], now: T0 + HOUR });
+
+    expect(JSON.parse(JSON.stringify(m))).toEqual(once);
+  });
+
+  it("does NOT instantly grow a part-grown pack under an active window (the migration bug)", () => {
+    const G = 5 * HOUR;
+    // 60% grown: 2h of the 5h remain.
+    const m = legacyMachine([
+      {
+        crop: "Sunflower",
+        seeds: 10,
+        growTimeRemaining: 0,
+        totalGrowTime: G,
+        startTime: T0 - 3 * HOUR,
+        readyAt: T0 + 2 * HOUR,
+      },
+    ]);
+    const speed = CROP_MACHINE_BOOST_SPEED["Tortoise Shrine"];
+    const windows = [{ from: T0 - 4 * HOUR, to: T0 + 4 * HOUR, speed }];
+
+    convertCropMachineToWindowed({ machine: m, windows, now: T0 });
+
+    const timings = resolveCropMachine({ machine: m, windows });
+    // Only the REMAINDER is windowed: 2h of work at 10/9 speed = 1.8h of wall
+    // clock — never `<= now`.
+    expect(timings.packs[0].readyAt).toBeCloseTo(T0 + 1.8 * HOUR, 5);
+    expect(timings.packs[0].readyAt!).toBeGreaterThan(T0);
+  });
+});

--- a/src/features/game/lib/cropMachineReadiness.test.ts
+++ b/src/features/game/lib/cropMachineReadiness.test.ts
@@ -420,6 +420,43 @@ describe("settleCropMachine", () => {
     expect(timings.packs[0].workRemainingMs).toBe(2 * HOUR);
   });
 
+  it("never moves the anchor backwards", () => {
+    // The BE settles on load at SERVER time, then replays each queued action at
+    // its CLIENT `createdAt`, which is up to MILLISECONDS_TO_SAVE older. Letting
+    // that rewind the anchor keeps the work banked by the load settlement while
+    // restarting the clock before it — free progress, compounding every save.
+    const m = machine([windowedPack(60_000)], 10 * HOUR);
+
+    settleCropMachine({ machine: m, windows: [], now: T0 + 20_000 });
+    expect(m.oilSettledAt).toBe(T0 + 20_000);
+    expect(m.queue?.[0].baseDurationMs).toBe(40_000);
+
+    settleCropMachine({ machine: m, windows: [], now: T0 + 10_000 });
+
+    expect(m.oilSettledAt).toBe(T0 + 20_000);
+    expect(m.queue?.[0].baseDurationMs).toBe(40_000);
+    expect(
+      resolveCropMachine({ machine: m, windows: [] }).packs[0].readyAt,
+    ).toBe(T0 + 60_000);
+  });
+
+  it("does not compound a rewind across repeated save cycles", () => {
+    const m = machine([windowedPack(60_000)], 10 * HOUR);
+
+    for (const [load, replay] of [
+      [20_000, 10_000],
+      [30_000, 20_000],
+      [40_000, 30_000],
+    ]) {
+      settleCropMachine({ machine: m, windows: [], now: T0 + load });
+      settleCropMachine({ machine: m, windows: [], now: T0 + replay });
+    }
+
+    expect(
+      resolveCropMachine({ machine: m, windows: [] }).packs[0].readyAt,
+    ).toBe(T0 + 60_000);
+  });
+
   it("no-ops on a legacy machine", () => {
     const legacy: CropMachineBuilding = {
       coordinates: { x: 0, y: 0 },
@@ -597,6 +634,42 @@ describe("convertCropMachineToWindowed", () => {
     convertCropMachineToWindowed({ machine: m, windows: [], now: T0 });
 
     expect(m.queue![0].baseDurationMs).toBe(4 * HOUR);
+  });
+
+  it("chains a queued pack off the one ahead, not a stale startTime", () => {
+    // Legacy `placeBuilding` shifts readyAt/growsUntil across the lift but
+    // leaves `startTime` untouched, so a re-placed machine carries starts that
+    // no longer match its schedule. Anchoring conversion on them counts the
+    // time a pack spends WAITING as both remaining work and reclaimed fuel.
+    //
+    // Two 1h packs, lifted at +30m and re-placed at +2h: legacy finishes are
+    // +2.5h and +3.5h, with 1.5h of oil still earmarked.
+    const now = T0 + 2 * HOUR;
+    const m = legacyMachine([
+      {
+        crop: "Sunflower",
+        seeds: 10,
+        growTimeRemaining: 0,
+        totalGrowTime: HOUR,
+        startTime: T0,
+        readyAt: T0 + 2.5 * HOUR,
+      },
+      {
+        crop: "Potato",
+        seeds: 10,
+        growTimeRemaining: 0,
+        totalGrowTime: HOUR,
+        startTime: T0 + HOUR,
+        readyAt: T0 + 3.5 * HOUR,
+      },
+    ]);
+
+    convertCropMachineToWindowed({ machine: m, windows: [], now });
+
+    const { packs } = resolveCropMachine({ machine: m, windows: [] });
+    expect(packs[0].readyAt).toBe(T0 + 2.5 * HOUR);
+    expect(packs[1].readyAt).toBe(T0 + 3.5 * HOUR);
+    expect(m.unallocatedOilTime).toBe(1.5 * HOUR);
   });
 
   it("is idempotent", () => {

--- a/src/features/game/lib/cropMachineReadiness.ts
+++ b/src/features/game/lib/cropMachineReadiness.ts
@@ -1,0 +1,449 @@
+import type {
+  CropMachineBuilding,
+  CropMachineQueueItem,
+} from "features/game/types/game";
+import {
+  computeReadyAt,
+  getEffectiveSpeedAt,
+  workAccruedAt,
+  type BoostWindow,
+} from "./boostWindows";
+
+/**
+ * A pack's resolved timing on a WINDOWED crop machine.
+ *
+ * - `readyAt` set: the pack completes (or completed) at that instant. For a
+ *   pack that has already been finalised (no `baseDurationMs`) this is its
+ *   stored, immutable history; otherwise it is derived.
+ * - `growsUntil` set: the tank runs dry mid-pack at that instant and the pack
+ *   stalls with `workRemainingMs` still owed. At most one pack in a queue
+ *   carries it — the one active when the fuel runs out.
+ * - Neither set with `startsAt` unset: the pack never starts (no fuel reaches
+ *   it, or the machine is lifted).
+ */
+export type CropMachinePackTiming = {
+  readyAt?: number;
+  startsAt?: number;
+  growsUntil?: number;
+  workRemainingMs: number;
+};
+
+export type CropMachineTimings = {
+  packs: CropMachinePackTiming[];
+  /** The instant the tank runs dry, if the queue outruns the fuel. */
+  fuelRunsOutAt?: number;
+  /** Fuel left once every pack that can complete has completed (ms). */
+  fuelRemainingMs: number;
+};
+
+type ResolvableMachine = Pick<
+  CropMachineBuilding,
+  "queue" | "unallocatedOilTime" | "oilSettledAt" | "removedAt"
+>;
+
+/**
+ * Resolve a windowed crop machine's pack timings AND fuel in one forward pass.
+ *
+ * The crop machine is the one activity where speed windows and fuel are
+ * entangled: packs grow SEQUENTIALLY, the tank drains 1:1 with the wall clock
+ * while a pack is actively growing, and a boost window changes how much WORK
+ * each wall-clock hour does. So a boosted pack finishes sooner AND burns less
+ * fuel — "boosts stretch fuel" — and the saved fuel flows to the next pack in
+ * the same pass. That entanglement is why fuel carries no per-pack earmarks on
+ * a windowed machine (a pack's fuel cost is derived, not reserved) and why
+ * ready times and the tank level must be resolved together rather than stamped
+ * at allocation time the way the legacy `updateCropMachine` does.
+ *
+ * Everything derives from three authoritative anchors — `oilSettledAt` (the
+ * simulation's start), each pack's `baseDurationMs` (work remaining at that
+ * instant) and `unallocatedOilTime` (the whole tank at that instant) — plus
+ * the windows. The stored `startTime`/`growsUntil`/`readyAt`/
+ * `growTimeRemaining` on a windowed pack are caches of this resolution and are
+ * never read back here: reconstructing a start from a cached `readyAt` mixes
+ * units (an unboosted duration off an already-boosted instant) and re-applies
+ * the windows on top of themselves — the exploit the cooking slice hit. The
+ * one exception is a FINALISED pack (no `baseDurationMs`): its `readyAt` is
+ * immutable completed history and passes straight through.
+ *
+ * The whole timeline is a projection independent of `now`; callers classify
+ * packs (ready / growing / stalled) by comparing against their own clock.
+ *
+ * A lifted machine (`removedAt` set) accrues nothing past the lift. Events
+ * settle AT the lift so in practice the simulation starts there; the clamp is
+ * defensive for un-settled state.
+ */
+export function resolveCropMachine({
+  machine,
+  windows,
+}: {
+  machine: ResolvableMachine;
+  windows: BoostWindow[];
+}): CropMachineTimings {
+  const queue = machine.queue ?? [];
+
+  let t = machine.oilSettledAt ?? 0;
+  let fuel = machine.unallocatedOilTime ?? 0;
+  const pauseAt = machine.removedAt;
+
+  let fuelRunsOutAt: number | undefined;
+
+  const packs: CropMachinePackTiming[] = queue.map((pack) => {
+    // Finalised (or pre-conversion legacy) pack: immutable completed history.
+    if (pack.baseDurationMs === undefined) {
+      return { readyAt: pack.readyAt, workRemainingMs: 0 };
+    }
+
+    const work = pack.baseDurationMs;
+
+    // Out of fuel, or the machine is lifted: the pack never starts. Later
+    // packs can't start either, but fall through here naturally.
+    if (fuel <= 0 || (pauseAt !== undefined && t >= pauseAt)) {
+      return { workRemainingMs: work };
+    }
+
+    const startsAt = t;
+    const finishAt = computeReadyAt({
+      startedAt: t,
+      baseDurationMs: work,
+      windows,
+    });
+    const fuelOutAt = t + fuel;
+    const runsUntil = Math.min(
+      finishAt,
+      fuelOutAt,
+      pauseAt ?? Number.POSITIVE_INFINITY,
+    );
+
+    // Fuel (and the machine's placement) covers the whole remainder — the
+    // pack completes. A tie with fuel-out still completes.
+    if (finishAt === runsUntil) {
+      fuel -= finishAt - t;
+      t = finishAt;
+      return { startsAt, readyAt: finishAt, workRemainingMs: 0 };
+    }
+
+    // The tank empties (or the machine was lifted) mid-pack: bank what accrued
+    // and stall. Only a genuine fuel-out gets a `growsUntil` stamp.
+    const done = workAccruedAt({ startedAt: t, at: runsUntil, windows });
+    fuel -= runsUntil - t;
+    const stalled = runsUntil === fuelOutAt;
+    if (stalled) fuelRunsOutAt = fuelOutAt;
+    t = runsUntil;
+    return {
+      startsAt,
+      ...(stalled ? { growsUntil: fuelOutAt } : {}),
+      workRemainingMs: Math.max(work - done, 0),
+    };
+  });
+
+  return { packs, fuelRunsOutAt, fuelRemainingMs: Math.max(fuel, 0) };
+}
+
+/**
+ * The tank level at `at`: the settled fuel minus the wall-clock time the
+ * machine spends actively growing in `[oilSettledAt, at]`.
+ */
+export function getCropMachineFuelAt({
+  machine,
+  windows,
+  at,
+}: {
+  machine: ResolvableMachine;
+  windows: BoostWindow[];
+  at: number;
+}): number {
+  const { packs } = resolveCropMachine({ machine, windows });
+
+  const burned = packs.reduce((total, pack) => {
+    if (pack.startsAt === undefined) return total;
+    const end = pack.readyAt ?? pack.growsUntil;
+    if (end === undefined) return total;
+    return total + Math.max(0, Math.min(end, at) - pack.startsAt);
+  }, 0);
+
+  return Math.max((machine.unallocatedOilTime ?? 0) - burned, 0);
+}
+
+/**
+ * A windowed pack's growth progress (0–100) at `at`, measured in WORK against
+ * `totalGrowTime`. Work done = what was banked into the anchors before the
+ * settlement (`totalGrowTime - baseDurationMs`) plus what has accrued since,
+ * fuel-gated by the resolved timeline. A finalised pack is simply done.
+ */
+export function getCropMachinePackProgress({
+  machine,
+  index,
+  windows,
+  at,
+}: {
+  machine: ResolvableMachine;
+  index: number;
+  windows: BoostWindow[];
+  at: number;
+}): number {
+  const pack: CropMachineQueueItem | undefined = machine.queue?.[index];
+  if (!pack || !pack.totalGrowTime) return 0;
+  if (pack.baseDurationMs === undefined) return 100;
+
+  const timing = resolveCropMachine({ machine, windows }).packs[index];
+
+  let accruedSinceSettle = 0;
+  if (timing.startsAt !== undefined) {
+    const end = Math.min(at, timing.readyAt ?? at, timing.growsUntil ?? at);
+    accruedSinceSettle = Math.min(
+      workAccruedAt({ startedAt: timing.startsAt, at: end, windows }),
+      pack.baseDurationMs,
+    );
+  }
+
+  const workDone =
+    pack.totalGrowTime - pack.baseDurationMs + accruedSinceSettle;
+  return Math.max(0, Math.min(100, (workDone / pack.totalGrowTime) * 100));
+}
+
+/**
+ * The machine's effective speed at `at`: the window product while a pack is
+ * actively growing, 1 otherwise (idle, stalled or lifted). Drives the UI's
+ * lightning indicator (countdowns show ACTUAL wall-clock time, so there is no
+ * accelerated tick to size).
+ */
+export function getCropMachineSpeedAt({
+  machine,
+  windows,
+  at,
+}: {
+  machine: ResolvableMachine;
+  windows: BoostWindow[];
+  at: number;
+}): number {
+  const { packs } = resolveCropMachine({ machine, windows });
+
+  const growing = packs.some((pack) => {
+    if (pack.startsAt === undefined || pack.startsAt > at) return false;
+    const end = pack.readyAt ?? pack.growsUntil;
+    return end === undefined || at < end;
+  });
+
+  return growing ? getEffectiveSpeedAt({ at, windows }) : 1;
+}
+
+/**
+ * Refresh the legacy cache fields on every still-windowed pack from a fresh
+ * resolution, so persistence/analytics/legacy readers keep seeing sensible
+ * values. `growTimeRemaining` keeps its legacy meaning of UNFUNDED work (zero
+ * while fuel covers the pack, the shortfall when it stalls), which is exactly
+ * `workRemainingMs`. No logic may read these back — see `resolveCropMachine`.
+ *
+ * Exported for events that change the queue's SHAPE after settling (pushing a
+ * new pack, filtering one out); pure timing changes are already refreshed by
+ * `settleCropMachine` itself.
+ */
+export function refreshCropMachineCaches({
+  machine,
+  windows,
+  now,
+}: {
+  machine: CropMachineBuilding;
+  windows: BoostWindow[];
+  now: number;
+}): void {
+  const { packs } = resolveCropMachine({ machine, windows });
+
+  (machine.queue ?? []).forEach((pack, index) => {
+    if (pack.baseDurationMs === undefined) return;
+
+    const timing = packs[index];
+    pack.growTimeRemaining = timing.workRemainingMs;
+
+    if (timing.readyAt !== undefined) pack.readyAt = timing.readyAt;
+    else delete pack.readyAt;
+
+    if (timing.growsUntil !== undefined) pack.growsUntil = timing.growsUntil;
+    else delete pack.growsUntil;
+
+    // A stamped PAST start is history and is kept; anything else (unset, or a
+    // projection that hasn't happened yet) tracks the derived value.
+    if (timing.startsAt !== undefined) {
+      if (pack.startTime === undefined || pack.startTime > now) {
+        pack.startTime = timing.startsAt;
+      }
+    } else if (pack.startTime !== undefined && pack.startTime > now) {
+      delete pack.startTime;
+    }
+
+    delete pack.pausedTimeRemaining;
+  });
+}
+
+/**
+ * Freeze the machine at `now`, in place — the ONLY mutator of a windowed
+ * machine's timing state, called by every crop-machine event with its
+ * `createdAt` (and by the lift/place handlers):
+ *
+ *   1. finalise every pack whose derived ready time has passed (its `readyAt`
+ *      becomes immutable history and its `baseDurationMs` marker is dropped);
+ *   2. bank each in-flight pack's accrued work into `baseDurationMs`;
+ *   3. burn the fuel the machine actually consumed and advance `oilSettledAt`;
+ *   4. refresh the legacy caches from a fresh resolution.
+ *
+ * Settlement is behaviour-neutral and idempotent: resolving a settled machine
+ * gives the same timeline as resolving the unsettled one, because banking
+ * converts elapsed window coverage to work with `workAccruedAt` (the same
+ * arithmetic the resolver uses) and no window's coverage of the PAST ever
+ * changes — live windows start at their placement's `createdAt`,
+ * `appendBoostHistory` records exactly the interval the live record already
+ * showed, and extensions only push a window's end outward. Settling on every
+ * event also defends the 7-day `boostHistory` prune: past credit is baked into
+ * the stored work before the window that earned it can be forgotten.
+ *
+ * No-op on a legacy machine (no `oilSettledAt`) — convert it first.
+ */
+export function settleCropMachine({
+  machine,
+  windows,
+  now,
+}: {
+  machine: CropMachineBuilding;
+  windows: BoostWindow[];
+  now: number;
+}): void {
+  if (machine.oilSettledAt === undefined) return;
+
+  const { packs } = resolveCropMachine({ machine, windows });
+  const queue = machine.queue ?? [];
+
+  // Fuel burned in [oilSettledAt, now]: the wall-clock the machine spent
+  // actively growing. Computed BEFORE the packs are mutated. A pack cut short
+  // by the lift clamp (`removedAt`) carries neither end stamp — it ran until
+  // the lift (which is `now` in the removeBuilding flow).
+  const pauseAt = machine.removedAt ?? Number.POSITIVE_INFINITY;
+  const burned = packs.reduce((total, pack) => {
+    if (pack.startsAt === undefined) return total;
+    const end = pack.readyAt ?? pack.growsUntil ?? pauseAt;
+    return total + Math.max(0, Math.min(end, now, pauseAt) - pack.startsAt);
+  }, 0);
+
+  queue.forEach((pack, index) => {
+    if (pack.baseDurationMs === undefined) return;
+
+    const timing = packs[index];
+
+    // Completed by now: finalise. The derived ready time becomes immutable
+    // history — a window placed later must never move it.
+    if (timing.readyAt !== undefined && timing.readyAt <= now) {
+      pack.readyAt = timing.readyAt;
+      // A stamped PAST start is history and wins; an unset or still-future
+      // (projected) one takes the derived value — same rule as refreshCropMachineCaches.
+      if (
+        timing.startsAt !== undefined &&
+        (pack.startTime === undefined || pack.startTime > now)
+      ) {
+        pack.startTime = timing.startsAt;
+      }
+      pack.growTimeRemaining = 0;
+      delete pack.growsUntil;
+      delete pack.baseDurationMs;
+      delete pack.pausedTimeRemaining;
+      return;
+    }
+
+    // Still in flight: bank what accrued before `now` (capped by a stall or
+    // the lift), and stamp the TRUE first start while this resolution still
+    // knows it — after the anchor advances, a later resolve only sees the
+    // anchor.
+    if (timing.startsAt !== undefined && timing.startsAt < now) {
+      if (pack.startTime === undefined || pack.startTime > now) {
+        pack.startTime = timing.startsAt;
+      }
+      const end = Math.min(now, timing.growsUntil ?? pauseAt, pauseAt);
+      const banked = Math.min(
+        workAccruedAt({ startedAt: timing.startsAt, at: end, windows }),
+        pack.baseDurationMs,
+      );
+      pack.baseDurationMs -= banked;
+    }
+  });
+
+  machine.unallocatedOilTime = Math.max(
+    (machine.unallocatedOilTime ?? 0) - burned,
+    0,
+  );
+  machine.oilSettledAt = now;
+
+  refreshCropMachineCaches({ machine, windows, now });
+}
+
+/**
+ * Convert a LEGACY machine to the windowed model, in place — one-shot and
+ * idempotent (keys off `oilSettledAt`). Freeze-and-forward at 1×: each
+ * non-ready pack's remaining schedule becomes `baseDurationMs` work, and the
+ * oil the legacy allocator had EARMARKED for its future growth is reclaimed
+ * into the tank (on a windowed machine fuel carries no earmarks). With no
+ * active windows the resolved 1× timeline reproduces the legacy
+ * `readyAt`/`growsUntil` schedule exactly — the reclamation is what makes that
+ * identity hold, and it is the guard against minting or burning oil.
+ *
+ * Runs on load for flagged players (BE `migrateSpeedBoosts`) and defensively
+ * at the top of every crop-machine event (a mid-session flag flip would
+ * otherwise hit an unconverted machine); events replay on the BE with the same
+ * `createdAt`, so both sides convert identically. Ready packs are skipped and
+ * kept as legacy completed history — they gain nothing from windowing and
+ * freezing them would move a past `readyAt` forward.
+ */
+export function convertCropMachineToWindowed({
+  machine,
+  windows,
+  now,
+}: {
+  machine: CropMachineBuilding;
+  /**
+   * The CURRENT crop-machine boost windows — used only to refresh the caches
+   * so they reflect the derived timeline (an active shrine speeds the frozen
+   * remainders from `now` onward). The conversion arithmetic itself is pure 1×
+   * legacy bookkeeping and never reads them.
+   */
+  windows: BoostWindow[];
+  now: number;
+}): void {
+  if (machine.oilSettledAt !== undefined) return;
+
+  const queue = machine.queue ?? [];
+  let reclaimed = 0;
+
+  for (const pack of queue) {
+    // Ready: completed legacy history, skip.
+    if (pack.readyAt !== undefined && pack.readyAt <= now) continue;
+
+    // A pack scheduled to start in the future anchors its remaining schedule
+    // at that start; one already growing anchors at `now`.
+    const from = Math.max(now, pack.startTime ?? now);
+
+    if (pack.readyAt !== undefined) {
+      // Fully allocated: the legacy allocator earmarked its whole remaining
+      // growth. Reclaim it; the resolver re-projects the same finish at 1×.
+      const remaining = pack.readyAt - from;
+      pack.baseDurationMs = remaining;
+      reclaimed += remaining;
+      delete pack.readyAt;
+    } else if (pack.growsUntil !== undefined && pack.growsUntil > now) {
+      // Partially allocated: earmarked up to `growsUntil`, with
+      // `growTimeRemaining` unfunded beyond it.
+      const earmark = pack.growsUntil - from;
+      pack.baseDurationMs = pack.growTimeRemaining + earmark;
+      reclaimed += earmark;
+      delete pack.growsUntil;
+    } else {
+      // Stalled (its allocation already burned away) or never started:
+      // nothing to reclaim, the unfunded work is the work.
+      pack.baseDurationMs = pack.growTimeRemaining;
+      delete pack.growsUntil;
+    }
+
+    delete pack.pausedTimeRemaining;
+  }
+
+  machine.unallocatedOilTime = (machine.unallocatedOilTime ?? 0) + reclaimed;
+  machine.oilSettledAt = now;
+
+  refreshCropMachineCaches({ machine, windows, now });
+}

--- a/src/features/game/lib/cropMachineReadiness.ts
+++ b/src/features/game/lib/cropMachineReadiness.ts
@@ -309,6 +309,17 @@ export function settleCropMachine({
 }): void {
   if (machine.oilSettledAt === undefined) return;
 
+  // The anchor is monotonic: everything before it is already banked, so moving
+  // it BACKWARDS would keep that banked work while restarting the clock ahead
+  // of it — free progress, compounding every time it happens.
+  //
+  // This is not hypothetical. The BE settles on load (`migrateSpeedBoosts`) at
+  // SERVER time and only then replays the batch's actions, each at its own
+  // CLIENT `createdAt`, which may be up to `MILLISECONDS_TO_SAVE` older. A
+  // full no-op is what keeps the boost credit: clamping `now` up to the anchor
+  // inside the banking arithmetic instead would re-bank the same interval.
+  if (now < machine.oilSettledAt) return;
+
   const { packs } = resolveCropMachine({ machine, windows });
   const queue = machine.queue ?? [];
 
@@ -410,31 +421,48 @@ export function convertCropMachineToWindowed({
   const queue = machine.queue ?? [];
   let reclaimed = 0;
 
+  // When the machine next frees up, in LEGACY schedule terms. Packs run
+  // sequentially, so a queued pack's remaining WORK is the gap between the
+  // finish of the pack ahead of it and its own — never the gap from `now`,
+  // which would count the time it spends waiting as work (and reclaim fuel
+  // for it twice over).
+  //
+  // Deliberately derived from the chain rather than read off `pack.startTime`:
+  // legacy `placeBuilding` shifts readyAt/growsUntil across a lift but leaves
+  // startTime untouched, so a re-placed machine's stamped starts no longer
+  // match its own schedule. For a machine that was never lifted the two agree,
+  // which is why this reproduces the old result exactly in the healthy case.
+  let cursor = now;
+
   for (const pack of queue) {
-    // Ready: completed legacy history, skip.
+    // Ready: completed legacy history, skip. A finished pack does not occupy
+    // the machine, so it must not advance the cursor either.
     if (pack.readyAt !== undefined && pack.readyAt <= now) continue;
 
-    // A pack scheduled to start in the future anchors its remaining schedule
-    // at that start; one already growing anchors at `now`.
-    const from = Math.max(now, pack.startTime ?? now);
+    const from = cursor;
 
     if (pack.readyAt !== undefined) {
       // Fully allocated: the legacy allocator earmarked its whole remaining
       // growth. Reclaim it; the resolver re-projects the same finish at 1×.
-      const remaining = pack.readyAt - from;
+      const remaining = Math.max(pack.readyAt - from, 0);
       pack.baseDurationMs = remaining;
       reclaimed += remaining;
+      cursor = pack.readyAt;
       delete pack.readyAt;
     } else if (pack.growsUntil !== undefined && pack.growsUntil > now) {
       // Partially allocated: earmarked up to `growsUntil`, with
       // `growTimeRemaining` unfunded beyond it.
-      const earmark = pack.growsUntil - from;
+      const earmark = Math.max(pack.growsUntil - from, 0);
       pack.baseDurationMs = pack.growTimeRemaining + earmark;
       reclaimed += earmark;
+      // It stalls there, so nothing queued behind it runs under the legacy
+      // allocation either.
+      cursor = pack.growsUntil;
       delete pack.growsUntil;
     } else {
       // Stalled (its allocation already burned away) or never started:
-      // nothing to reclaim, the unfunded work is the work.
+      // nothing to reclaim, the unfunded work is the work. The cursor stays
+      // put — legacy never funded this pack, so it blocks nothing.
       pack.baseDurationMs = pack.growTimeRemaining;
       delete pack.growsUntil;
     }

--- a/src/features/game/lib/timerDisplay.ts
+++ b/src/features/game/lib/timerDisplay.ts
@@ -67,7 +67,8 @@ export function getPreActionDisplay({
   at,
 }: {
   seconds: number;
-  baseSeconds: number;
+  /** Optional, mirroring `isPreActionBoosted`: no base time means not boosted. */
+  baseSeconds?: number;
   namedBoostCount: number;
   windows: BoostWindow[];
   at: number;

--- a/src/features/game/types/collectibleItemBuffs.ts
+++ b/src/features/game/types/collectibleItemBuffs.ts
@@ -2120,7 +2120,9 @@ export const COLLECTIBLE_BUFF_LABELS: Partial<
       boostedItemIcon: ITEM_DETAILS["Greenhouse"].image,
     },
     {
-      shortDescription: translate("description.tortoiseShrine.buff.2"),
+      shortDescription: hasFeatureAccess(game, "SPEED_BOOSTS")
+        ? translate("description.tortoiseShrine.buff.2.speed")
+        : translate("description.tortoiseShrine.buff.2"),
       labelType: "info",
       boostTypeIcon: SUNNYSIDE.icons.stopwatch,
       boostedItemIcon: ITEM_DETAILS["Crop Machine"].image,

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1085,11 +1085,32 @@ export type CropMachineQueueItem = {
   criticalHit?: CriticalHit;
   amount?: number;
   pausedTimeRemaining?: number;
+  /**
+   * Remaining WORK (permanent-boosted ms, temporary boosts excluded) as of the
+   * machine's `oilSettledAt`. Presence = this pack is windowed (SPEED_BOOSTS):
+   * its timing derives from `resolveCropMachine` and the stored
+   * `startTime`/`growsUntil`/`readyAt`/`growTimeRemaining` become refreshed
+   * caches. Deleted when the pack completes, at which point `readyAt` becomes
+   * immutable history. Permanent per-pack marker — read paths key off it, NOT
+   * the flag, so a windowed pack keeps windowed timing on a flag rollback.
+   */
+  baseDurationMs?: number;
 };
 
 export type CropMachineBuilding = PlacedItem & {
   queue?: CropMachineQueueItem[];
   unallocatedOilTime?: number;
+  /**
+   * Presence = this MACHINE is windowed (SPEED_BOOSTS). The tank is
+   * machine-wide, so the fuel ledger's discriminator is too: when set,
+   * `unallocatedOilTime` means the WHOLE tank — wall-clock ms of unburned fuel,
+   * with no per-pack earmarks — as of this instant, and every windowed pack's
+   * `baseDurationMs` is its remaining work as of this instant. Advanced by
+   * `settleCropMachine` on every crop-machine event. On a legacy machine
+   * (unset), `unallocatedOilTime` keeps its original meaning: oil-work not yet
+   * earmarked to a pack by `updateCropMachine`.
+   */
+  oilSettledAt?: number;
 };
 
 type CustomBuildings = {

--- a/src/features/island/buildings/components/building/cropMachine/CropMachine.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachine.tsx
@@ -25,6 +25,7 @@ import type { CropMachineBuilding } from "features/game/types/game";
 
 import type { AddSeedsInput } from "features/game/events/landExpansion/supplyCropMachine";
 import { SUNNYSIDE } from "assets/sunnyside";
+import { useCropMachineView } from "./lib/cropMachineView";
 
 const _cropMachine = (id: string) => (state: MachineState) => {
   const machines = state.context.state.buildings["Crop Machine"];
@@ -53,7 +54,10 @@ export const CropMachine: React.FC<Props> = ({ id }) => {
     gameService,
     _cropMachine(id),
   ) as CropMachineBuilding;
-  const queue = cropMachine?.queue ?? [];
+  // On a windowed machine (SPEED_BOOSTS) the stored pack timings are caches
+  // refreshed only on events; the view substitutes the DERIVED timings so a
+  // Tortoise Shrine placed or expiring mid-grow is reflected live.
+  const { queue, windowed, windows } = useCropMachineView(cropMachine);
 
   const now = useCropMachineLiveNow(queue);
 
@@ -246,6 +250,9 @@ export const CropMachine: React.FC<Props> = ({ id }) => {
         service={cropMachineService}
         queue={queue}
         unallocatedOilTime={cropMachine.unallocatedOilTime ?? 0}
+        machine={cropMachine}
+        windowed={windowed}
+        windows={windows}
         show={showModal}
         onClose={() => setShowModal(false)}
         onAddSeeds={handleAddSeeds}

--- a/src/features/island/buildings/components/building/cropMachine/CropMachine.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachine.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 
 import { CropMachineModal } from "./CropMachineModal";
 import { BuildingImageWrapper } from "../BuildingImageWrapper";
@@ -71,6 +71,26 @@ export const CropMachine: React.FC<Props> = ({ id }) => {
   const cropMachineService = useInterpret(cropStateMachine, {
     context: cropMachineContext,
   }) as unknown as MachineInterpreter;
+
+  // The interpreter takes `cropMachineContext` only at creation; every later
+  // change reaches it as an event. Crop-machine events send their own (see the
+  // handlers below), but a WINDOWED machine's queue can also change with no
+  // event at all — a Tortoise Shrine placed or expiring mid-grow re-derives
+  // every pack's timing. Without this the 1s TICK would keep re-deriving the
+  // sprite stage, `canHarvest` and running/paused from the stale queue while
+  // the modal already shows the new times. `queue` is identity-stable out of
+  // `useCropMachineView`'s `useMemo`, so this only fires on a real change.
+  const syncedQueue = useRef(queue);
+  useEffect(() => {
+    if (syncedQueue.current === queue) return;
+    syncedQueue.current = queue;
+
+    cropMachineService.send({
+      type: "SUPPLY_MACHINE",
+      updatedQueue: queue,
+      updatedUnallocatedOilTime: cropMachine.unallocatedOilTime ?? 0,
+    });
+  }, [queue, cropMachineService, cropMachine.unallocatedOilTime]);
 
   const growingCropPackStage = useSelector(
     cropMachineService,

--- a/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
@@ -4,9 +4,19 @@ import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { Modal } from "components/ui/Modal";
 import type {
   Bumpkin,
+  CropMachineBuilding,
   CropMachineQueueItem,
   Inventory,
 } from "features/game/types/game";
+import type { BoostWindow } from "features/game/lib/boostWindows";
+import { hasFeatureAccess } from "lib/flags";
+import { projectSeconds } from "features/game/lib/timerDisplay";
+import { calculateCropProgress } from "./lib/calculateCropProgress";
+import {
+  getCropMachineFuelAt,
+  getCropMachinePackProgress,
+  getCropMachineSpeedAt,
+} from "./lib/cropMachineView";
 import {
   type CropMachineState,
   type MachineInterpreter,
@@ -57,8 +67,13 @@ import { getPackYieldAmount } from "features/game/events/landExpansion/harvestCr
 
 interface Props {
   show: boolean;
+  /** The RESOLVED queue from `useCropMachineView` (derived timings substituted). */
   queue: CropMachineQueueItem[];
   unallocatedOilTime: number;
+  /** The stored building — the fuel/progress helpers derive from its anchors. */
+  machine: CropMachineBuilding;
+  windowed: boolean;
+  windows: BoostWindow[];
   growingCropPackIndex?: number;
   service: MachineInterpreter;
   onClose: () => void;
@@ -98,6 +113,9 @@ export const CropMachineModalContent: React.FC<Props> = ({
   queue,
   service,
   unallocatedOilTime,
+  machine,
+  windowed,
+  windows,
   onClose,
   onAddSeeds,
   onHarvestPack: onHarvestPack,
@@ -155,6 +173,15 @@ export const CropMachineModalContent: React.FC<Props> = ({
 
   const getProjectedOilTimeMillis = () => {
     const projectedOilTime = getOilTimeInMillis(totalOil, state);
+
+    // Windowed machine: the tank has no per-pack earmarks — its level derives
+    // from the settled anchors; getTotalOilMillisInMachine is legacy-only.
+    if (windowed) {
+      return (
+        getCropMachineFuelAt({ machine, windows, at: now }) + projectedOilTime
+      );
+    }
+
     const projectedTotalOilTime = getTotalOilMillisInMachine(
       queue,
       unallocatedOilTime + projectedOilTime,
@@ -257,6 +284,45 @@ export const CropMachineModalContent: React.FC<Props> = ({
   };
 
   const selectedPack = queue[selectedPackIndex];
+
+  // The next supplied pack will be windowed if the machine already is, or the
+  // moment a flagged player supplies it (the event converts the machine) — so
+  // the pre-action preview excludes the Tortoise from the baked duration and
+  // projects the actual time through its window instead.
+  const packWillBeWindowed =
+    windowed || hasFeatureAccess(state, "SPEED_BOOSTS");
+  const projectPackSeconds = (seconds: number) =>
+    packWillBeWindowed
+      ? projectSeconds({ seconds, windows, at: now })
+      : seconds;
+
+  // The machine's effective speed right now (1 unless a windowed pack is
+  // actively growing under a Tortoise window) — drives the ⚡ label.
+  const machineSpeed = windowed
+    ? getCropMachineSpeedAt({ machine, windows, at: now })
+    : 1;
+
+  // Fill-bar progress for the growing pack: WORK-based for a windowed pack
+  // (the bar fills faster while boosted), the legacy arithmetic otherwise.
+  const growingPackProgress =
+    selectedPackIndex === growingCropPackIndex && selectedPack
+      ? windowed
+        ? getCropMachinePackProgress({
+            machine,
+            index: selectedPackIndex,
+            windows,
+            at: now,
+          })
+        : calculateCropProgress({
+            startTime: selectedPack.startTime,
+            totalGrowTime: selectedPack.totalGrowTime,
+            readyAt: selectedPack.readyAt,
+            growsUntil: selectedPack.growsUntil,
+            growTimeRemaining: selectedPack.growTimeRemaining,
+            now,
+          })
+      : 0;
+
   const stackedQueue: (CropMachineQueueItem | null)[] = [
     ...queue,
     ...new Array(Math.max(0, MAX_QUEUE_SIZE(state) - queue.length)).fill(null),
@@ -327,7 +393,13 @@ export const CropMachineModalContent: React.FC<Props> = ({
                     startTime={selectedPack.startTime as number}
                     totalGrowTime={selectedPack.totalGrowTime}
                     growTimeRemaining={selectedPack.growTimeRemaining}
+                    now={now}
                   />
+                  {machineSpeed > 1 && (
+                    <Label type="vibrant" icon={lightning}>
+                      {t("cropMachine.boosted")}
+                    </Label>
+                  )}
                   {paused && (
                     <Label type="default">{t("cropMachine.paused")}</Label>
                   )}
@@ -340,14 +412,7 @@ export const CropMachineModalContent: React.FC<Props> = ({
                     {`${t("growing")} ${getTranslatedItemName(selectedPack.crop)}`}
                   </span>
                   {show && (
-                    <PackGrowthProgressBar
-                      paused={paused}
-                      growsUntil={selectedPack.growsUntil}
-                      startTime={selectedPack.startTime as number}
-                      totalGrowTime={selectedPack.totalGrowTime}
-                      readyAt={selectedPack.readyAt}
-                      growTimeRemaining={selectedPack.growTimeRemaining}
-                    />
+                    <PackGrowthProgressBar progress={growingPackProgress} />
                   )}
                 </div>
               </div>
@@ -462,14 +527,17 @@ export const CropMachineModalContent: React.FC<Props> = ({
                         <span>
                           {t("cropMachine.growTime", {
                             time: secondsToString(
-                              calculateCropTime(
-                                {
-                                  type: selectedSeed,
-                                  amount: totalSeeds,
-                                },
-                                state,
-                                now,
-                              ).milliSeconds / 1000,
+                              projectPackSeconds(
+                                calculateCropTime(
+                                  {
+                                    type: selectedSeed,
+                                    amount: totalSeeds,
+                                  },
+                                  state,
+                                  now,
+                                  { windowed: packWillBeWindowed },
+                                ).milliSeconds / 1000,
+                              ),
                               {
                                 length: "medium",
                                 isShortFormat: true,
@@ -543,14 +611,18 @@ export const CropMachineModalContent: React.FC<Props> = ({
                     <span>
                       {t("cropMachine.growTime", {
                         time: secondsToString(
-                          calculateCropTime(
-                            {
-                              type: `${selectedPack.crop} Seed`,
-                              amount: selectedPack.seeds,
-                            },
-                            state,
-                            now,
-                          ).milliSeconds / 1000,
+                          projectPackSeconds(
+                            (selectedPack.baseDurationMs ??
+                              calculateCropTime(
+                                {
+                                  type: `${selectedPack.crop} Seed`,
+                                  amount: selectedPack.seeds,
+                                },
+                                state,
+                                now,
+                                { windowed: packWillBeWindowed },
+                              ).milliSeconds) / 1000,
+                          ),
                           {
                             length: "medium",
                             isShortFormat: true,
@@ -603,6 +675,9 @@ export const CropMachineModalContent: React.FC<Props> = ({
               stopped={paused || idle}
               queue={queue}
               unallocatedOilTime={unallocatedOilTime}
+              machine={machine}
+              windowed={windowed}
+              windows={windows}
               onAddOil={() => {
                 // Reset Oil Before showing Overlay to Prevent accidental adding
                 setTotalOil(0);
@@ -731,6 +806,9 @@ export const CropMachineModal: React.FC<Props> = ({
   queue,
   service,
   unallocatedOilTime,
+  machine,
+  windowed,
+  windows,
   onClose,
   onAddSeeds,
   onHarvestPack: onHarvestPack,
@@ -742,6 +820,9 @@ export const CropMachineModal: React.FC<Props> = ({
       show={show}
       queue={queue}
       unallocatedOilTime={unallocatedOilTime}
+      machine={machine}
+      windowed={windowed}
+      windows={windows}
       service={service}
       onClose={onClose}
       onAddSeeds={onAddSeeds}

--- a/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
@@ -291,10 +291,41 @@ export const CropMachineModalContent: React.FC<Props> = ({
   // projects the actual time through its window instead.
   const packWillBeWindowed =
     windowed || hasFeatureAccess(state, "SPEED_BOOSTS");
-  const projectPackSeconds = (seconds: number) =>
-    packWillBeWindowed
-      ? projectSeconds({ seconds, windows, at: now })
-      : seconds;
+
+  // A pack ALREADY in the queue is windowed only if it carries the per-pack
+  // MARKER — never because the flag is on. A legacy pack on a not-yet-converted
+  // machine still has the Tortoise baked into its stored duration, so treating
+  // it as windowed would take the shrine back out of `calculateCropTime` and
+  // then project it through the live window, counting it twice.
+  const selectedPackWindowed = selectedPack?.baseDurationMs !== undefined;
+
+  // Windows are sampled from the instant the pack actually GROWS, not from
+  // `now`: packs run sequentially, so a queued pack starts only once those
+  // ahead of it finish. Anchoring at `now` would credit it a window that will
+  // have expired by then (or miss one that only opens later).
+  const projectPackSeconds = (
+    seconds: number,
+    { windowed: isWindowed, at }: { windowed: boolean; at: number },
+  ) => (isWindowed ? projectSeconds({ seconds, windows, at }) : seconds);
+
+  // On a resolved windowed pack that has not begun, `startTime` IS its derived
+  // start (see `getResolvedCropMachineQueue`). A pack the fuel cannot reach has
+  // none — its start depends on a refuel and is unknowable — so fall back to now.
+  const selectedPackStartsAt = selectedPack?.startTime ?? now;
+
+  // A newly supplied pack joins the BACK of the queue, so it starts when
+  // everything already queued has finished. Any pack without a derived finish
+  // is stalled, which leaves that instant unknowable: fall back to now.
+  const nextPackStartsAt = useMemo(() => {
+    if (!packWillBeWindowed) return now;
+
+    let startsAt = now;
+    for (const pack of queue) {
+      if (pack.readyAt === undefined) return now;
+      startsAt = Math.max(startsAt, pack.readyAt);
+    }
+    return startsAt;
+  }, [packWillBeWindowed, queue, now]);
 
   // The machine's effective speed right now (1 unless a windowed pack is
   // actively growing under a Tortoise window) — drives the ⚡ label.
@@ -537,6 +568,10 @@ export const CropMachineModalContent: React.FC<Props> = ({
                                   now,
                                   { windowed: packWillBeWindowed },
                                 ).milliSeconds / 1000,
+                                {
+                                  windowed: packWillBeWindowed,
+                                  at: nextPackStartsAt,
+                                },
                               ),
                               {
                                 length: "medium",
@@ -620,8 +655,12 @@ export const CropMachineModalContent: React.FC<Props> = ({
                                 },
                                 state,
                                 now,
-                                { windowed: packWillBeWindowed },
+                                { windowed: selectedPackWindowed },
                               ).milliSeconds) / 1000,
+                            {
+                              windowed: selectedPackWindowed,
+                              at: selectedPackStartsAt,
+                            },
                           ),
                           {
                             length: "medium",

--- a/src/features/island/buildings/components/building/cropMachine/components/OilTank.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/components/OilTank.tsx
@@ -2,7 +2,13 @@ import React from "react";
 import { Label } from "components/ui/Label";
 import { MAX_OIL_CAPACITY_IN_MILLIS } from "features/game/events/landExpansion/supplyCropMachine";
 import { getTotalOilMillisInMachine } from "features/game/events/landExpansion/supplyCropMachineOil";
-import type { CropMachineQueueItem, GameState } from "features/game/types/game";
+import type {
+  CropMachineBuilding,
+  CropMachineQueueItem,
+  GameState,
+} from "features/game/types/game";
+import type { BoostWindow } from "features/game/lib/boostWindows";
+import { getCropMachineFuelAt } from "../lib/cropMachineView";
 import { Button } from "components/ui/Button";
 import { secondsToString } from "lib/utils/time";
 import { ResizableBar } from "components/ui/ProgressBar";
@@ -16,6 +22,10 @@ interface OilTankProps {
   stopped: boolean;
   queue: CropMachineQueueItem[];
   unallocatedOilTime: number;
+  /** Windowed machine (SPEED_BOOSTS): the tank derives from the fuel ledger. */
+  machine: CropMachineBuilding;
+  windowed: boolean;
+  windows: BoostWindow[];
   onAddOil: () => void;
   state: GameState;
 }
@@ -24,6 +34,9 @@ export const OilTank: React.FC<OilTankProps> = ({
   stopped,
   queue,
   unallocatedOilTime,
+  machine,
+  windowed,
+  windows,
   onAddOil,
   state,
 }) => {
@@ -31,11 +44,12 @@ export const OilTank: React.FC<OilTankProps> = ({
 
   const now = useNow({ live: !stopped });
 
-  const totalOilMillis = getTotalOilMillisInMachine(
-    queue,
-    unallocatedOilTime,
-    now,
-  );
+  // A windowed machine's tank has no per-pack earmarks — its level derives
+  // from the settled fuel ledger (and drains 1:1 with wall clock only while a
+  // pack is actively growing); getTotalOilMillisInMachine is legacy-only.
+  const totalOilMillis = windowed
+    ? getCropMachineFuelAt({ machine, windows, at: now })
+    : getTotalOilMillisInMachine(queue, unallocatedOilTime, now);
   const oilInTank = Math.min(
     100,
     (totalOilMillis / MAX_OIL_CAPACITY_IN_MILLIS(state)) * 100,

--- a/src/features/island/buildings/components/building/cropMachine/components/PackGrowthProgressBar.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/components/PackGrowthProgressBar.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from "react";
-import { calculateCropProgress } from "../lib/calculateCropProgress";
+import React from "react";
 import { ResizableBar } from "components/ui/ProgressBar";
 
 export interface ProgressProps {
@@ -9,53 +8,25 @@ export interface ProgressProps {
   readyAt?: number;
   totalGrowTime: number;
   growTimeRemaining: number;
+  /** The modal's live clock (`useCropMachineLiveNow`) — no internal timer. */
+  now: number;
 }
 
 export const PackGrowthProgressBar = ({
-  startTime,
-  totalGrowTime,
-  growsUntil,
-  readyAt,
-  growTimeRemaining,
-  paused,
-}: ProgressProps) => {
-  // Calculate initial progress as default
-  const [progress, setProgress] = useState(
-    calculateCropProgress({
-      startTime,
-      totalGrowTime,
-      readyAt,
-      growsUntil,
-      growTimeRemaining,
-    }),
-  );
-
-  useEffect(() => {
-    if (progress < 100 && !paused) {
-      const interval = setInterval(() => {
-        setProgress(
-          calculateCropProgress({
-            startTime,
-            totalGrowTime,
-            readyAt,
-            growsUntil,
-            growTimeRemaining,
-          }),
-        );
-      }, 1000);
-      return () => clearInterval(interval);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [progress, paused, startTime, totalGrowTime]);
-
-  return (
-    <ResizableBar
-      percentage={progress}
-      type="progress"
-      outerDimensions={{
-        width: 70,
-        height: 8,
-      }}
-    />
-  );
-};
+  progress,
+}: {
+  /**
+   * 0–100, computed by the modal: work-based for a windowed pack
+   * (`getCropMachinePackProgress`), `calculateCropProgress` for a legacy one.
+   */
+  progress: number;
+}) => (
+  <ResizableBar
+    percentage={progress}
+    type="progress"
+    outerDimensions={{
+      width: 70,
+      height: 8,
+    }}
+  />
+);

--- a/src/features/island/buildings/components/building/cropMachine/components/TimeRemainingLabel.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/components/TimeRemainingLabel.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from "react";
-import { calculateCropProgress } from "../lib/calculateCropProgress";
+import React from "react";
 import type { ProgressProps } from "./PackGrowthProgressBar";
 import { secondsToString } from "lib/utils/time";
 import { Label } from "components/ui/Label";
@@ -7,43 +6,29 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 export const TimeRemainingLabel = ({
-  startTime,
-  paused,
   growsUntil,
-  totalGrowTime,
   readyAt,
   growTimeRemaining,
+  now,
 }: ProgressProps) => {
   const { t } = useAppTranslation();
 
+  // ACTUAL time remaining (per the actual-time convention): the wall-clock gap
+  // to the (derived, for windowed packs) readyAt while the pack will finish;
+  // for a stalled pack, the unfunded work plus whatever funded growth is still
+  // ahead of it. For a legacy pack this is arithmetically identical to the old
+  // progress-based derivation (work == wall clock at 1×).
   const getTimeRemaining = () => {
-    const progress = calculateCropProgress({
-      startTime,
-      totalGrowTime,
-      readyAt,
-      growsUntil,
-      growTimeRemaining,
-    });
-    const elapsedGrowTime = (totalGrowTime * progress) / 100;
-    const remainingGrowTime = totalGrowTime - elapsedGrowTime;
+    if (readyAt !== undefined) return Math.max(readyAt - now, 0) / 1000;
 
-    return remainingGrowTime / 1000;
+    if (growsUntil !== undefined) {
+      return (growTimeRemaining + Math.max(growsUntil - now, 0)) / 1000;
+    }
+
+    return growTimeRemaining / 1000;
   };
 
-  const [secondsRemaining, setSecondsRemaining] = useState(getTimeRemaining());
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      if (!paused) {
-        setSecondsRemaining(getTimeRemaining());
-      }
-    }, 1000);
-
-    return () => clearInterval(interval);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [paused, startTime, totalGrowTime]);
-
-  const seconds = Math.max(secondsRemaining, 0);
+  const seconds = Math.max(getTimeRemaining(), 0);
   const time = secondsToString(seconds, {
     length: "medium",
     isShortFormat: true,

--- a/src/features/island/buildings/components/building/cropMachine/lib/calculateCropProgress.ts
+++ b/src/features/island/buildings/components/building/cropMachine/lib/calculateCropProgress.ts
@@ -1,7 +1,8 @@
 type Args = {
   totalGrowTime: number;
   startTime?: number;
-  now?: number;
+  /** The caller's clock (a `useNow` value in components — never `Date.now()`). */
+  now: number;
   readyAt?: number;
   growsUntil?: number;
   growTimeRemaining: number;
@@ -12,7 +13,7 @@ export const calculateCropProgress = ({
   readyAt,
   growsUntil,
   startTime,
-  now = Date.now(),
+  now,
   growTimeRemaining,
 }: Args) => {
   if (startTime === undefined || startTime > now) return 0;

--- a/src/features/island/buildings/components/building/cropMachine/lib/cropMachine.ts
+++ b/src/features/island/buildings/components/building/cropMachine/lib/cropMachine.ts
@@ -51,11 +51,18 @@ function getGrowingCropPackStage(
   item: CropMachineQueueItem & { startTime: number },
   now: number,
 ): CropMachineGrowingStage {
-  const stageDuration = item.totalGrowTime / 3;
+  // A windowed pack (SPEED_BOOSTS) finishes at its DERIVED readyAt, which under
+  // a boost arrives sooner than startTime + totalGrowTime — so its stages are
+  // thirds of the real wall-clock interval, not of the base grow time (art
+  // only; readiness is decided by readyAt either way).
+  const stageDuration =
+    item.baseDurationMs !== undefined && item.readyAt !== undefined
+      ? (item.readyAt - item.startTime) / 3
+      : item.totalGrowTime / 3;
 
   const stage1Threshold = item.startTime + stageDuration;
   const stage2Threshold = stage1Threshold + stageDuration;
-  const harvestThreshold = item.startTime + item.totalGrowTime - 5000; // 5 seconds before the end
+  const harvestThreshold = item.startTime + stageDuration * 3 - 5000; // 5 seconds before the end
 
   if (now < stage1Threshold) return "planting";
   if (now < stage2Threshold) return "sprouting";

--- a/src/features/island/buildings/components/building/cropMachine/lib/cropMachineView.ts
+++ b/src/features/island/buildings/components/building/cropMachine/lib/cropMachineView.ts
@@ -1,0 +1,133 @@
+import { useContext, useMemo } from "react";
+import { useSelector } from "@xstate/react";
+import { Context } from "features/game/GameProvider";
+import type { MachineState } from "features/game/lib/gameMachine";
+import type {
+  CropMachineBuilding,
+  CropMachineQueueItem,
+} from "features/game/types/game";
+import {
+  areBoostWindowsEqual,
+  getCropMachineBoostWindows,
+  type BoostWindow,
+} from "features/game/lib/boostWindows";
+import {
+  getCropMachineFuelAt,
+  getCropMachinePackProgress,
+  getCropMachineSpeedAt,
+  resolveCropMachine,
+} from "features/game/lib/cropMachineReadiness";
+
+export type CropMachineView = {
+  /**
+   * The queue the UI should render. On a windowed machine every still-growing
+   * pack has its `startTime`/`readyAt`/`growsUntil`/`growTimeRemaining`
+   * substituted with the DERIVED values (the stored ones are caches refreshed
+   * only on events, so a Tortoise Shrine placed since would leave them stale);
+   * a legacy machine's queue passes through untouched. Identity-preserving:
+   * a pack whose derived values match its stored ones keeps its object.
+   */
+  queue: CropMachineQueueItem[];
+  /** Whether this machine is on the windowed model (`oilSettledAt` set). */
+  windowed: boolean;
+  windows: BoostWindow[];
+};
+
+/**
+ * Substitute a windowed machine's derived timings into its queue for display.
+ *
+ * The synthesized fields keep the LEGACY semantics every consumer already
+ * expects (the xstate stage machine, `isCropPackReady`, the modal's
+ * remove-button gate, `calculateCropProgress`):
+ *  - `startTime` — the pack's true first start where one was stamped, else the
+ *    derived (possibly projected) start; a stamped start is never later than
+ *    the derived one, so `min` picks it.
+ *  - `readyAt` / `growsUntil` — the derived finish / fuel-out instants. A pack
+ *    that has begun but has no fuel left at all gets `growsUntil` pinned to the
+ *    fuel anchor so it reads as PAUSED (mirrors a legacy stalled pack keeping
+ *    its past `growsUntil`) rather than never-started.
+ *  - `growTimeRemaining` — unfunded work, exactly the legacy meaning.
+ */
+export function getResolvedCropMachineQueue(
+  machine: CropMachineBuilding,
+  windows: BoostWindow[],
+): CropMachineQueueItem[] {
+  const queue = machine.queue ?? [];
+  if (machine.oilSettledAt === undefined) return queue;
+
+  const { packs } = resolveCropMachine({ machine, windows });
+
+  return queue.map((pack, index) => {
+    if (pack.baseDurationMs === undefined) return pack;
+
+    const timing = packs[index];
+
+    const startTime =
+      timing.startsAt !== undefined
+        ? pack.startTime !== undefined
+          ? Math.min(pack.startTime, timing.startsAt)
+          : timing.startsAt
+        : pack.startTime;
+
+    const hasBegun =
+      startTime !== undefined && startTime <= (machine.oilSettledAt ?? 0);
+    const growsUntil =
+      timing.growsUntil ??
+      (timing.readyAt === undefined && hasBegun
+        ? machine.oilSettledAt
+        : undefined);
+
+    const resolved: CropMachineQueueItem = {
+      ...pack,
+      startTime,
+      readyAt: timing.readyAt,
+      growsUntil,
+      growTimeRemaining: timing.workRemainingMs,
+    };
+    if (resolved.startTime === undefined) delete resolved.startTime;
+    if (resolved.readyAt === undefined) delete resolved.readyAt;
+    if (resolved.growsUntil === undefined) delete resolved.growsUntil;
+
+    const unchanged =
+      resolved.startTime === pack.startTime &&
+      resolved.readyAt === pack.readyAt &&
+      resolved.growsUntil === pack.growsUntil &&
+      resolved.growTimeRemaining === pack.growTimeRemaining;
+
+    return unchanged ? pack : resolved;
+  });
+}
+
+const _windows = (state: MachineState) =>
+  getCropMachineBoostWindows(state.context.state);
+
+/**
+ * The crop machine's display view: the resolved queue plus the boost windows
+ * that shaped it. Legacy machines pass through with empty windows.
+ */
+export function useCropMachineView(
+  machine: CropMachineBuilding | undefined,
+): CropMachineView {
+  const { gameService } = useContext(Context);
+  const windows = useSelector(gameService, _windows, areBoostWindowsEqual);
+
+  return useMemo(() => {
+    if (!machine || machine.oilSettledAt === undefined) {
+      // Legacy machine: stored queue as-is. The windows still come along —
+      // the modal's pre-action preview needs them for a flagged player whose
+      // machine converts on its next supply.
+      return { queue: machine?.queue ?? [], windowed: false, windows };
+    }
+    return {
+      queue: getResolvedCropMachineQueue(machine, windows),
+      windowed: true,
+      windows,
+    };
+  }, [machine, windows]);
+}
+
+export {
+  getCropMachineFuelAt,
+  getCropMachinePackProgress,
+  getCropMachineSpeedAt,
+};

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6849,6 +6849,7 @@
   "description.tortoiseShrine.buff": "x0.67 Greenhouse Growth Time",
   "description.tortoiseShrine.buff.speed": "1.5x Greenhouse Growth Speed",
   "description.tortoiseShrine.buff.2": "x0.9 Crop Machine Growth Time",
+  "description.tortoiseShrine.buff.2.speed": "1.11x Crop Machine Growth Speed",
   "description.mothShrine.buff": "x0.75 Flower Growth Time",
   "description.mothShrine.buff.speed": "1.35x Flower Growth Speed",
   "description.mothShrine.buff.2": "20% chance to get +1 Flower",


### PR DESCRIPTION
## Summary

FE half of the crop machine SPEED_BOOSTS slice — API counterpart: sunflower-land/sunflower-land-api#3579 (merges first, per convention). Game logic is byte-identical bar imports and the `boostUsed` shape.

Migrates the crop machine's **Tortoise Shrine ×0.9** (its only temporary boost — no totems or hourglasses apply) onto the live window model at the exact reciprocal **10/9** speed, so no balance change. In-flight packs respond to shrine placement/expiry, credited only for the overlap.

## Oil is fully derived — "boosts stretch fuel"

One rule governs speed and fuel: **the tank drains 1:1 with the wall clock while a pack is actively growing; windows change how much work each hour does** — so a boosted pack finishes sooner AND burns less fuel, retroactively, with the surplus flowing to the next pack. Full model description (fuel-ledger anchor `oilSettledAt`, whole-tank `unallocatedOilTime` with no earmarks, settle-on-every-event, earmark-reclaiming legacy conversion, windowed lift/place pause) in the API PR.

## UI

- New `useCropMachineView` hook substitutes the **derived** timings into the queue (identity-preserving), so the xstate stage machine, modal, pack boxes and ready overlays all react live to a shrine placed or expiring mid-grow — the stored timestamps are caches refreshed only on events.
- `PackGrowthProgressBar` and `TimeRemainingLabel` lose their raw `setInterval`/`Date.now()` plumbing and become presentational: the bar takes work-based progress (fills faster while boosted); the label shows **actual wall-clock remaining** per the actual-time convention (`readyAt − now` — arithmetically identical for legacy packs, whose work equals wall clock at 1×). `calculateCropProgress` now requires `now`.
- The oil tank and the modal's oil projections read the derived fuel level on windowed machines (`getTotalOilMillisInMachine` is legacy-only — its arithmetic assumes earmarks).
- Pre-action grow time excludes the Tortoise and projects the actual expected time through its window; a ⚡ label shows while the growing pack is boosted; the growing sprite's stage thirds follow the real wall interval for windowed packs (art only).
- Boost panel attribution via a new `cropMachine` set in `boostContributions` (parity-tested against `getCropMachineBoostWindows`), and the Tortoise crop-machine buff label gains a flag-gated **"1.11x Crop Machine Growth Speed"** variant (`dictionary.json` only).

## Intentional, please don't flag

- Read paths key off the **markers** (`oilSettledAt` / `baseDurationMs`), not the flag — a windowed machine keeps windowed timing on a flag rollback (pinned by a mainnet test).
- The Tortoise no longer enters `boostsUsed` under the flag — windowed convention; the boost panel lists it via `boostContributions` instead.
- `10/9` is deliberately not rounded (unlike the shrine's greenhouse half at 1.5×) so a full-coverage shrine reproduces the legacy time to the millisecond.
- `InProgressInfo`-style timers here deliberately show actual time, not an accelerated tick — countdowns are real wall-clock per the actual-time convention.

## Testing

- Step 0 (landed green before any behaviour change): the four crop-machine suites pinned to mainnet at file level (FE jest runs amoy = flag on), the previously-missing legacy Tortoise ×0.9 baseline added, and a vestigial Beta Pass removed from the remove-pack fixtures (the event's introduction-era flag gate is long gone, and it would have defeated the pin).
- 34 shared-leaf tests (settlement idempotence, retroactive fuel-stretch, conversion table + 1× timing-neutrality identity, no-instant-growth) mirrored from the API; windowed describes on all four events + lift/place; `boostContributions` parity.
- Full `src/features/game`: 4,901 passing; tsc and repo-wide eslint clean. No React component tests per house convention — UI verified by tsc/eslint/build and in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Crop Machines now support window-based Tortoise Shrine speed boosts.
  * Progress, readiness, fuel usage, and remaining time update dynamically as boost windows change.
  * Boosted machines support oil management, harvesting, removal, placement, and pack cancellation.
  * Crop Machine previews and status displays reflect active speed boosts.
  * Tortoise Shrine descriptions now show boosted Crop Machine growth speed.
* **Bug Fixes**
  * Improved preservation of progress, fuel, and completion times when moving or resuming Crop Machines.
  * Fixed fractional seed quantities when using the “All” supply option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->