### PR TITLE
[FIX] Clarify linked wallet mismatch for withdrawals

### DIFF
--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -530,7 +530,12 @@ export const Wallet: React.FC<PropsWithChildren<Props>> = ({
   }
 
   if (requiresLinkedWalletSelected && !hasLinkedWalletSelected) {
-    return <SelectLinkedWallet linkedWallet={linkedAddress as `0x${string}`} />;
+    return (
+      <SelectLinkedWallet
+        linkedWallet={linkedAddress as `0x${string}`}
+        isWithdrawal={action === "withdrawFlower" || action === "withdrawItems"}
+      />
+    );
   }
 
   if (requiresChain && !hasChain) {

--- a/src/features/wallet/components/SelectLinkedWallet.tsx
+++ b/src/features/wallet/components/SelectLinkedWallet.tsx
@@ -12,7 +12,8 @@ const SelectLinkedWalletHeader: React.FC<{
   address: `0x${string}`;
   linkedWallet: `0x${string}`;
   icon: string;
-}> = ({ address, linkedWallet, icon }) => {
+  isWithdrawal: boolean;
+}> = ({ address, linkedWallet, icon, isWithdrawal }) => {
   const { t } = useAppTranslation();
 
   return (
@@ -25,7 +26,13 @@ const SelectLinkedWalletHeader: React.FC<{
           {shortAddress(address)}
         </Label>
       </div>
-      <p className="text-xs p-2">{t("walletWall.requiresLinkedWallet")}</p>
+      <p className="text-xs p-2">
+        {t(
+          isWithdrawal
+            ? "walletWall.withdrawWalletMismatch"
+            : "walletWall.requiresLinkedWallet",
+        )}
+      </p>
       <div className="flex text-xs sm:text-xs space-x-1 p-2 pt-0">
         <span className="whitespace-nowrap">{`${t("deposit.connectedWallet")}`}</span>
         <CopyAddress address={address} />
@@ -42,7 +49,8 @@ const SelectLinkedWalletHeader: React.FC<{
 
 export const SelectLinkedWallet: React.FC<{
   linkedWallet: `0x${string}`;
-}> = ({ linkedWallet }) => {
+  isWithdrawal?: boolean;
+}> = ({ linkedWallet, isWithdrawal = false }) => {
   const { address, connector } = useConnection();
 
   return (
@@ -52,6 +60,7 @@ export const SelectLinkedWallet: React.FC<{
           linkedWallet={linkedWallet}
           address={address ?? "0x"}
           icon={getWalletIcon(connector)}
+          isWithdrawal={isWithdrawal}
         />
       }
       onSignMessage={null}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6446,6 +6446,7 @@
   "walletWall.connectLinkedWallet": "Connect your linked wallet",
   "walletWall.tryAnotherWallet": "Try another wallet",
   "walletWall.linkedWalletNotConnected": "Please connect your linked wallet to continue with this action.",
+  "walletWall.withdrawWalletMismatch": "You selected a different wallet. Your connected and linked wallets don't match, so you cannot withdraw.",
   "walletWall.pleaseAcceptConnection": "Please accept the connection request in your wallet.",
   "walletWall.pleaseCheckWallet": "Please check your wallet for a signature request.",
   "walletWall.signMessage": "Sign Message",


### PR DESCRIPTION
## Problem

Withdrawing requires the connected wallet to match the farm's linked wallet. When the addresses differ, the withdrawal flow is completely blocked, but the current modal does not explicitly identify the mismatch or say that withdrawal is unavailable.

Players can therefore keep reconnecting, refreshing, and retrying without understanding what prevents the withdrawal or how to resolve it. Because this blocking state has no clear explanation or self-service guidance, it can generate an uncontrolled number of repeated support requests for the same underlying issue.

## Root cause

The wallet guard correctly prevents a non-linked wallet from submitting the withdrawal, but it reuses generic copy that only asks the player to connect the linked wallet. It does not explain that:

- a different wallet is currently connected;
- the connected and linked wallet addresses do not match;
- the mismatch is the reason withdrawal cannot continue.

## Solution

<img width="590" height="198" alt="image" src="https://github.com/user-attachments/assets/21d80967-b155-404c-8eff-403b297ae0d2" />


For withdrawal actions, the modal now explicitly tells the player that they selected a different wallet, the connected and linked wallets do not match, and they cannot withdraw until the linked wallet is connected.

The modal continues to show both addresses so the player can identify which account to select. Non-withdrawal actions retain the existing generic message.

## Testing

- `node_modules/.bin/eslint src/features/wallet/Wallet.tsx src/features/wallet/components/SelectLinkedWallet.tsx`
- `node_modules/.bin/tsc --noEmit`
- `git diff --check`
- Parsed `src/lib/i18n/dictionaries/dictionary.json` as JSON

DevStand and browser-based visual verification were not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clearer message when users attempt to withdraw with connected and linked wallets that do not match.
  * Withdrawal flows now display guidance specific to wallet mismatches while preserving the standard linked-wallet message in other situations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->