### PR TITLE
[FIX] Address CodeRabbit review on the Lover's Dilemma scene

### DIFF
--- a/src/features/world/scenes/LoveIslandScene.ts
+++ b/src/features/world/scenes/LoveIslandScene.ts
@@ -110,6 +110,9 @@ export class LoveIslandScene extends BaseScene {
   private labelledRoundId?: number;
   private selectedRoundId?: number;
   private revealedRoundId?: number;
+  /** Last HUD values rendered - the strings only change once a round. */
+  private renderedAttemptsLeft?: number;
+  private renderedStatus?: string;
   /** roundId -> platform, the local player's picks (local mode only). */
   private localChoices: Record<number, number> = {};
 
@@ -478,19 +481,30 @@ export class LoveIslandScene extends BaseScene {
       state: this.freshState,
       now,
     });
-    this.attemptsText?.setText(
-      translate("loveDilemma.attemptsLeft", { count: attemptsLeft }),
-    );
 
-    if (round.phase === "choose") {
-      this.statusText?.setText(
-        attemptsLeft > 0
-          ? translate("loveDilemma.choose")
-          : translate("loveDilemma.noAttemptsLeft"),
+    // Only touch the text (and the i18n lookups) when a value changes
+    if (attemptsLeft !== this.renderedAttemptsLeft) {
+      this.renderedAttemptsLeft = attemptsLeft;
+      this.attemptsText?.setText(
+        attemptsLeft === 1
+          ? translate("loveDilemma.oneAttemptLeft")
+          : translate("loveDilemma.attemptsLeft", { count: attemptsLeft }),
       );
-    } else {
-      this.statusText?.setText(translate("loveDilemma.reveal"));
+    }
 
+    const status =
+      round.phase === "reveal"
+        ? "loveDilemma.reveal"
+        : attemptsLeft > 0
+          ? "loveDilemma.choose"
+          : "loveDilemma.noAttemptsLeft";
+
+    if (status !== this.renderedStatus) {
+      this.renderedStatus = status;
+      this.statusText?.setText(translate(status));
+    }
+
+    if (round.phase === "reveal") {
       if (
         this.revealedRoundId !== round.roundId &&
         this.hasAuthoritativeChoices(round, now)
@@ -606,8 +620,10 @@ export class LoveIslandScene extends BaseScene {
       this.showPlatformResults(result.losingPlatforms);
     }
 
+    // Ignore a pick outside 0..platforms-1 - the room is the only source of
+    // `mine`, and an out-of-range value would otherwise read as a "win"
     const mine = choices[myKey];
-    if (mine === undefined) return;
+    if (mine === undefined || !PLATFORM_SPOTS[mine]) return;
 
     if (result.isVoid) {
       this.currentPlayer?.speak(

--- a/src/features/world/types/Room.ts
+++ b/src/features/world/types/Room.ts
@@ -142,7 +142,7 @@ export interface LoveDilemma extends Schema {
   chooseEndsAt: number;
   /** Epoch ms - end of the reveal phase (start of the next round). */
   revealEndsAt: number;
-  /** Tier (0 = best) shown on each platform, indexed by platform 0-3. */
+  /** Tier (0 = best) shown on each platform, indexed by platform 0-2 (length 3). */
   tiers: ArraySchema<number>;
   /** How many players have locked in a choice this round. */
   chosenCount: number;

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6288,6 +6288,7 @@
   "loveDilemma.notEnoughPlayers": "Not enough players. No attempt used.",
   "loveDilemma.lost": "Too crowded! No prize this round.",
   "loveDilemma.attemptsLeft": "{{count}} attempts left today",
+  "loveDilemma.oneAttemptLeft": "1 attempt left today",
   "description.bronzeFoodBox": "A bronze food box",
   "description.silverFoodBox": "A silver food box",
   "description.goldFoodBox": "A gold food box",


### PR DESCRIPTION
Follow-up to #7612, which was merged before its last review round was addressed. Carries over the fixes for the three inline CodeRabbit comments plus its nitpick:

- Guard the local player's pick against an out-of-range platform before indexing payouts, so a bad value from the room can't be scored as a win or dispatch an undefined amount.
- Add a singular `loveDilemma.oneAttemptLeft` string so the HUD never reads "1 attempts left today".
- Only re-render the HUD attempt/status strings when their values change instead of doing i18n lookups every frame.
- Correct the `tiers` comment in `Room.ts` to platforms 0-2 (length 3), matching the spec the MMO team implements against.

Type-check clean; world and prize-event suites pass (60 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)