### PR TITLE
[FIX] Applying a layout no longer lifts hourglasses, totems or shrines

### DIFF
--- a/src/features/game/events/landExpansion/lib/layouts.test.ts
+++ b/src/features/game/events/landExpansion/lib/layouts.test.ts
@@ -80,6 +80,62 @@ const applyLayout = ({
 // Tests the shared layouts lib (snapshotFarm + applyFarmLayout) directly —
 // the layout effects persist to the `layouts` collection around this core.
 describe("layouts lib (applyFarmLayout)", () => {
+  describe("limited items (hourglasses, totems, shrines)", () => {
+    // Removal restrictions do not let a player lift these; applying a layout
+    // must not do it behind their back either, or they come back as unplaced
+    // instances with a stale clock that expire the moment they are re-placed.
+    const createdAt = 1_700_000_000_000;
+    const placedHourglass = (): GameState => ({
+      ...withInventory({ "Gourmet Hourglass": 1 }),
+      collectibles: {
+        "Gourmet Hourglass": [
+          { id: "hg", coordinates: { x: 0, y: 0 }, createdAt },
+        ],
+      },
+    });
+
+    it("leaves a placed hourglass where it is when the layout does not mention it", () => {
+      const state = placedHourglass();
+      const layout = makeLayout(baseFarm);
+
+      applyFarmLayout(state, layout, createdAt + 1000);
+
+      expect(state.collectibles["Gourmet Hourglass"]![0]).toEqual({
+        id: "hg",
+        coordinates: { x: 0, y: 0 },
+        createdAt,
+      });
+    });
+
+    it("moves a hourglass the layout names by id and keeps its clock", () => {
+      const state = placedHourglass();
+      const layout = makeLayout(state);
+      layout.collectibles["Gourmet Hourglass"]![0].coordinates = { x: 2, y: 2 };
+
+      const counts = applyFarmLayout(state, layout, createdAt + 1000);
+
+      expect(counts.applied).toBe(1);
+      expect(state.collectibles["Gourmet Hourglass"]![0]).toEqual({
+        id: "hg",
+        coordinates: { x: 2, y: 2 },
+        createdAt,
+      });
+    });
+
+    it("never places a hourglass from the chest for an id the player does not own", () => {
+      const state = withInventory({ "Gourmet Hourglass": 1 });
+      const layout = makeLayout(baseFarm);
+      layout.collectibles["Gourmet Hourglass"] = [
+        { id: "someone-elses", coordinates: { x: 1, y: 1 } },
+      ];
+
+      const counts = applyFarmLayout(state, layout, createdAt);
+
+      expect(counts.skipped).toBe(1);
+      expect(state.collectibles["Gourmet Hourglass"] ?? []).toHaveLength(0);
+    });
+  });
+
   it("places an owned collectible at its saved position and flip", () => {
     const saved = withSavedLayout({
       ...withInventory({ "Wicker Man": 1 }),

--- a/src/features/game/events/landExpansion/lib/layouts.ts
+++ b/src/features/game/events/landExpansion/lib/layouts.ts
@@ -8,6 +8,7 @@ import type {
 } from "features/game/types/game";
 import { getChestItemCount } from "features/island/hud/components/inventory/utils/inventory";
 import { isCollectibleWithTimestamps } from "features/game/events/landExpansion/placeCollectible";
+import { LIMITED_ITEMS } from "features/game/events/landExpansion/burnCollectible";
 import { getAvailableNodes } from "features/game/lib/resourceNodes";
 import { updateBeehives } from "features/game/lib/updateBeehives";
 import { COLLECTIBLES_DIMENSIONS } from "features/game/types/craftables";
@@ -659,6 +660,7 @@ export function applyFarmLayout(
 ): { applied: number; skipped: number; noInventory: number } {
   const slots: LayoutSlot[] = [];
   let noInventory = 0;
+  let skipped = 0;
 
   // Deterministic id for a newly-created instance — identical on FE and BE
   // (same `createdAt`), and never collides with the 8-hex uuid-slice ids.
@@ -673,6 +675,15 @@ export function applyFarmLayout(
     getBucket: (name: N) => PlacedItem[] | undefined,
     ensureBucket: (name: N) => PlacedItem[],
     newItem: (name: N, id: string) => PlacedItem,
+    /**
+     * Names a layout may only MOVE, never lift or create: the time-limited
+     * collectibles (hourglasses, totems, shrines). Removal restrictions stop
+     * the player lifting these, so a layout must not do it behind their back -
+     * the instance would come back as an unplaced copy with a stale clock and
+     * expire the moment it is re-placed. And creating one from the chest
+     * would start a consumable's clock the player never asked for.
+     */
+    fixed: (name: N) => boolean = () => false,
   ) => {
     getObjectEntries(layoutGroup).forEach(([name, entries]) => {
       const dimensions = PLACEABLE_DIMENSIONS[name];
@@ -681,10 +692,52 @@ export function applyFarmLayout(
       const originalCoords = new Map(
         group.map((item) => [item.id, item.coordinates]),
       );
+      const byId = new Map(group.map((item) => [item.id, item]));
+
+      if (fixed(name)) {
+        // Move the player's own instances to their saved spots; leave every
+        // other instance where it stands; never create.
+        entries.forEach((entry) => {
+          const own = byId.get(entry.id);
+          if (!own) {
+            skipped += 1;
+            return;
+          }
+          const original = originalCoords.get(entry.id);
+          own.coordinates = undefined; // lift only this one
+          slots.push({
+            name: name as LandscapingPlaceable,
+            position: {
+              x: entry.coordinates.x,
+              y: entry.coordinates.y,
+              width: dimensions.width,
+              height: dimensions.height,
+            },
+            place: () => {
+              own.coordinates = { ...entry.coordinates };
+              own.flipped = entry.flipped;
+            },
+            restore: original
+              ? {
+                  position: {
+                    x: original.x,
+                    y: original.y,
+                    width: dimensions.width,
+                    height: dimensions.height,
+                  },
+                  apply: () => {
+                    own.coordinates = { ...original };
+                  },
+                }
+              : undefined,
+          });
+        });
+        return;
+      }
+
       group.forEach((item) => {
         if (item.coordinates) item.coordinates = undefined; // lift
       });
-      const byId = new Map(group.map((item) => [item.id, item]));
       const owned = getChestItemCount(
         state,
         name as InventoryItemName,
@@ -758,6 +811,8 @@ export function applyFarmLayout(
     (name) => (state.collectibles[name] ??= []),
     (name, id) =>
       isCollectibleWithTimestamps(name) ? { id, createdAt } : { id },
+
+    (name) => LIMITED_ITEMS.includes(name),
   );
   addNamedSlots(
     layout.buildings,
@@ -1015,6 +1070,8 @@ export function applyFarmLayout(
   // is intentionally left alone — it is the avatar and is always captured on-farm.
   getObjectEntries(state.collectibles).forEach(([name, items]) => {
     if (layout.collectibles[name]) return;
+    // Time-limited collectibles stay put - see addNamedSlots' `fixed`.
+    if (LIMITED_ITEMS.includes(name)) return;
     items?.forEach((item) => {
       item.coordinates = undefined;
     });
@@ -1039,7 +1096,6 @@ export function applyFarmLayout(
   // (non-layout items + already-placed slots). A blocked slot stays unplaced
   // for now; reused instances get a best-effort restore pass below.
   let applied = 0;
-  let skipped = 0;
   const blockedSlots: LayoutSlot[] = [];
   for (const slot of slots) {
     const blocked = detectCollision({


### PR DESCRIPTION
# Pull request description

## Summary

Applying a saved layout no longer lifts time-limited collectibles (hourglasses, totems, shrines) off the farm. They are moved if the layout names their id, left in place otherwise, and never created from the chest.

## Context / motivation

A player placed a Gourmet Hourglass from the chest and it arrived already expired. Their farm had an **unplaced** Gourmet Hourglass instance with a week-old `createdAt`: `applyFarmLayout`'s exact-restore pass lifts every collectible the layout does not mention, with no removal-restriction check, so applying either of their two saved layouts (neither contains that hourglass) had lifted it without burning it. A week later, `placeCollectible` reused that stale instance instead of creating a fresh one — the reducers reuse the first unplaced instance of a name — and kept its `createdAt`, so the "new" hourglass was expired on arrival.

The player is not allowed to lift these items themselves (`removeCollectible` blocks `LIMITED_ITEMS`); a layout doing it behind their back is the bug.

## How it works

`addNamedSlots` gains a `fixed` predicate, set to `LIMITED_ITEMS` for collectibles:

- an instance the layout names **by id** is moved to its saved spot, clock untouched (same collision/restore handling as everything else);
- every other instance of that name stays exactly where it stands;
- a layout entry for an id the player doesn't own is `skipped`, never created — placing a consumable from the chest would start its clock without the player asking, which matters for shared layouts.

The exact-restore pass skips `LIMITED_ITEMS` for the same reason. This mirrors what the landscaping sandbox commit (#3585) already does for these items.

## How to test

`npx jest src/features/game/events/landExpansion/lib/layouts.test.ts` — three new cases: a placed hourglass the layout omits stays put; one the layout names by id moves with its `createdAt` intact; a foreign id is skipped and nothing is placed. Full suite green (348 suites).

Backend: sunflower-land-api#3589 (merge that first; this is the client mirror of the same reducer).

## Screenshots or screen recording

N/A — no UI change; the layouts modal behaves as before, it just no longer disturbs time-limited items.

## Related issues

Related sunflower-land-api#3589

---

## Checklist

### PR and scope

- [x] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [x] I have read the contributing guidelines and agree to the T&Cs

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Farm layouts now handle limited collectibles such as hourglasses, totems, and shrines more reliably.
  - Existing collectibles remain in place when they are not included in a saved layout.
  - Owned collectibles can be restored to their saved positions without losing their creation timing.
  - Layouts skip collectibles that are not owned instead of placing them from storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->