### PR TITLE
[FEAT] Landscaping sandbox on every surface

### DIFF
--- a/src/features/game/actions/arrangementEffects.ts
+++ b/src/features/game/actions/arrangementEffects.ts
@@ -1,9 +1,9 @@
 import type { GameState } from "features/game/types/game";
 import type { PlaceableLocation } from "features/game/types/collectibles";
 import type { MachineInterpreter } from "features/game/lib/gameMachine";
-import { snapshotFarm } from "features/game/events/landExpansion/lib/layouts";
 import {
   applyArrangement,
+  snapshotSurface,
   ArrangementConflictError,
   type ArrangementConflict,
 } from "features/game/events/landExpansion/applyArrangement";
@@ -46,7 +46,7 @@ export async function saveArrangementEffect({
   state: GameState;
   location: PlaceableLocation;
 }): Promise<{ gameState: GameState }> {
-  const arrangement = snapshotFarm(state);
+  const arrangement = snapshotSurface(state, location);
 
   if (ART_MODE) {
     try {

--- a/src/features/game/events/landExpansion/applyArrangement.test.ts
+++ b/src/features/game/events/landExpansion/applyArrangement.test.ts
@@ -2,10 +2,13 @@ import Decimal from "decimal.js-light";
 import cloneDeep from "lodash.clonedeep";
 import { INITIAL_FARM, INITIAL_BUMPKIN } from "features/game/lib/constants";
 import type { GameState, InventoryItemName } from "features/game/types/game";
+import type { PlaceableLocation } from "features/game/types/collectibles";
 import { DEFAULT_HONEY_PRODUCTION_TIME } from "features/game/lib/updateBeehives";
 import { snapshotFarm } from "./lib/layouts";
+import { isOutOfBounds } from "features/game/expansion/placeable/lib/collisionDetection";
 import {
   applyArrangement,
+  snapshotSurface,
   ArrangementConflictError,
   type Arrangement,
   type ArrangementConflict,
@@ -63,7 +66,7 @@ const withInventory = (
 const apply = (
   state: GameState,
   arrangement: Arrangement,
-  location: "farm" | "home" = "farm",
+  location: PlaceableLocation = "farm",
 ) =>
   applyArrangement({
     state,
@@ -111,9 +114,14 @@ describe("applyArrangement", () => {
     expect(state).toEqual(before);
   });
 
-  it("throws for a non-farm location", () => {
-    expect(() => apply(baseFarm, snapshotFarm(baseFarm), "home")).toThrow(
-      /Unsupported arrangement location/,
+  it("throws for a surface that is not unlocked", () => {
+    const noUpstairs: GameState = {
+      ...baseFarm,
+      interior: { ground: { collectibles: {} } },
+    };
+
+    expect(() => apply(noUpstairs, { collectibles: {} }, "level_one")).toThrow(
+      /not unlocked/,
     );
   });
 
@@ -637,6 +645,230 @@ describe("applyArrangement", () => {
       expect(result.bumpkin.coordinates).toEqual({ x: 1, y: 1 });
       expect(result.bumpkin.flipped).toBe(true);
       expect(result.bumpkin.location).toBe("farm");
+    });
+  });
+
+  describe("indoor surfaces", () => {
+    /** Any 1x1 tile the given surface accepts, found by asking the bounds check. */
+    const validTile = (state: GameState, location: PlaceableLocation) => {
+      for (let x = -6; x <= 6; x++) {
+        for (let y = 6; y >= -6; y--) {
+          const position = { x, y, width: 1, height: 1 };
+          if (!isOutOfBounds({ state, position, location })) return { x, y };
+        }
+      }
+      throw new Error(`no valid tile for ${location}`);
+    };
+
+    const homeFarm: GameState = {
+      ...baseFarm,
+      inventory: { ...baseFarm.inventory, "Basic Bear": new Decimal(2) },
+      home: {
+        collectibles: {
+          "Basic Bear": [{ id: "h1", coordinates: { x: 0, y: 0 } }],
+        },
+      },
+    };
+
+    it("moves an item within the home without touching the farm", () => {
+      // Same item name placed on BOTH surfaces, at the same coordinates —
+      // indoor and outdoor coordinate spaces overlap numerically, so this is
+      // the case that catches a commit reading the wrong bucket.
+      const state: GameState = {
+        ...homeFarm,
+        collectibles: {
+          "Basic Bear": [{ id: "f1", coordinates: { x: 0, y: 0 } }],
+        },
+      };
+      const arrangement = snapshotSurface(state, "home");
+      arrangement.collectibles["Basic Bear"]![0].coordinates = { x: 1, y: 1 };
+
+      const result = apply(state, arrangement, "home");
+
+      expect(result.home.collectibles["Basic Bear"]![0].coordinates).toEqual({
+        x: 1,
+        y: 1,
+      });
+      expect(result.collectibles["Basic Bear"]![0].coordinates).toEqual({
+        x: 0,
+        y: 0,
+      });
+    });
+
+    it("reports an item pushed outside the home bounds", () => {
+      const arrangement = snapshotSurface(homeFarm, "home");
+      arrangement.collectibles["Basic Bear"]![0].coordinates = { x: 40, y: 40 };
+
+      const conflicts = conflictsOf(() => apply(homeFarm, arrangement, "home"));
+
+      expect(conflicts).toEqual([
+        {
+          code: "OFF_LAND",
+          name: "Basic Bear",
+          id: "h1",
+          coordinates: { x: 40, y: 40 },
+        },
+      ]);
+    });
+
+    it("removes an item from the home", () => {
+      const arrangement = snapshotSurface(homeFarm, "home");
+      arrangement.collectibles = {};
+
+      const result = apply(homeFarm, arrangement, "home");
+
+      expect(
+        result.home.collectibles["Basic Bear"]![0].coordinates,
+      ).toBeUndefined();
+    });
+
+    it("places a chest item into the home", () => {
+      const arrangement = snapshotSurface(homeFarm, "home");
+      arrangement.collectibles["Basic Bear"]!.push({
+        id: "h2",
+        coordinates: { x: 2, y: 2 },
+      });
+
+      const result = apply(homeFarm, arrangement, "home");
+
+      expect(result.home.collectibles["Basic Bear"]).toHaveLength(2);
+      expect(result.home.collectibles["Basic Bear"]![1].coordinates).toEqual({
+        x: 2,
+        y: 2,
+      });
+    });
+
+    it("moves the bumpkin within the home and keeps its location", () => {
+      const state: GameState = {
+        ...homeFarm,
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          coordinates: { x: 0, y: 1 },
+          location: "home",
+        },
+      };
+      const arrangement = snapshotSurface(state, "home");
+      arrangement.bumpkin = { x: 1, y: 2 };
+
+      const result = apply(state, arrangement, "home");
+
+      expect(result.bumpkin.coordinates).toEqual({ x: 1, y: 2 });
+      expect(result.bumpkin.location).toBe("home");
+    });
+
+    it("never carries an item between surfaces", () => {
+      // The farm instance is placed, so the home arrangement cannot claim it.
+      const state: GameState = {
+        ...homeFarm,
+        collectibles: {
+          "Basic Bear": [{ id: "f1", coordinates: { x: 3, y: 3 } }],
+        },
+      };
+      const arrangement = snapshotSurface(state, "home");
+      arrangement.collectibles["Basic Bear"]!.push({
+        id: "f1",
+        coordinates: { x: 2, y: 2 },
+      });
+
+      const conflicts = conflictsOf(() => apply(state, arrangement, "home"));
+
+      expect(conflicts).toEqual([
+        expect.objectContaining({ code: "PLACED_ELSEWHERE", id: "f1" }),
+      ]);
+    });
+
+    it("rejects farm-only buckets in an indoor arrangement", () => {
+      const arrangement = snapshotSurface(homeFarm, "home");
+      arrangement.buildings = {
+        "Fire Pit": [{ id: "fp", coordinates: { x: 0, y: 0 } }],
+      };
+
+      expect(() => apply(homeFarm, arrangement, "home")).toThrow(
+        /cannot contain buildings/,
+      );
+    });
+
+    it("rearranges the interior floor", () => {
+      const state: GameState = {
+        ...baseFarm,
+        inventory: { ...baseFarm.inventory, "Basic Bear": new Decimal(1) },
+        interior: {
+          ground: {
+            collectibles: {
+              "Basic Bear": [{ id: "i1", coordinates: { x: 0, y: 0 } }],
+            },
+          },
+        },
+      };
+      const from = validTile(state, "interior");
+      const placed: GameState = {
+        ...state,
+        interior: {
+          ground: {
+            collectibles: {
+              "Basic Bear": [{ id: "i1", coordinates: from }],
+            },
+          },
+        },
+      };
+      const arrangement = snapshotSurface(placed, "interior");
+      arrangement.collectibles["Basic Bear"]![0].coordinates = {
+        ...from,
+        x: from.x + 1,
+      };
+
+      const result = apply(placed, arrangement, "interior");
+
+      expect(
+        result.interior.ground.collectibles["Basic Bear"]![0].coordinates,
+      ).toEqual({ ...from, x: from.x + 1 });
+    });
+
+    it("rearranges the pet house and rejects entities it cannot hold", () => {
+      const state: GameState = {
+        ...baseFarm,
+        inventory: { ...baseFarm.inventory, Barkley: new Decimal(1) },
+        petHouse: {
+          level: 1,
+          pets: { Barkley: [{ id: "p1", coordinates: { x: 0, y: 0 } }] },
+        },
+      };
+      const arrangement = snapshotSurface(state, "petHouse");
+      arrangement.collectibles.Barkley![0].coordinates = { x: 1, y: 1 };
+
+      const result = apply(state, arrangement, "petHouse");
+      expect(result.petHouse.pets.Barkley![0].coordinates).toEqual({
+        x: 1,
+        y: 1,
+      });
+
+      const withBumpkin = snapshotSurface(state, "petHouse");
+      withBumpkin.bumpkin = { x: 0, y: 0 };
+      expect(() => apply(state, withBumpkin, "petHouse")).toThrow(
+        /cannot contain a bumpkin/,
+      );
+    });
+
+    it("leaves indoor surfaces out of the farm's post passes", () => {
+      // A stale hive on the farm must not be re-derived by a home commit.
+      const state: GameState = {
+        ...homeFarm,
+        beehives: {
+          h1: {
+            x: -2,
+            y: -2,
+            swarm: false,
+            honey: { updatedAt: 0, produced: 0 },
+            flowers: [],
+          },
+        },
+      };
+      const arrangement = snapshotSurface(state, "home");
+      arrangement.collectibles["Basic Bear"]![0].coordinates = { x: 1, y: 1 };
+
+      const result = apply(state, arrangement, "home");
+
+      expect(result.beehives.h1.honey.updatedAt).toBe(0);
     });
   });
 

--- a/src/features/game/events/landExpansion/applyArrangement.ts
+++ b/src/features/game/events/landExpansion/applyArrangement.ts
@@ -1,4 +1,5 @@
 import type {
+  Collectibles,
   GameState,
   LayoutCoordinates,
   PlacedItem,
@@ -17,7 +18,7 @@ import type { ResourceName } from "features/game/types/resources";
 import { PET_NFT_DIMENSIONS } from "features/game/types/pets";
 import {
   NON_COLLIDING_OBJECTS,
-  detectWaterCollision,
+  isOutOfBounds,
   isOverlapping,
   type Position,
 } from "features/game/expansion/placeable/lib/collisionDetection";
@@ -73,15 +74,10 @@ import { removeLavaPit } from "./removeLavaPit";
  */
 export type Arrangement = Pick<
   SavedLayout,
-  | "collectibles"
-  | "buildings"
-  | "resources"
-  | "buds"
-  | "petNFTs"
-  | "farmHands"
-  | "bumpkin"
-  | "land"
->;
+  "collectibles" | "buds" | "petNFTs" | "farmHands" | "bumpkin" | "land"
+> &
+  // Only the farm has buildings and resource nodes; indoor surfaces omit them.
+  Partial<Pick<SavedLayout, "buildings" | "resources">>;
 
 export type ApplyArrangementAction = {
   type: "arrangement.saved";
@@ -154,11 +150,189 @@ type Entry = {
   dimensions: Dimensions;
 };
 
+/** Where a Bumpkin or FarmHand may stand — everywhere but the pet house. */
+type PersonLocation = Exclude<PlaceableLocation, "petHouse">;
+
 const BUD_DIMENSIONS: Dimensions = { width: 1, height: 1 };
 const PERSON_DIMENSIONS: Dimensions = { width: 1, height: 1 };
 
-const isOnFarm = (placed: { location?: string; coordinates?: unknown }) =>
-  !!placed.coordinates && (!placed.location || placed.location === "farm");
+/**
+ * What each placeable surface holds. Every landscaping location commits through
+ * the same diff; they differ only in which buckets exist and where the
+ * collectibles live. Buildings and resource nodes are farm-only, and the pet
+ * house takes pets (as collectibles) and Pet NFTs but no Buds, FarmHands or
+ * Bumpkin.
+ */
+type Surface = {
+  /** This surface's collectible bucket, or undefined when it isn't built yet. */
+  getCollectibles: (state: GameState) => Collectibles | undefined;
+  hasBuildings: boolean;
+  hasResources: boolean;
+  buds: boolean;
+  petNFTs: boolean;
+  farmHands: boolean;
+  bumpkin: boolean;
+};
+
+const SURFACES: Record<PlaceableLocation, Surface> = {
+  farm: {
+    getCollectibles: (s) => s.collectibles,
+    hasBuildings: true,
+    hasResources: true,
+    buds: true,
+    petNFTs: true,
+    farmHands: true,
+    bumpkin: true,
+  },
+  home: {
+    getCollectibles: (s) => s.home.collectibles,
+    hasBuildings: false,
+    hasResources: false,
+    buds: true,
+    petNFTs: true,
+    farmHands: true,
+    bumpkin: true,
+  },
+  interior: {
+    getCollectibles: (s) => s.interior.ground.collectibles,
+    hasBuildings: false,
+    hasResources: false,
+    buds: true,
+    petNFTs: true,
+    farmHands: true,
+    bumpkin: true,
+  },
+  level_one: {
+    getCollectibles: (s) => s.interior.level_one?.collectibles,
+    hasBuildings: false,
+    hasResources: false,
+    buds: true,
+    petNFTs: true,
+    farmHands: true,
+    bumpkin: true,
+  },
+  petHouse: {
+    getCollectibles: (s) => s.petHouse?.pets as Collectibles | undefined,
+    hasBuildings: false,
+    hasResources: false,
+    buds: false,
+    petNFTs: true,
+    farmHands: false,
+    bumpkin: false,
+  },
+};
+
+/**
+ * Capture what is currently placed on `location`, in the shape the commit
+ * accepts. The client edits this locally and posts the result; a round trip
+ * through {@link applyArrangement} with an untouched snapshot is a no-op.
+ *
+ * The farm equivalent used by saved layouts is `snapshotFarm` in ./layouts —
+ * that one also records land extent for previews and is bound to the
+ * `SavedLayout` storage shape, so the two stay separate on purpose.
+ */
+export function snapshotSurface(
+  state: GameState,
+  location: PlaceableLocation,
+): Arrangement {
+  const surface = SURFACES[location];
+  const arrangement: Arrangement = { collectibles: {} };
+
+  getObjectEntries<Collectibles>(surface.getCollectibles(state) ?? {}).forEach(
+    ([name, group]) => {
+      const placed = (group ?? [])
+        .filter((item) => !!item.coordinates)
+        .map((item) => ({
+          id: item.id,
+          coordinates: { ...item.coordinates } as LayoutCoordinates,
+          ...(item.flipped !== undefined ? { flipped: item.flipped } : {}),
+        }));
+      if (placed.length > 0) arrangement.collectibles[name] = placed;
+    },
+  );
+
+  if (surface.hasBuildings) {
+    const buildings: NonNullable<Arrangement["buildings"]> = {};
+    getObjectEntries(state.buildings).forEach(([name, group]) => {
+      const placed = (group ?? [])
+        .filter((item) => !!item.coordinates)
+        .map((item) => ({
+          id: item.id,
+          coordinates: { ...item.coordinates } as LayoutCoordinates,
+          ...(item.flipped !== undefined ? { flipped: item.flipped } : {}),
+        }));
+      if (placed.length > 0) buildings[name] = placed;
+    });
+    arrangement.buildings = buildings;
+  }
+
+  if (surface.hasResources) {
+    const resources = {} as NonNullable<Arrangement["resources"]>;
+    RESOURCE_BUCKETS.forEach(({ key, get }) => {
+      resources[key] = {};
+      Object.entries(get(state)).forEach(([id, node]) => {
+        if (node.x === undefined || node.y === undefined) return;
+        const coordinates: LayoutCoordinates = { x: node.x, y: node.y };
+        if (node.oX !== undefined) coordinates.oX = node.oX;
+        if (node.oY !== undefined) coordinates.oY = node.oY;
+        resources[key][id] = coordinates;
+      });
+    });
+    arrangement.resources = resources;
+  }
+
+  if (surface.buds) {
+    const buds: NonNullable<Arrangement["buds"]> = {};
+    Object.entries(state.buds ?? {}).forEach(([id, bud]) => {
+      if (isOnSurface(bud, location)) {
+        buds[id] = { ...(bud.coordinates as LayoutCoordinates) };
+      }
+    });
+    arrangement.buds = buds;
+  }
+
+  if (surface.petNFTs) {
+    const petNFTs: NonNullable<Arrangement["petNFTs"]> = {};
+    Object.entries(state.pets?.nfts ?? {}).forEach(([id, pet]) => {
+      if (isOnSurface(pet, location)) {
+        petNFTs[id] = { ...(pet.coordinates as LayoutCoordinates) };
+      }
+    });
+    arrangement.petNFTs = petNFTs;
+  }
+
+  if (surface.farmHands) {
+    const farmHands: NonNullable<Arrangement["farmHands"]> = {};
+    Object.entries(state.farmHands?.bumpkins ?? {}).forEach(([id, hand]) => {
+      if (!isOnSurface(hand, location)) return;
+      farmHands[id] = {
+        ...(hand.coordinates as LayoutCoordinates),
+        ...(hand.flipped !== undefined ? { flipped: hand.flipped } : {}),
+      };
+    });
+    arrangement.farmHands = farmHands;
+  }
+
+  if (surface.bumpkin && isOnSurface(state.bumpkin, location)) {
+    arrangement.bumpkin = {
+      ...(state.bumpkin.coordinates as LayoutCoordinates),
+      ...(state.bumpkin.flipped !== undefined
+        ? { flipped: state.bumpkin.flipped }
+        : {}),
+    };
+  }
+
+  return arrangement;
+}
+
+/**
+ * True when a placeable sits on `location`. Legacy items carry no `location`
+ * and are farm-placed by convention.
+ */
+const isOnSurface = (
+  placed: { location?: string; coordinates?: unknown },
+  location: PlaceableLocation,
+) => !!placed.coordinates && (placed.location ?? "farm") === location;
 
 const boxOf = (entry: Entry): Position => ({
   x: entry.coordinates.x,
@@ -193,12 +367,17 @@ const withCoordinates = (c: LayoutCoordinates): PlacedItem["coordinates"] => ({
   ...(c.oY !== undefined ? { oY: c.oY } : {}),
 });
 
-/** Every placed item on the farm, keyed for diffing. */
-function indexLive(state: GameState): Map<string, Entry> {
+/** Every item placed on `location`, keyed for diffing. */
+function indexLive(
+  state: GameState,
+  location: PlaceableLocation,
+): Map<string, Entry> {
+  const surface = SURFACES[location];
   const entries = new Map<string, Entry>();
   const add = (entry: Entry) => entries.set(entry.key, entry);
 
-  getObjectEntries(state.collectibles).forEach(([name, group]) => {
+  const liveCollectibles: Collectibles = surface.getCollectibles(state) ?? {};
+  getObjectEntries(liveCollectibles).forEach(([name, group]) => {
     group?.forEach((item) => {
       if (!item.coordinates) return;
       add({
@@ -213,75 +392,82 @@ function indexLive(state: GameState): Map<string, Entry> {
     });
   });
 
-  getObjectEntries(state.buildings).forEach(([name, group]) => {
-    group?.forEach((item) => {
-      if (!item.coordinates) return;
-      add({
-        key: `building:${name}:${item.id}`,
-        category: "building",
-        name,
-        id: item.id,
-        coordinates: item.coordinates,
-        flipped: item.flipped,
-        dimensions: BUILDINGS_DIMENSIONS[name],
+  if (surface.hasBuildings)
+    getObjectEntries(state.buildings).forEach(([name, group]) => {
+      group?.forEach((item) => {
+        if (!item.coordinates) return;
+        add({
+          key: `building:${name}:${item.id}`,
+          category: "building",
+          name,
+          id: item.id,
+          coordinates: item.coordinates,
+          flipped: item.flipped,
+          dimensions: BUILDINGS_DIMENSIONS[name],
+        });
       });
     });
-  });
 
-  RESOURCE_BUCKETS.forEach(({ key, get, resourceName }) => {
-    Object.entries(get(state)).forEach(([id, node]) => {
-      if (node.x === undefined || node.y === undefined) return;
-      const name = (node as { name?: string }).name ?? resourceName;
+  if (surface.hasResources)
+    RESOURCE_BUCKETS.forEach(({ key, get, resourceName }) => {
+      Object.entries(get(state)).forEach(([id, node]) => {
+        if (node.x === undefined || node.y === undefined) return;
+        const name = (node as { name?: string }).name ?? resourceName;
+        add({
+          key: `resource:${key}:${id}`,
+          category: "resource",
+          name,
+          id,
+          bucket: key,
+          coordinates: { x: node.x, y: node.y },
+          dimensions: PLACEABLE_DIMENSIONS[resourceName],
+        });
+      });
+    });
+
+  if (surface.buds)
+    Object.entries(state.buds ?? {}).forEach(([id, bud]) => {
+      if (!isOnSurface(bud, location)) return;
       add({
-        key: `resource:${key}:${id}`,
-        category: "resource",
-        name,
+        key: `bud:${id}`,
+        category: "bud",
+        name: "Bud",
         id,
-        bucket: key,
-        coordinates: { x: node.x, y: node.y },
-        dimensions: PLACEABLE_DIMENSIONS[resourceName],
+        coordinates: bud.coordinates as LayoutCoordinates,
+        dimensions: BUD_DIMENSIONS,
       });
     });
-  });
 
-  Object.entries(state.buds ?? {}).forEach(([id, bud]) => {
-    if (!isOnFarm(bud)) return;
-    add({
-      key: `bud:${id}`,
-      category: "bud",
-      name: "Bud",
-      id,
-      coordinates: bud.coordinates as LayoutCoordinates,
-      dimensions: BUD_DIMENSIONS,
+  if (surface.petNFTs)
+    Object.entries(state.pets?.nfts ?? {}).forEach(([id, pet]) => {
+      if (!isOnSurface(pet, location)) return;
+      add({
+        key: `pet:${id}`,
+        category: "pet",
+        name: "Pet",
+        id,
+        coordinates: pet.coordinates as LayoutCoordinates,
+        dimensions: PET_NFT_DIMENSIONS,
+      });
     });
-  });
 
-  Object.entries(state.pets?.nfts ?? {}).forEach(([id, pet]) => {
-    if (!isOnFarm(pet)) return;
-    add({
-      key: `pet:${id}`,
-      category: "pet",
-      name: "Pet",
-      id,
-      coordinates: pet.coordinates as LayoutCoordinates,
-      dimensions: PET_NFT_DIMENSIONS,
-    });
-  });
+  if (surface.farmHands)
+    Object.entries(state.farmHands?.bumpkins ?? {}).forEach(
+      ([id, farmHand]) => {
+        if (!isOnSurface(farmHand, location)) return;
+        add({
+          key: `farmHand:${id}`,
+          category: "farmHand",
+          name: "FarmHand",
+          id,
+          coordinates: farmHand.coordinates as LayoutCoordinates,
+          flipped: farmHand.flipped,
+          dimensions: PERSON_DIMENSIONS,
+        });
+      },
+    );
 
-  Object.entries(state.farmHands?.bumpkins ?? {}).forEach(([id, farmHand]) => {
-    if (!isOnFarm(farmHand)) return;
-    add({
-      key: `farmHand:${id}`,
-      category: "farmHand",
-      name: "FarmHand",
-      id,
-      coordinates: farmHand.coordinates as LayoutCoordinates,
-      flipped: farmHand.flipped,
-      dimensions: PERSON_DIMENSIONS,
-    });
-  });
-
-  if (isOnFarm(state.bumpkin)) {
+  if (surface.bumpkin && isOnSurface(state.bumpkin, location)) {
     add({
       key: "bumpkin",
       category: "bumpkin",
@@ -303,11 +489,34 @@ function indexLive(state: GameState): Map<string, Entry> {
  */
 function indexDesired(
   state: GameState,
+  location: PlaceableLocation,
   arrangement: Arrangement,
   conflicts: ArrangementConflict[],
 ): Map<string, Entry> {
+  const surface = SURFACES[location];
   const entries = new Map<string, Entry>();
   const add = (entry: Entry) => entries.set(entry.key, entry);
+
+  // A bucket the surface cannot hold is a malformed payload, not something the
+  // player can fix by moving an item - fail loudly rather than silently
+  // dropping half of what was sent.
+  const reject = (bucket: string) => {
+    throw new Error(`Arrangement for ${location} cannot contain ${bucket}`);
+  };
+  if (!surface.hasBuildings && Object.keys(arrangement.buildings ?? {}).length)
+    reject("buildings");
+  if (
+    !surface.hasResources &&
+    Object.values(arrangement.resources ?? {}).some(
+      (bucket) => Object.keys(bucket ?? {}).length,
+    )
+  )
+    reject("resources");
+  if (!surface.buds && Object.keys(arrangement.buds ?? {}).length)
+    reject("buds");
+  if (!surface.farmHands && Object.keys(arrangement.farmHands ?? {}).length)
+    reject("farm hands");
+  if (!surface.bumpkin && arrangement.bumpkin) reject("a bumpkin");
 
   Object.entries(arrangement.collectibles ?? {}).forEach(([name, items]) => {
     items?.forEach((item) => {
@@ -355,22 +564,23 @@ function indexDesired(
     });
   });
 
-  RESOURCE_BUCKETS.forEach(({ key, get, resourceName }) => {
-    Object.entries(arrangement.resources?.[key] ?? {}).forEach(
-      ([id, coordinates]) => {
-        const existing = get(state)[id] as { name?: string } | undefined;
-        add({
-          key: `resource:${key}:${id}`,
-          category: "resource",
-          name: existing?.name ?? resourceName,
-          id,
-          bucket: key,
-          coordinates,
-          dimensions: PLACEABLE_DIMENSIONS[resourceName],
-        });
-      },
-    );
-  });
+  if (surface.hasResources)
+    RESOURCE_BUCKETS.forEach(({ key, get, resourceName }) => {
+      Object.entries(arrangement.resources?.[key] ?? {}).forEach(
+        ([id, coordinates]) => {
+          const existing = get(state)[id] as { name?: string } | undefined;
+          add({
+            key: `resource:${key}:${id}`,
+            category: "resource",
+            name: existing?.name ?? resourceName,
+            id,
+            bucket: key,
+            coordinates,
+            dimensions: PLACEABLE_DIMENSIONS[resourceName],
+          });
+        },
+      );
+    });
 
   Object.entries(arrangement.buds ?? {}).forEach(([id, coordinates]) => {
     add({
@@ -770,13 +980,20 @@ export function applyArrangement({
   farmId = 0,
   createdAt,
 }: Options): GameState {
-  if (action.location !== "farm") {
-    throw new Error(`Unsupported arrangement location: ${action.location}`);
+  const { location } = action;
+  const surface = SURFACES[location];
+  if (!surface) {
+    throw new Error(`Unsupported arrangement location: ${location}`);
+  }
+  // A surface that hasn't been built has nothing to rearrange, and its bounds
+  // check would reject every position anyway.
+  if (!surface.getCollectibles(state)) {
+    throw new Error(`Arrangement location is not unlocked: ${location}`);
   }
 
   const conflicts: ArrangementConflict[] = [];
-  const live = indexLive(state);
-  const desired = indexDesired(state, action.arrangement, conflicts);
+  const live = indexLive(state, location);
+  const desired = indexDesired(state, location, action.arrangement, conflicts);
 
   let working = cloneDeep(state);
   let beesChanged = false;
@@ -799,7 +1016,7 @@ export function applyArrangement({
     }
 
     try {
-      working = thaw(removeEntry(working, entry, createdAt));
+      working = thaw(removeEntry(working, entry, location, createdAt));
       touchesBees(entry);
     } catch (e) {
       conflicts.push(
@@ -820,7 +1037,7 @@ export function applyArrangement({
     ) {
       return;
     }
-    moveEntry(working, entry);
+    moveEntry(working, entry, location);
     touchesBees(entry);
   });
 
@@ -831,16 +1048,16 @@ export function applyArrangement({
   // a footprint; the sandbox already blocks those spots client-side, so the FE
   // copy (ART_MODE + parity) skips that pass.
 
-  const placed = [...indexLive(working).values()];
+  const placed = [...indexLive(working, location).values()];
   placements.forEach((entry) => {
-    const elsewhere = placedElsewhere(working, entry);
+    const elsewhere = placedElsewhere(working, entry, location);
     if (elsewhere) {
       conflicts.push(conflictOf(entry, "PLACED_ELSEWHERE"));
       return;
     }
 
     const box = boxOf(entry);
-    if (detectWaterCollision(expansionsOf(working), box)) {
+    if (isOutOfBounds({ state: working, position: box, location })) {
       conflicts.push(conflictOf(entry, "OFF_LAND"));
       return;
     }
@@ -859,7 +1076,7 @@ export function applyArrangement({
     }
 
     try {
-      working = placeEntry(working, entry, farmId, createdAt);
+      working = placeEntry(working, entry, location, farmId, createdAt);
       placed.push(entry);
       touchesBees(entry);
     } catch (e) {
@@ -878,10 +1095,9 @@ export function applyArrangement({
   });
 
   // --- Validate the final state as a whole. --------------------------------
-  const final = [...indexLive(working).values()];
-  const expansions = expansionsOf(working);
+  const final = [...indexLive(working, location).values()];
   final.forEach((entry) => {
-    if (detectWaterCollision(expansions, boxOf(entry))) {
+    if (isOutOfBounds({ state: working, position: boxOf(entry), location })) {
       // Already reported for placements above.
       if (!placements.some((p) => p.key === entry.key)) {
         conflicts.push(conflictOf(entry, "OFF_LAND"));
@@ -926,13 +1142,17 @@ export function applyArrangement({
   }
 
   // --- Post passes, once. ---------------------------------------------------
-  if (beesChanged) {
-    working = {
-      ...working,
-      beehives: updateBeehives({ game: working, createdAt }),
-    };
+  // All of these are farm concerns: beehive pollination and scarecrow AOE read
+  // farm geometry, and mushrooms/airdrops/clutter only ever spawn outdoors.
+  if (location === "farm") {
+    if (beesChanged) {
+      working = {
+        ...working,
+        beehives: updateBeehives({ game: working, createdAt }),
+      };
+    }
+    refreshBasicScarecrowTimeAOE(working);
   }
-  refreshBasicScarecrowTimeAOE(working);
 
   return working;
 }
@@ -950,6 +1170,7 @@ const thaw = (state: GameState): GameState => cloneDeep(state);
 function removeEntry(
   state: GameState,
   entry: Entry,
+  location: PlaceableLocation,
   createdAt: number,
 ): GameState {
   switch (entry.category) {
@@ -960,7 +1181,7 @@ function removeEntry(
           type: "collectible.removed",
           name: entry.name as CollectibleName,
           id: entry.id,
-          location: "farm",
+          location,
         },
         createdAt,
       });
@@ -988,26 +1209,30 @@ function removeEntry(
           type: "nft.removed",
           id: entry.id,
           nft: (entry.category === "bud" ? "Bud" : "Pet") as NFTName,
-          location: "farm",
+          location,
         },
         createdAt,
       });
     case "farmHand":
       return removeFarmHand({
         state,
-        action: { type: "farmHand.removed", id: entry.id, location: "farm" },
+        action: { type: "farmHand.removed", id: entry.id, location },
       });
     case "bumpkin":
       return removeBumpkinPlacement({
         state,
-        action: { type: "bumpkin.removedPlacement", location: "farm" },
+        action: { type: "bumpkin.removedPlacement", location },
         createdAt,
       });
   }
 }
 
 /** Plain coordinate/flip write on an instance that stays placed. */
-function moveEntry(state: GameState, entry: Entry): void {
+function moveEntry(
+  state: GameState,
+  entry: Entry,
+  location: PlaceableLocation,
+): void {
   const setFlip = (item: { flipped?: boolean }) => {
     if (entry.flipped === undefined) delete item.flipped;
     else item.flipped = entry.flipped;
@@ -1016,7 +1241,9 @@ function moveEntry(state: GameState, entry: Entry): void {
   switch (entry.category) {
     case "collectible": {
       const item = (
-        state.collectibles[entry.name as CollectibleName] ?? []
+        SURFACES[location].getCollectibles(state)?.[
+          entry.name as CollectibleName
+        ] ?? []
       ).find((c) => c.id === entry.id) as PlacedItem;
       item.coordinates = withCoordinates(entry.coordinates);
       setFlip(item);
@@ -1041,25 +1268,27 @@ function moveEntry(state: GameState, entry: Entry): void {
     case "bud": {
       const bud = state.buds![Number(entry.id)];
       bud.coordinates = point(entry.coordinates);
-      bud.location = "farm";
+      bud.location = location;
       return;
     }
     case "pet": {
       const pet = state.pets!.nfts![Number(entry.id)];
       pet.coordinates = point(entry.coordinates);
-      pet.location = "farm";
+      pet.location = location;
       return;
     }
     case "farmHand": {
       const farmHand = state.farmHands.bumpkins[entry.id];
       farmHand.coordinates = point(entry.coordinates);
-      farmHand.location = "farm";
+      // SURFACES marks the pet house as holding no farm hands, so this branch
+      // is only reachable for the locations their type allows.
+      farmHand.location = location as PersonLocation;
       setFlip(farmHand);
       return;
     }
     case "bumpkin": {
       state.bumpkin.coordinates = point(entry.coordinates);
-      state.bumpkin.location = "farm";
+      state.bumpkin.location = location as PersonLocation;
       setFlip(state.bumpkin);
       return;
     }
@@ -1067,39 +1296,46 @@ function moveEntry(state: GameState, entry: Entry): void {
 }
 
 /** True when the desired instance is currently placed on another surface. */
-function placedElsewhere(state: GameState, entry: Entry): boolean {
+/**
+ * True when the desired instance is currently placed on a *different* surface.
+ * The commit only ever rearranges the surface being saved, so an item standing
+ * in the player's home is never silently teleported onto the farm — the player
+ * has to lift it there first.
+ */
+function placedElsewhere(
+  state: GameState,
+  entry: Entry,
+  location: PlaceableLocation,
+): boolean {
+  const otherSurfaces = getObjectEntries(SURFACES).filter(
+    ([name]) => name !== location,
+  );
+
   switch (entry.category) {
-    case "collectible": {
-      const name = entry.name as CollectibleName;
-      const surfaces: (PlacedItem[] | undefined)[] = [
-        state.home.collectibles[name],
-        state.interior?.ground.collectibles[name],
-        state.interior?.level_one?.collectibles[name],
-        (state.petHouse?.pets as Record<string, PlacedItem[] | undefined>)?.[
-          name
-        ],
-      ];
-      return surfaces.some((items) =>
-        items?.some((item) => item.id === entry.id && !!item.coordinates),
+    case "collectible":
+      return otherSurfaces.some(([, surface]) =>
+        surface
+          .getCollectibles(state)
+          ?.[
+            entry.name as CollectibleName
+          ]?.some((item) => item.id === entry.id && !!item.coordinates),
       );
-    }
     case "bud": {
       const bud = state.buds?.[Number(entry.id)];
-      return !!bud?.coordinates && !!bud.location && bud.location !== "farm";
+      return !!bud?.coordinates && (bud.location ?? "farm") !== location;
     }
     case "pet": {
       const pet = state.pets?.nfts?.[Number(entry.id)];
-      return !!pet?.coordinates && !!pet.location && pet.location !== "farm";
+      return !!pet?.coordinates && (pet.location ?? "farm") !== location;
     }
     case "farmHand": {
-      const fh = state.farmHands?.bumpkins?.[entry.id];
-      return !!fh?.coordinates && !!fh.location && fh.location !== "farm";
+      const hand = state.farmHands?.bumpkins?.[entry.id];
+      return !!hand?.coordinates && (hand.location ?? "farm") !== location;
     }
     case "bumpkin":
       return (
         !!state.bumpkin.coordinates &&
-        !!state.bumpkin.location &&
-        state.bumpkin.location !== "farm"
+        (state.bumpkin.location ?? "farm") !== location
       );
     default:
       return false;
@@ -1109,6 +1345,7 @@ function placedElsewhere(state: GameState, entry: Entry): boolean {
 function placeEntry(
   state: GameState,
   entry: Entry,
+  location: PlaceableLocation,
   farmId: number,
   createdAt: number,
 ): GameState {
@@ -1125,22 +1362,21 @@ function placeEntry(
             name,
             id: entry.id,
             coordinates,
-            location: "farm",
+            location,
           },
           createdAt,
         });
-      const knownUnplaced = state.collectibles[name]?.some(
-        (item) => item.id === entry.id && !item.coordinates,
-      );
+      const knownUnplaced = SURFACES[location]
+        .getCollectibles(state)
+        ?.[name]?.some((item) => item.id === entry.id && !item.coordinates);
       const next = knownUnplaced
         ? withIsolatedCollectible(state, name, entry.id, run)
         : thaw(run(state));
-      const item = next.collectibles[name]!.find(
-        (c) =>
-          !!c.coordinates &&
-          c.coordinates.x === coordinates.x &&
-          c.coordinates.y === coordinates.y,
-      )!;
+      const item = SURFACES[location]
+        .getCollectibles(next)!
+        [
+          name
+        ]!.find((c) => !!c.coordinates && c.coordinates.x === coordinates.x && c.coordinates.y === coordinates.y)!;
       // The reducer may have reused another unplaced instance; the arrangement
       // is the contract, so the placed instance takes the requested id.
       item.id = entry.id;
@@ -1217,7 +1453,7 @@ function placeEntry(
             id: entry.id,
             nft,
             coordinates,
-            location: "farm",
+            location,
           },
           createdAt,
         }),
@@ -1231,7 +1467,7 @@ function placeEntry(
             type: "farmHand.placed",
             id: entry.id,
             coordinates,
-            location: "farm",
+            location,
           },
           createdAt,
         }),
@@ -1245,7 +1481,7 @@ function placeEntry(
       const next = thaw(
         placeBumpkin({
           state,
-          action: { type: "bumpkin.placed", coordinates, location: "farm" },
+          action: { type: "bumpkin.placed", coordinates, location },
           createdAt,
         }),
       );

--- a/src/features/game/expansion/placeable/landscapingMachine.ts
+++ b/src/features/game/expansion/placeable/landscapingMachine.ts
@@ -484,10 +484,7 @@ export const landscapingMachine = createMachine<
                         } as PlacementEvent;
                       }
                       const id = uuidv4().slice(0, 8);
-                      if (
-                        location === "farm" &&
-                        LIVE_LANDSCAPING_EVENTS.has(action as string)
-                      ) {
+                      if (LIVE_LANDSCAPING_EVENTS.has(action as string)) {
                         return {
                           type: action,
                           name: placeable?.name,
@@ -509,8 +506,7 @@ export const landscapingMachine = createMachine<
                   // the chest when this runs.
                   choose([
                     {
-                      cond: ({ placeable, action }, { location }) =>
-                        location === "farm" &&
+                      cond: ({ placeable, action }) =>
                         !!placeable?.name &&
                         LIVE_LANDSCAPING_EVENTS.has(action as string),
                       actions: sendParent(

--- a/src/features/game/expansion/placeable/lib/collisionDetection.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.ts
@@ -479,6 +479,71 @@ export const FURNITURE_OBJECTS: InventoryItemName[] = [
   "Stool",
 ];
 
+/**
+ * Translate a farm-space footprint into the bottom-left layout coordinates the
+ * interior tile masks use. GenesisBlock sits at canvas-centre and `Placeable`
+ * anchors (0, 0) there, so the conversion is +canvas/2 on both axes. Must match
+ * the API translation.
+ */
+const toInteriorLayout = (position: BoundingBox): BoundingBox => ({
+  ...position,
+  x: position.x + INTERIOR_CANVAS.width / 2,
+  y: position.y + INTERIOR_CANVAS.height / 2,
+});
+
+const isOutsideRect = (position: BoundingBox, bounds: BoundingBox) =>
+  position.x < bounds.x ||
+  position.x + position.width > bounds.x + bounds.width ||
+  position.y > bounds.y + bounds.height ||
+  position.y - position.height < bounds.y;
+
+/**
+ * Is this footprint outside the placeable area of `location`? The *bounds* half
+ * of {@link detectCollision}, split out so callers that run their own overlap
+ * pass reuse exactly the same geometry.
+ *
+ * The landscaping commit (`applyArrangement`) is the reason this exists: it
+ * validates a whole desired arrangement at once, so it must ask "is this in
+ * bounds" without also asking "does it hit something", which would flag two
+ * items swapping places.
+ */
+export function isOutOfBounds({
+  state,
+  position,
+  location,
+}: {
+  state: GameState;
+  position: BoundingBox;
+  location: PlaceableLocation;
+}): boolean {
+  switch (location) {
+    case "home":
+      return isOutsideRect(position, HOME_BOUNDS[state.island.type]);
+    case "petHouse":
+      return isOutsideRect(
+        position,
+        PET_HOUSE_BOUNDS[state.petHouse?.level ?? 1],
+      );
+    case "interior":
+      return !isValidInteriorBase(
+        state.island.type,
+        toInteriorLayout(position),
+      );
+    case "level_one": {
+      const { level_one: levelOne, expansion } = state.interior;
+      // An unbuilt floor has no placeable area at all.
+      if (!levelOne || !expansion) return true;
+      return !isValidHomeExpansionBase(expansion, toInteriorLayout(position));
+    }
+    case "farm":
+    default:
+      return detectWaterCollision(
+        state.inventory["Basic Land"]?.toNumber() ?? 3,
+        position,
+      );
+  }
+}
+
 function detectHomeCollision({
   state,
   position,
@@ -488,15 +553,7 @@ function detectHomeCollision({
   position: BoundingBox;
   name: LandscapingPlaceable;
 }) {
-  const bounds = HOME_BOUNDS[state.island.type];
-
-  const isOutside =
-    position.x < bounds.x ||
-    position.x + position.width > bounds.x + bounds.width ||
-    position.y > bounds.y + bounds.height ||
-    position.y - position.height < bounds.y;
-
-  if (isOutside) {
+  if (isOutOfBounds({ state, position, location: "home" })) {
     return true;
   }
 
@@ -546,16 +603,7 @@ function detectPetHouseCollision({
   position: BoundingBox;
   name: LandscapingPlaceable;
 }) {
-  const petHouseLevel = state.petHouse?.level ?? 1;
-  const bounds = PET_HOUSE_BOUNDS[petHouseLevel];
-
-  const isOutside =
-    position.x < bounds.x ||
-    position.x + position.width > bounds.x + bounds.width ||
-    position.y > bounds.y + bounds.height ||
-    position.y - position.height < bounds.y;
-
-  if (isOutside) {
+  if (isOutOfBounds({ state, position, location: "petHouse" })) {
     return true;
   }
 
@@ -736,17 +784,9 @@ function detectInteriorCollision({
   position: BoundingBox;
   name: LandscapingPlaceable;
 }) {
-  // 1. Layout mask — translate Placeable coords → bottom-left layout coords.
-  // GenesisBlock lives at canvas-centre (12, 12) and Placeable anchors
-  // coord (0, 0) there, so the conversion is +canvas/2 on both axes.
-  // Collision and render must use matching fudges — both are 0 right now,
-  // so adjust them in lockstep if alignment drifts.
-  const layoutPosition = {
-    ...position,
-    x: position.x + INTERIOR_CANVAS.width / 2,
-    y: position.y + INTERIOR_CANVAS.height / 2,
-  };
-  if (!isValidInteriorBase(state.island.type, layoutPosition)) {
+  // 1. Layout mask. Collision and render must use matching fudges — both are 0
+  // right now, so adjust them in lockstep if alignment drifts.
+  if (isOutOfBounds({ state, position, location: "interior" })) {
     return true;
   }
 
@@ -804,21 +844,11 @@ function detectLevelOneCollision({
   position: BoundingBox;
   name: LandscapingPlaceable;
 }) {
-  const levelOne = state.interior.level_one;
-  const expansion = state.interior.expansion;
-  if (!levelOne || !expansion) {
+  if (isOutOfBounds({ state, position, location: "level_one" })) {
     return true;
   }
-
-  // Match detectInteriorCollision's translation (no fudge currently).
-  const layoutPosition = {
-    ...position,
-    x: position.x + INTERIOR_CANVAS.width / 2,
-    y: position.y + INTERIOR_CANVAS.height / 2,
-  };
-  if (!isValidHomeExpansionBase(expansion, layoutPosition)) {
-    return true;
-  }
+  // isOutOfBounds already rejected an unbuilt floor.
+  const levelOne = state.interior.level_one!;
 
   // Same overlap policy as the ground floor — see detectInteriorCollision
   // for rationale. Rugs / tiles can still stack freely.

--- a/src/features/game/lib/landscapingDraft.test.ts
+++ b/src/features/game/lib/landscapingDraft.test.ts
@@ -61,9 +61,19 @@ describe("landscapingDraft", () => {
       expect(isDraftEvent("biome.applied", "farm")).toBe(false);
     });
 
-    it("leaves other locations on the streamed path", () => {
-      expect(isDraftEvent("collectible.moved", "home")).toBe(false);
+    it("drafts placement edits on every placeable surface", () => {
+      expect(isDraftEvent("collectible.moved", "home")).toBe(true);
+      expect(isDraftEvent("collectible.moved", "interior")).toBe(true);
+      expect(isDraftEvent("collectible.moved", "level_one")).toBe(true);
+      expect(isDraftEvent("collectible.moved", "petHouse")).toBe(true);
+    });
+
+    it("drafts nothing when not landscaping", () => {
       expect(isDraftEvent("collectible.moved", undefined)).toBe(false);
+    });
+
+    it("keeps purchases live indoors too", () => {
+      expect(isDraftEvent("decoration.bought", "home")).toBe(false);
     });
   });
 

--- a/src/features/game/lib/landscapingDraft.ts
+++ b/src/features/game/lib/landscapingDraft.ts
@@ -66,14 +66,14 @@ const PERSON_PLACEMENT_EVENTS: ReadonlySet<string> = new Set(
 
 /**
  * True when an event dispatched while landscaping should be drafted rather
- * than sent live. Only the farm is sandboxed for now; other locations keep
- * streaming their edits.
+ * than sent live. Every placeable surface is sandboxed; only purchases and
+ * biome changes still settle immediately.
  */
 export const isDraftEvent = (
   type: string,
   location: PlaceableLocation | undefined,
 ): boolean =>
-  location === "farm" &&
+  !!location &&
   !LIVE_LANDSCAPING_EVENTS.has(type) &&
   (type in PLACEMENT_EVENTS || PERSON_PLACEMENT_EVENTS.has(type));
 

--- a/src/features/island/hud/LandscapingHud.tsx
+++ b/src/features/island/hud/LandscapingHud.tsx
@@ -99,8 +99,7 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
   const [quickDragging, setQuickDragging] = useState(false);
   const button = useSound("button");
 
-  // Landscaping sandbox (farm only): edits live in a local draft until Save.
-  const isSandbox = location === "farm";
+  // Every placeable surface is a sandbox: edits live in a local draft until Save.
   const isDirty = useSelector(
     gameService,
     (state) => state.context.draftActions.length > 0,
@@ -145,7 +144,7 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
   const cancel = () => {
     if (saving || saveInFlight) return;
     button.play();
-    if (isSandbox && isDirty) {
+    if (isDirty) {
       setShowDiscardConfirmation(true);
       return;
     }
@@ -355,23 +354,21 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
                 top: `${PIXEL_SCALE * 31}px`,
               }}
             >
-              {isSandbox && (
-                <RoundButton
-                  className="mb-3.5"
-                  disabled={saving || saveInFlight}
-                  onClick={save}
-                >
-                  <img
-                    src={SUNNYSIDE.icons.confirm}
-                    className="absolute group-active:translate-y-[2px]"
-                    style={{
-                      top: `${PIXEL_SCALE * 5.5}px`,
-                      left: `${PIXEL_SCALE * 5.5}px`,
-                      width: `${PIXEL_SCALE * 11}px`,
-                    }}
-                  />
-                </RoundButton>
-              )}
+              <RoundButton
+                className="mb-3.5"
+                disabled={saving || saveInFlight}
+                onClick={save}
+              >
+                <img
+                  src={SUNNYSIDE.icons.confirm}
+                  className="absolute group-active:translate-y-[2px]"
+                  style={{
+                    top: `${PIXEL_SCALE * 5.5}px`,
+                    left: `${PIXEL_SCALE * 5.5}px`,
+                    width: `${PIXEL_SCALE * 11}px`,
+                  }}
+                />
+              </RoundButton>
               <RoundButton
                 className="mb-3.5"
                 disabled={saving || saveInFlight}
@@ -588,7 +585,7 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
           }}
         />
       )}
-      {isSandbox && conflicts && conflicts.length > 0 && (
+      {conflicts && conflicts.length > 0 && (
         <ArrangementConflictsPanel
           conflicts={conflicts}
           onDismiss={() =>


### PR DESCRIPTION
# Pull request description

## Summary

Extends the landscaping sandbox from the farm to every placeable surface: the home, both interior floors and the pet house. Edits there now go to a local draft and commit once on Save, and Cancel genuinely discards.

**Stacked on sunflower-land/sunflower-land#7618** — that PR builds the sandbox on the farm; this one spreads it. Review and merge #7618 first, then this retargets to `main` on its own.

⚠️ Needs sunflower-land/sunflower-land-api#3586 (itself stacked on #3585) deployed first.

## Context / motivation

#7618 deliberately sandboxed the farm alone, so the model could be judged on one surface. Everything else still streamed a placement event per edit, which means indoors the old problems remain: **Cancel silently saves**, and every drag is a server round trip. Since all five surfaces render the same `LandscapingHud`, leaving them split would also mean two behaviours behind one identical UI.

## How it works

Very little new machinery — the draft model was already keyed on location, it was just refusing to engage anywhere but the farm.

- **`isDraftEvent`** drafts on any placeable surface instead of only `"farm"`. Purchases and biome changes stay live everywhere, so buying indoors still settles immediately and Cancel keeps the item in your chest.
- **`applyArrangement`** mirrors the API's `SURFACES` adapter: which collectible bucket a location owns, and which entity kinds it can hold. The pet house takes pets and Pet NFTs but no buds, farm hands or bumpkin; buildings and resources stay farm-only.
- **The cross-surface guard is now "any surface but this one".** Indoor and outdoor coordinates overlap numerically, so a home tile `(0, 0)` and a farm tile `(0, 0)` are unrelated — without this a commit could claim an item standing on another surface. Tested with the same item name at the same coordinates on both surfaces.
- **`isOutOfBounds`** is the bounds half of the per-location collision checks, extracted so the commit validates against exactly the geometry the placement UI already uses (rectangles for home and pet house, tile masks for the interior floors).
- The commit snapshots the **active** surface rather than always snapshotting the farm.
- HUD: Save, the discard confirmation and the conflicts panel are no longer farm-gated.

The Saved Layouts button stays farm-only — layouts are a farm concept and untouched here.

## How to test

Needs the API branch (`feat/landscaping-sandbox-all-locations`) running, or #3586 deployed.

For **each** of home, interior, level one and the pet house:

1. Enter landscaping, move a couple of items, **Cancel** → confirmation appears, everything reverts, and the network tab shows **no autosave carrying placement events**.
2. Move items, **Save** → one `POST /event` with `arrangement.saved` carrying that location; reload and the arrangement persists.
3. Buy a decoration while landscaping indoors → the purchase autosaves without coordinates, the item lands at your tile, you stay in landscaping. Cancel → item is in the chest, coins still spent.

Then the case worth being deliberate about:

4. Place the same collectible on the farm and in the home. Rearrange the home and Save → **the farm copy must not move**. Repeat the other way round.
5. Pet house: rearrange pets and Save. Confirm a bumpkin or farm hand still cannot be placed there at all.
6. Farm behaviour from #7618 is unchanged — re-run that PR's checklist.

Full suite green (348 suites / 5380 tests); type-check, lint and production build clean.

## Screenshots or screen recording

TODO — recording of a home and pet house save/cancel.

## Related issues

Related sunflower-land/sunflower-land#7618
Related sunflower-land-api#3586

---

## Checklist

### PR and scope

- [x] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [x] I have read the contributing guidelines and agree to the T&Cs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
