### PR TITLE
[CHORE] Polish UI animals bounty hub

### DIFF
--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -8,6 +8,7 @@ export interface CheckboxProps {
   checked: boolean;
   onChange: (checked: boolean) => void;
   disabled?: boolean;
+  size?: number;
   "aria-label"?: string;
 }
 
@@ -15,6 +16,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   checked,
   onChange,
   disabled = false,
+  size = PIXEL_SCALE * 10,
   "aria-label": ariaLabel,
 }) => {
   const handleClick = () => {
@@ -44,8 +46,8 @@ export const Checkbox: React.FC<CheckboxProps> = ({
           "bg-brown-100 cursor-not-allowed opacity-75": disabled,
         })}
         style={{
-          width: `${PIXEL_SCALE * 10}px`,
-          height: `${PIXEL_SCALE * 10}px`,
+          width: `${size}px`,
+          height: `${size}px`,
           ...pixelLightBorderStyle,
         }}
       />
@@ -53,7 +55,12 @@ export const Checkbox: React.FC<CheckboxProps> = ({
         <img
           src={SUNNYSIDE.icons.confirm}
           alt="checked"
-          className="absolute left-1 bottom-1 w-8"
+          className="absolute"
+          style={{
+            width: `${size * 0.8}px`,
+            left: `${size * 0.1}px`,
+            bottom: `${size * 0.1}px`,
+          }}
         />
       )}
     </div>

--- a/src/features/barn/BarnInside.tsx
+++ b/src/features/barn/BarnInside.tsx
@@ -343,20 +343,23 @@ export const BarnInside: React.FC = () => {
 
               {!deal && !showSellPanel && (
                 <>
-                  <img
-                    src={shopDisc}
-                    alt="Buy Animals"
-                    className="absolute top-[18px] right-[18px] cursor-pointer z-10"
+                  <button
+                    type="button"
+                    aria-label="Buy Animals"
+                    className="absolute top-[18px] right-[18px] z-10 flex cursor-pointer items-center justify-center border-0 bg-transparent p-0 hover:img-highlight"
                     style={{
                       width: `${PIXEL_SCALE * 18}px`,
+                      height: `${PIXEL_SCALE * 21}px`,
                     }}
                     onClick={() => setShowModal(true)}
-                  />
+                  >
+                    <img src={shopDisc} className="h-full w-full" alt="" />
+                  </button>
 
-                  <div
-                    role="button"
+                  <button
+                    type="button"
                     aria-label="Sell Animals"
-                    className="absolute cursor-pointer z-10 hover:img-highlight"
+                    className="absolute z-10 cursor-pointer border-0 bg-transparent p-0 hover:img-highlight"
                     style={{
                       // The shop disc has a 2px bag sprite above its disc, so its disc face sits
                       // 2 native px lower than the plain disc. Match that so the two discs line up.
@@ -366,14 +369,18 @@ export const BarnInside: React.FC = () => {
                     }}
                     onClick={() => setShowSellPanel(true)}
                   >
-                    <img className="w-full" src={SUNNYSIDE.icons.disc} alt="" />
+                    <img
+                      className="block w-full"
+                      src={SUNNYSIDE.icons.disc}
+                      alt=""
+                    />
                     <img
                       className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
                       src={SUNNYSIDE.icons.death}
                       alt=""
                       style={{ width: `${PIXEL_SCALE * 7}px` }}
                     />
-                  </div>
+                  </button>
 
                   <img
                     src={SUNNYSIDE.icons.upgrade_disc}

--- a/src/features/barn/BarnInside.tsx
+++ b/src/features/barn/BarnInside.tsx
@@ -345,7 +345,7 @@ export const BarnInside: React.FC = () => {
                 <>
                   <button
                     type="button"
-                    aria-label="Buy Animals"
+                    aria-label={t("buy")}
                     className="absolute top-[18px] right-[18px] z-10 flex cursor-pointer items-center justify-center border-0 bg-transparent p-0 hover:img-highlight"
                     style={{
                       width: `${PIXEL_SCALE * 18}px`,
@@ -358,7 +358,7 @@ export const BarnInside: React.FC = () => {
 
                   <button
                     type="button"
-                    aria-label="Sell Animals"
+                    aria-label={t("bounties.sellAnimals")}
                     className="absolute z-10 cursor-pointer border-0 bg-transparent p-0 hover:img-highlight"
                     style={{
                       // The shop disc has a 2px bag sprite above its disc, so its disc face sits

--- a/src/features/barn/components/AnimalBountyQuickPanel.tsx
+++ b/src/features/barn/components/AnimalBountyQuickPanel.tsx
@@ -23,15 +23,20 @@ import { getKeys } from "lib/object";
 const _game = (state: MachineState) => state.context.state;
 const CARD_SIZE = PIXEL_SCALE * 28;
 const SELECT_CORNER_SIZE = PIXEL_SCALE * 8;
+const SELECT_CORNER_OFFSET = PIXEL_SCALE * 3;
 
 interface Props {
   animalTypes: InventoryItemName[];
   selectedDeal?: AnimalBounty;
+  hideCompleted?: boolean;
   onSelect: (deal?: AnimalBounty) => void;
 }
 
 export const SelectionCorners: React.FC = () => (
-  <div className="absolute inset-0 z-40 pointer-events-none">
+  <div
+    className="absolute z-40 pointer-events-none"
+    style={{ inset: `${-SELECT_CORNER_OFFSET}px` }}
+  >
     <img
       src={SUNNYSIDE.ui.selectBoxTL}
       className="absolute top-0 left-0"
@@ -58,6 +63,7 @@ export const SelectionCorners: React.FC = () => (
 export const AnimalBountyQuickPanel: React.FC<Props> = ({
   animalTypes,
   selectedDeal,
+  hideCompleted = false,
   onSelect,
 }) => {
   const { t } = useAppTranslation();
@@ -108,7 +114,18 @@ export const AnimalBountyQuickPanel: React.FC<Props> = ({
     return [...coins, ...gems, ...tickets];
   }, [deals]);
 
-  const renderDealCard = (deal: AnimalBounty) => {
+  const { activeDeals, soldDeals } = useMemo(() => {
+    const soldDealIds = new Set(
+      state.bounties.completed.map((completed) => completed.id),
+    );
+
+    return {
+      activeDeals: orderedDeals.filter((deal) => !soldDealIds.has(deal.id)),
+      soldDeals: orderedDeals.filter((deal) => soldDealIds.has(deal.id)),
+    };
+  }, [orderedDeals, state.bounties.completed]);
+
+  const renderDealCard = (deal: AnimalBounty, startsSoldGroup = false) => {
     const isSold = state.bounties.completed.some(
       (completed) => completed.id === deal.id,
     );
@@ -119,7 +136,9 @@ export const AnimalBountyQuickPanel: React.FC<Props> = ({
     return (
       <div
         key={deal.id}
-        className="relative shrink-0"
+        className={classNames("relative shrink-0", {
+          "ml-2": startsSoldGroup,
+        })}
         style={{
           width: `${CARD_SIZE}px`,
           height: `${CARD_SIZE * 1.15}px`,
@@ -195,17 +214,28 @@ export const AnimalBountyQuickPanel: React.FC<Props> = ({
   };
 
   return (
-    <InnerPanel className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      {deals.length > 0 ? (
+    <InnerPanel
+      className="flex w-full flex-none flex-col overflow-hidden"
+      style={{ height: `${CARD_SIZE * 1.15 + PIXEL_SCALE * 12}px` }}
+    >
+      {activeDeals.length > 0 || (!hideCompleted && soldDeals.length > 0) ? (
         // Just the cards: a single scrolling row keeps the panel as short as
         // possible. Top/bottom padding leaves room for the cards' overhanging
         // level and reward labels.
         <div className="scrollable flex flex-nowrap items-start gap-x-3 overflow-x-auto overflow-y-hidden pl-3 pr-1 pt-2.5 pb-1.5">
-          {orderedDeals.map(renderDealCard)}
+          {activeDeals.map((deal) => renderDealCard(deal))}
+          {!hideCompleted &&
+            soldDeals.map((deal, index) =>
+              renderDealCard(deal, activeDeals.length > 0 && index === 0),
+            )}
         </div>
       ) : (
-        <div className="h-20 flex items-center justify-center px-4">
-          <span className="text-xs">{t("bounties.board.empty")}</span>
+        <div className="flex flex-1 items-center justify-center px-4">
+          <span className="text-xs">
+            {deals.length > 0
+              ? t("bounties.completedHidden")
+              : t("bounties.board.empty")}
+          </span>
         </div>
       )}
     </InnerPanel>

--- a/src/features/barn/components/AnimalBountySellPanel.tsx
+++ b/src/features/barn/components/AnimalBountySellPanel.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { SUNNYSIDE } from "assets/sunnyside";
+import { Checkbox } from "components/ui/Checkbox";
 import { HudContainer } from "components/ui/HudContainer";
 import { Label } from "components/ui/Label";
 import { OuterPanel } from "components/ui/Panel";
@@ -10,7 +11,10 @@ import type { AnimalBounty, InventoryItemName } from "features/game/types/game";
 import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDetails";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { useCountdown } from "lib/utils/hooks/useCountdown";
+import { useLocalStorage } from "lib/utils/hooks/useLocalStorage";
 import { AnimalBountyQuickPanel } from "./AnimalBountyQuickPanel";
+
+const HIDE_COMPLETED_BOUNTIES_KEY = "animalBounties.hideCompleted";
 
 interface Props {
   animalTypes: InventoryItemName[];
@@ -27,16 +31,44 @@ export const AnimalBountySellPanel: React.FC<Props> = ({
 }) => {
   const { t } = useAppTranslation();
   const expiresAt = useCountdown(weekResetsAt());
+  const [hideCompleted, setHideCompleted] = useLocalStorage<boolean>(
+    HIDE_COMPLETED_BOUNTIES_KEY,
+    false,
+  );
 
   return (
     <HudContainer zIndex="z-50">
       <div className="absolute bottom-0 left-0 right-0">
-        {/* Title + weekly reset countdown, perched above the panel's left edge. */}
-        <div className="absolute z-20 -top-8 left-2 flex items-center gap-2">
-          <Label type="default">{t("bounties.sellAnimals")}</Label>
-          <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
+        {/* Panel controls share one bounded row so they cannot overlap on
+            narrow screens. */}
+        <div className="absolute z-20 -top-10 left-2 right-20 flex min-w-0 items-center gap-2 whitespace-nowrap">
+          <Label type="default" className="shrink-0">
+            {t("bounties.sellAnimals")}
+          </Label>
+          <Label
+            type="info"
+            icon={SUNNYSIDE.icons.stopwatch}
+            className="shrink-0"
+          >
             <TimerDisplay time={expiresAt} />
           </Label>
+
+          <div
+            className="flex min-w-0 cursor-pointer items-center gap-1 overflow-hidden"
+            onClick={() => setHideCompleted((hidden) => !hidden)}
+          >
+            <div className="pointer-events-none shrink-0">
+              <Checkbox
+                checked={hideCompleted}
+                onChange={setHideCompleted}
+                size={PIXEL_SCALE * 7}
+                aria-label={t("bounties.hideCompleted")}
+              />
+            </div>
+            <span className="truncate text-xs">
+              {t("bounties.hideCompleted")}
+            </span>
+          </div>
         </div>
 
         <button
@@ -61,6 +93,7 @@ export const AnimalBountySellPanel: React.FC<Props> = ({
             <AnimalBountyQuickPanel
               animalTypes={animalTypes}
               selectedDeal={selectedDeal}
+              hideCompleted={hideCompleted}
               onSelect={onSelect}
             />
           </div>

--- a/src/features/henHouse/HenHouseInside.tsx
+++ b/src/features/henHouse/HenHouseInside.tsx
@@ -235,7 +235,7 @@ export const HenHouseInside: React.FC = () => {
                 <>
                   <button
                     type="button"
-                    aria-label="Buy Animals"
+                    aria-label={t("buy")}
                     className="absolute top-[18px] right-[18px] z-10 flex cursor-pointer items-center justify-center border-0 bg-transparent p-0 hover:img-highlight"
                     style={{
                       width: `${PIXEL_SCALE * 18}px`,
@@ -248,7 +248,7 @@ export const HenHouseInside: React.FC = () => {
 
                   <button
                     type="button"
-                    aria-label="Sell Animals"
+                    aria-label={t("bounties.sellAnimals")}
                     className="absolute z-10 cursor-pointer border-0 bg-transparent p-0 hover:img-highlight"
                     style={{
                       // The shop disc has a 2px bag sprite above its disc, so its disc face sits

--- a/src/features/henHouse/HenHouseInside.tsx
+++ b/src/features/henHouse/HenHouseInside.tsx
@@ -233,20 +233,23 @@ export const HenHouseInside: React.FC = () => {
             <div className={"relative w-full h-full"}>
               {!deal && !showSellPanel && (
                 <>
-                  <img
-                    src={shopDisc}
-                    alt="Buy Animals"
-                    className="absolute top-[18px] right-[18px] cursor-pointer z-10"
+                  <button
+                    type="button"
+                    aria-label="Buy Animals"
+                    className="absolute top-[18px] right-[18px] z-10 flex cursor-pointer items-center justify-center border-0 bg-transparent p-0 hover:img-highlight"
                     style={{
                       width: `${PIXEL_SCALE * 18}px`,
+                      height: `${PIXEL_SCALE * 21}px`,
                     }}
                     onClick={() => setShowModal(true)}
-                  />
+                  >
+                    <img src={shopDisc} className="h-full w-full" alt="" />
+                  </button>
 
-                  <div
-                    role="button"
+                  <button
+                    type="button"
                     aria-label="Sell Animals"
-                    className="absolute cursor-pointer z-10 hover:img-highlight"
+                    className="absolute z-10 cursor-pointer border-0 bg-transparent p-0 hover:img-highlight"
                     style={{
                       // The shop disc has a 2px bag sprite above its disc, so its disc face sits
                       // 2 native px lower than the plain disc. Match that so the two discs line up.
@@ -256,14 +259,18 @@ export const HenHouseInside: React.FC = () => {
                     }}
                     onClick={() => setShowSellPanel(true)}
                   >
-                    <img className="w-full" src={SUNNYSIDE.icons.disc} alt="" />
+                    <img
+                      className="block w-full"
+                      src={SUNNYSIDE.icons.disc}
+                      alt=""
+                    />
                     <img
                       className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
                       src={SUNNYSIDE.icons.death}
                       alt=""
                       style={{ width: `${PIXEL_SCALE * 7}px` }}
                     />
-                  </div>
+                  </button>
 
                   <Button
                     className="absolute -bottom-16"

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4252,6 +4252,8 @@
   "bounties.sold": "Sold",
   "bounties.minLevel": "Lvl {{level}}+",
   "bounties.sellAnimals": "Sell animals",
+  "bounties.hideCompleted": "Hide completed",
+  "bounties.completedHidden": "Completed bounties are hidden.",
   "bounties.sell.coins": "Are you sure you want to sell this for {{amount}} coins?",
   "bounties.sell.items": "Are you sure you want to sell this for {{amount}}?",
   "bounties.sell.sfl": "Are you sure you want to sell this for {{amount}} FLOWER?",


### PR DESCRIPTION
## Summary

- keep active animal bounties first and move completed bounties to the end with a clearer visual gap
- add a persisted Hide completed control and a stable empty state without changing the HUB height
- make the bounty card region fill the full HUD width
- move selected-card corner markers outside the card content boundary
- align Buy/Guide and Sell entry discs and give both the same hover feedback in Barn and Hen House
- support a compact checkbox size while preserving the existing default checkbox appearance

## UX behavior

Completed bounties remain visible by default, but are always ordered after bounties that can still be completed. Players can hide completed entries using the new compact control; the preference is stored locally. The card viewport keeps a fixed height whether it contains active cards, completed cards, or the completed-hidden empty state.

The selected bounty frame now follows the established offset-corner pattern used elsewhere in the game, so it frames the card instead of covering its animal, level, or reward.

<img width="584" height="402" alt="image" src="https://github.com/user-attachments/assets/c357ae04-c41a-4ea3-8743-0351174425fa" />

<img width="584" height="208" alt="image" src="https://github.com/user-attachments/assets/575aa9f5-3834-41c4-971d-1b1050c48403" />

<img width="587" height="153" alt="image" src="https://github.com/user-attachments/assets/c085dc65-c5e8-4100-b483-0850c4f29dc5" />


PR doesn't make any logical or game changes

## Validation

- TypeScript: tsc --noEmit
- targeted ESLint: 0 errors; two pre-existing useLayoutEffect dependency warnings in BarnInside and HenHouseInside
- git diff --check
- visual DevStand checks for full-width HUD, selected-card framing, and aligned entry discs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Hide completed” option for animal bounties, with the preference saved between visits.
  - Bounty panels now separate active and completed deals and display a message when completed deals are hidden.
  - Added scalable checkbox sizing for a more flexible interface.

- **Accessibility & Usability**
  - Updated barn and hen house Buy/Sell controls with native button behavior, clearer translated labels, and hover feedback.
  - Added English text for the completed-bounty visibility option and its hidden-state message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->