### PR TITLE
[FEAT] Show upcoming Bee Swarm on beehives

### DIFF
--- a/src/features/game/expansion/components/resources/beehive/Beehive.tsx
+++ b/src/features/game/expansion/components/resources/beehive/Beehive.tsx
@@ -251,6 +251,24 @@ export const Beehive: React.FC<Props> = ({ id }) => {
             right: `${PIXEL_SCALE * 2}px`,
           }}
         />
+        {/* Orbiting bee indicating this hive will trigger a Bee Swarm when full */}
+        {!landscaping && hive.swarm && (
+          <div
+            role="img"
+            aria-label={t("beehive.beeSwarm")}
+            className="bee-swarm-orbit absolute left-1/2 -translate-x-1/2 pointer-events-none z-40"
+            style={{ top: `${PIXEL_SCALE * -2}px` }}
+          >
+            <img
+              src={bee}
+              alt=""
+              className="bee-swarm-orbit-bee"
+              style={{
+                width: `${PIXEL_SCALE * 7}px`,
+              }}
+            />
+          </div>
+        )}
         {/* Bee to indicate honey is currently being produced */}
         {!showBeeAnimation &&
           !landscaping &&
@@ -313,12 +331,20 @@ export const Beehive: React.FC<Props> = ({ id }) => {
           }}
         >
           <InfoPopover showPopover={showHoneyLevelPopover}>
-            <div className="flex flex-1 items-center text-xxs justify-center px-2 py-1 whitespace-nowrap">
-              <img src={ITEM_DETAILS.Honey.image} className="w-4 mr-1" />
-              <span>
-                {t("honey")}
-                {":"} {honeyPercentageDisplay} {t("full")}
-              </span>
+            <div className="flex flex-1 flex-col text-xxs px-2 py-1 whitespace-nowrap">
+              <div className="flex items-center justify-center">
+                <img src={ITEM_DETAILS.Honey.image} className="w-4 mr-1" />
+                <span>
+                  {t("honey")}
+                  {":"} {honeyPercentageDisplay} {t("full")}
+                </span>
+              </div>
+              {hive.swarm && (
+                <div className="flex items-center justify-center mt-0.5">
+                  <img src={bee} className="w-4 mr-1" alt="" />
+                  <span>{t("beehive.beeSwarmAfterFullHive")}</span>
+                </div>
+              )}
             </div>
           </InfoPopover>
         </div>

--- a/src/features/game/expansion/components/resources/beehive/Beehive.tsx
+++ b/src/features/game/expansion/components/resources/beehive/Beehive.tsx
@@ -447,6 +447,14 @@ export const Beehive: React.FC<Props> = ({ id }) => {
               </div>
             </div>
           )}
+          {hive.swarm && (
+            <div className="flex px-2 py-1 items-center gap-x-2 gap-y-1 flex-wrap">
+              <Label type="default" icon={bee}>
+                {t("beehive.beeSwarm")}
+              </Label>
+              <div className="text-xs mb-0.5">{t("beehive.afterFullHive")}</div>
+            </div>
+          )}
           <Button className="mt-1" onClick={handleHarvestHoney}>
             {t("beehive.harvestHoney")}
           </Button>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -275,6 +275,7 @@
   "beehive.harvestHoney": "Harvest honey",
   "beehive.noFlowersGrowing": "No flowers growing",
   "beehive.beeSwarm": "Bee swarm",
+  "beehive.beeSwarmAfterFullHive": "Bee swarm after full hive!",
   "beehive.pollinationCelebration": "Pollination celebration! Your crops are in for a treat with a +{{amount}} boost from a friendly bee swarm!",
   "beehive.honeyProductionPaused": "Honey production paused",
   "beehive.yield": "Yield",

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -276,6 +276,7 @@
   "beehive.noFlowersGrowing": "No flowers growing",
   "beehive.beeSwarm": "Bee swarm",
   "beehive.beeSwarmAfterFullHive": "Bee swarm after full hive!",
+  "beehive.afterFullHive": "After full hive!",
   "beehive.pollinationCelebration": "Pollination celebration! Your crops are in for a treat with a +{{amount}} boost from a friendly bee swarm!",
   "beehive.honeyProductionPaused": "Honey production paused",
   "beehive.yield": "Yield",

--- a/src/styles.css
+++ b/src/styles.css
@@ -1278,6 +1278,55 @@ img {
   animation: floating 750ms infinite;
 }
 
+@keyframes bee-swarm-orbit {
+  0%,
+  100% {
+    opacity: 0.9;
+    transform: translate3d(-15px, 1px, 0) scale(0.92);
+  }
+  12.5% {
+    opacity: 0.8;
+    transform: translate3d(-11px, -3px, 0) scale(0.9);
+  }
+  25% {
+    opacity: 0.72;
+    transform: translate3d(0, -5px, 0) scale(0.88);
+  }
+  37.5% {
+    opacity: 0.8;
+    transform: translate3d(11px, -3px, 0) scale(0.9);
+  }
+  50% {
+    opacity: 0.9;
+    transform: translate3d(15px, 1px, 0) scale(0.92);
+  }
+  62.5% {
+    opacity: 1;
+    transform: translate3d(11px, 5px, 0) scale(1);
+  }
+  75% {
+    opacity: 1;
+    transform: translate3d(0, 7px, 0) scale(1.06);
+  }
+  87.5% {
+    opacity: 1;
+    transform: translate3d(-11px, 5px, 0) scale(1);
+  }
+}
+
+.bee-swarm-orbit-bee {
+  animation: bee-swarm-orbit 4s linear infinite;
+  transform-origin: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bee-swarm-orbit-bee {
+    animation: none;
+    opacity: 1;
+    transform: translate3d(0, -6px, 0);
+  }
+}
+
 @keyframes enter-hive {
   0% {
     transform: translate(-50%, 0) scale(1);


### PR DESCRIPTION
## Problem

Players can see when a beehive is full, but cannot tell in advance which hive/how many will trigger a Bee Swarm on its next full harvest.

## Changes

- show a persistent orbiting bee above hives whose `swarm` flag is active
- keep the indicator independent from the existing bee-to-flower production animation
- align the compact orbit above the hive and use transform/opacity-only animation
- preserve the indicator as a static bee when reduced motion is enabled
- add a Bee Swarm row with a bee icon to the honey progress hover popover
- add a Bee Swarm badge and `After full hive!` text to the selected hive details modal
- add the new source translation strings to `dictionary.json`

https://github.com/user-attachments/assets/00b170f3-eed8-4a7b-ad4a-90308846b6ed

## Validation

- `npx prettier --check src/features/game/expansion/components/resources/beehive/Beehive.tsx src/lib/i18n/dictionaries/dictionary.json src/styles.css`
- `npx eslint src/features/game/expansion/components/resources/beehive/Beehive.tsx`
- `yarn tsc --noEmit`
- `git diff --check`
- user-reviewed on DevStand with a synced community farm copy and a preview-only Swarm hive fixture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Beehives with an active swarm now display an orbiting bee indicator.
  - Honey progress details and the honey modal now include swarm information.
  - Honey level details warn that a bee swarm will occur after the hive is full.
  - The bee animation respects reduced-motion accessibility preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
