### PR TITLE
[FEAT] Show box darker panel if they do not have requirements

### DIFF
--- a/src/components/ui/Box.tsx
+++ b/src/components/ui/Box.tsx
@@ -27,6 +27,12 @@ export interface BoxProps {
   onClick?: () => void;
   disabled?: boolean;
   locked?: boolean;
+  /**
+   * The player is missing something this item requires (coins, ingredients).
+   * Darkens the box background while keeping it clickable so the player can
+   * still open it and see what is missing.
+   */
+  missingRequirements?: boolean;
   canBeLongPressed?: boolean;
   /**
    * This can be used a different icon when there is no count passed in.
@@ -78,6 +84,7 @@ export const Box: React.FC<BoxProps> = ({
   onClick,
   disabled,
   locked,
+  missingRequirements = false,
   canBeLongPressed,
   cooldownInProgress,
   showOverlay = false,
@@ -123,8 +130,10 @@ export const Box: React.FC<BoxProps> = ({
       style={style}
     >
       <div
-        className={classNames("bg-brown-600 relative", {
-          "bg-brown-600 cursor-not-allowed opacity-75": disabled,
+        className={classNames("relative", {
+          "bg-brown-700": missingRequirements && !disabled,
+          "bg-brown-600": !missingRequirements || disabled,
+          "cursor-not-allowed opacity-75": disabled,
           "cursor-pointer": canClick,
         })}
         {...clickEvents}

--- a/src/features/island/buildings/components/building/Recipes.tsx
+++ b/src/features/island/buildings/components/building/Recipes.tsx
@@ -156,10 +156,13 @@ export const Recipes: React.FC<Props> = ({
     item: selected.name,
   });
 
-  const lessIngredients = () =>
-    Object.entries(ingredients).some(([name, amount]) =>
-      amount.greaterThan(inventory[name as InventoryItemName] ?? 0),
+  const hasLessIngredients = (item: CookableName) =>
+    Object.entries(getCookingRequirements({ state, item })).some(
+      ([name, amount]) =>
+        amount.greaterThan(inventory[name as InventoryItemName] ?? 0),
     );
+
+  const lessIngredients = () => hasLessIngredients(selected.name);
 
   const getNewRecipeStartAt = () => {
     if (!cooking) return;
@@ -429,6 +432,7 @@ export const Recipes: React.FC<Props> = ({
                     }}
                     image={ITEM_DETAILS[item.name].image}
                     count={inventory[item.name]}
+                    missingRequirements={hasLessIngredients(item.name)}
                   />
                 ))}
             </div>

--- a/src/features/island/buildings/components/building/market/SeasonalSeeds.tsx
+++ b/src/features/island/buildings/components/building/market/SeasonalSeeds.tsx
@@ -160,6 +160,9 @@ export const SeasonalSeeds: React.FC = () => {
     return coins < price * amount;
   };
 
+  const lessFundsForSeed = (seedName: SeedName) =>
+    coins < getBuyPrice(seedName, SEEDS[seedName], state).price;
+
   const stock = state.stock[selectedName] || new Decimal(0);
   const inventoryLimit = INVENTORY_LIMIT(state)[selectedName] ?? new Decimal(0);
   // Rounded down to a whole seed: seeds are discrete units, and comparing
@@ -550,6 +553,9 @@ export const SeasonalSeeds: React.FC = () => {
                   image={ITEM_DETAILS[SEEDS[name].yield ?? name].image}
                   showOverlay={isSeedLocked(name)}
                   count={inventory[name]}
+                  missingRequirements={
+                    !isSeedLocked(name) && lessFundsForSeed(name)
+                  }
                 />
               ))}
             </div>
@@ -593,6 +599,9 @@ export const SeasonalSeeds: React.FC = () => {
                     showOverlay={isSeedLocked(name)}
                     // secondaryImage={SUNNYSIDE.icons.seedling}
                     count={inventory[name]}
+                    missingRequirements={
+                      !isSeedLocked(name) && lessFundsForSeed(name)
+                    }
                   />
                 ))}
               </div>
@@ -617,6 +626,9 @@ export const SeasonalSeeds: React.FC = () => {
                     showOverlay={isSeedLocked(name)}
                     // secondaryImage={SUNNYSIDE.icons.seedling}
                     count={inventory[name]}
+                    missingRequirements={
+                      !isSeedLocked(name) && lessFundsForSeed(name)
+                    }
                   />
                 ))}
               </div>

--- a/src/features/island/buildings/components/building/workBench/components/Tools.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/Tools.tsx
@@ -85,6 +85,20 @@ export const Tools: React.FC = () => {
     return state.coins < price * amount;
   };
 
+  // Whether the player is short on coins or ingredients for a single craft.
+  const lacksRequirements = (toolName: WorkbenchToolName | LoveAnimalItem) => {
+    const tool = isLoveAnimalTool(toolName)
+      ? LOVE_ANIMAL_TOOLS[toolName]
+      : WORKBENCH_TOOLS[toolName];
+    const toolPrice = getToolPrice(tool, 1, state);
+    const lessCoins = !!toolPrice && state.coins < toolPrice;
+    const lessItems = getObjectEntries(
+      tool.ingredients(state.bumpkin.skills),
+    ).some(([name, amount]) => amount?.greaterThan(inventory[name] || 0));
+
+    return lessCoins || lessItems;
+  };
+
   const onToolClick = (toolName: WorkbenchToolName | LoveAnimalItem) => {
     setSelectedName(toolName);
     shortcutItem(toolName);
@@ -366,6 +380,7 @@ export const Tools: React.FC = () => {
                   count={inventory[toolName]}
                   secondaryImage={isLocked ? SUNNYSIDE.icons.lock : undefined}
                   showOverlay={isLocked}
+                  missingRequirements={!isLocked && lacksRequirements(toolName)}
                 />
               );
             })}
@@ -391,6 +406,7 @@ export const Tools: React.FC = () => {
                   count={inventory[toolName]}
                   secondaryImage={isLocked ? SUNNYSIDE.icons.lock : undefined}
                   showOverlay={isLocked}
+                  missingRequirements={!isLocked && lacksRequirements(toolName)}
                 />
               );
             })}
@@ -408,6 +424,7 @@ export const Tools: React.FC = () => {
                   image={ITEM_DETAILS[toolName].image}
                   onClick={() => onToolClick(toolName)}
                   count={inventory[toolName]}
+                  missingRequirements={lacksRequirements(toolName)}
                 />
               );
             })}


### PR DESCRIPTION
# Pull request description

To help with identifying which items you can craft/buy, boxes that do not have the requirements will be slightly darker.

Helps with cooking a lot!

<img width="123" height="68" alt="Screenshot 2026-09-03 at 10 57 51 am" src="https://github.com/user-attachments/assets/67327523-a4dd-4625-bc32-5502e9e0a10d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recipe cards now visibly indicate when ingredient requirements are missing.
  * Seed entries are flagged when the player lacks sufficient coins, except for level-locked seeds.
  * Crafting tools indicate when required coins or ingredients are unavailable.
  * Added visual styling for items with unmet requirements while keeping eligible items clickable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->