### PR TITLE
[FEAT] Love Boulder health bar and clear buffer

### DIFF
--- a/docs/LOVE_ISLAND_PUZZLES.md
+++ b/docs/LOVE_ISLAND_PUZZLES.md
@@ -260,8 +260,11 @@ it down from **50,000 hits** to zero. When it cracks, a **5 Love Charm**
 prize sits on the rubble for **5 seconds**: anyone who landed at least one
 hit on that boulder can click it to claim, **once per UTC day**. When the 5
 seconds are up a fresh boulder appears at 50,000 and anyone who didn't click
-misses out. There is no guide entry and no HUD text beyond the hit count
-above the boulder (in a label) - the boulder is meant to be discovered.
+misses out. There is no guide entry and no HUD beyond the hit count above
+the boulder (in a label) and a health bar below it - the boulder is meant to
+be discovered. The boulder's collider is the art plus an **8px** buffer on
+every side, so the crowd mines it from around its edge rather than standing
+on top of it.
 
 ```ts
 LOVE_BOULDER_HITS = 50_000;
@@ -303,7 +306,7 @@ Rules:
 - Ignore if `roundId` ≠ the current round, or the boulder is broken
   (`brokenAt > 0`).
 - Ignore if the player's last accepted hit was under **200ms** ago.
-- Ignore if the player is further than ~**40px** from the boulder (use the
+- Ignore if the player is further than ~**50px** from the boulder (use the
   position in `state.players`; the client refuses to send from further away,
   so this only guards forged messages).
 - Otherwise `hitsRemaining -= 1` and `miners[farmId] += 1`.
@@ -319,9 +322,10 @@ farm's `floatingIsland.prizeClaims` (and bounded by the event's daily caps).
 
 ### What the client does
 
-- Shows `hitsRemaining` in a label above the boulder (nothing else), subtracting hits it
-  has sent that the room hasn't reflected yet, and never lets that optimistic
-  count reach zero - only `brokenAt > 0` breaks the boulder.
+- Shows `hitsRemaining` in a label above the boulder and as a health bar
+  below it (`hitsRemaining / hits`), subtracting hits it has sent that the
+  room hasn't reflected yet, and never lets that optimistic count (or the
+  bar) reach zero - only `brokenAt > 0` breaks the boulder.
 - Each tap: must be within reach, respects the 200ms cooldown, sends
   `loveBoulder.hit`, shakes the boulder and chips off rubble.
 - When `brokenAt` flips from 0: plays the shatter and shows a clickable

--- a/src/features/world/lib/loveIsland.ts
+++ b/src/features/world/lib/loveIsland.ts
@@ -299,6 +299,8 @@ export const LOVE_BOULDER_RESPAWN_MS = 5 * 1000;
 export type LoveBoulderRound = {
   /** Increments every time a fresh boulder appears. */
   roundId: number;
+  /** Hits a fresh boulder starts with - the health bar's full width. */
+  hits: number;
   /** Hits still needed to break it (0 once broken). */
   hitsRemaining: number;
   /**
@@ -418,6 +420,7 @@ export function createLoveBoulderLocalRound(
 ): LoveBoulderLocalRound {
   return {
     roundId,
+    hits: LOVE_BOULDER_HITS,
     hitsRemaining: LOVE_BOULDER_HITS,
     broken: false,
     crowdProgress: 0,
@@ -462,6 +465,7 @@ export function tickLoveBoulderLocalRound({
 
   return {
     roundId: round.roundId,
+    hits: round.hits,
     hitsRemaining: 0,
     broken: true,
     brokenAt: now,

--- a/src/features/world/scenes/LoveIslandScene.ts
+++ b/src/features/world/scenes/LoveIslandScene.ts
@@ -85,8 +85,27 @@ const LOCAL_BOT_COUNT = 6;
 const BOULDER_SPOT = { x: 620, y: 362 };
 const BOULDER_WIDTH = 26;
 const BOULDER_HEIGHT = 25;
-/** How close a player has to stand to land a hit. */
-const BOULDER_REACH = 40;
+/**
+ * Clear ground kept around the rock. Without it the crowd stands on top of
+ * the boulder and nobody can see it; the collider is the art plus this buffer
+ * on every side, so miners gather around its edge.
+ */
+const BOULDER_BUFFER = 8;
+/**
+ * How close a player has to stand to land a hit - far enough to reach from
+ * the buffer's corners (a body's width past the collider).
+ */
+const BOULDER_REACH = 50;
+/** Health bar below the boulder, in the HUD bars' red-on-dark palette. */
+const HEALTH_BAR_WIDTH = 30;
+const HEALTH_BAR_HEIGHT = 5;
+const HEALTH_BAR_INNER_WIDTH = HEALTH_BAR_WIDTH - 2;
+const HEALTH_BAR_Y = BOULDER_SPOT.y + BOULDER_HEIGHT / 2 + 4;
+const HEALTH_BAR_TRACK = 0x3e2731;
+const HEALTH_BAR_FILL = 0xe43b44;
+/** The fill flashes this colour for a moment on every tap you land. */
+const HEALTH_BAR_FLASH = 0xff8e8e;
+const HEALTH_BAR_FLASH_MS = 80;
 /** Rubble colours pulled from the boulder art. */
 const RUBBLE_COLOURS = [0x9a9aa8, 0x6b6b7a, 0xc8c8d4];
 /** Clickable area of the prize label (icon + "+5"), generous for thumbs. */
@@ -126,7 +145,8 @@ const LOSE_COLOUR = 0xe57373;
  * the rubble for 5 seconds - anyone who landed a hit can click it for 5
  * Love Charms (once a day) - then a fresh boulder appears. The room
  * publishes `state.loveBoulder`; until it does, a simulated crowd chips
- * away locally. The only HUD is the hit count in a label above the boulder.
+ * away locally. The HUD is the hit count in a label above the boulder and a
+ * health bar below it that drains with every tap.
  */
 export class LoveIslandScene extends BaseScene {
   sceneId: SceneId = "love_island";
@@ -160,6 +180,12 @@ export class LoveIslandScene extends BaseScene {
   /** Nine-patch behind the hit count, resized to fit the number. */
   private boulderHitsLabel?: Phaser.GameObjects.Container;
   private boulderHitsPatch?: { resize: (w: number, h: number) => void };
+  /** Health bar under the boulder, redrawn when its fill width changes. */
+  private boulderHealthBar?: Phaser.GameObjects.Graphics;
+  private boulderHealthFill?: number;
+  private boulderHealthFlashing = false;
+  /** Epoch ms the health bar's tap flash ends. */
+  private boulderHealthFlashUntil = 0;
   /** Love Charm prize shown on the rubble while it can be claimed. */
   private boulderReward?: Phaser.GameObjects.Container;
   /** Round whose prize the local player has clicked. */
@@ -731,12 +757,13 @@ export class LoveIslandScene extends BaseScene {
       .setInteractive({ cursor: "pointer" })
       .on("pointerdown", () => this.hitBoulder());
 
-    // Solid - you mine it from around it, not through it
+    // Solid, with clear ground around it - you mine it from its edge, so the
+    // crowd can't pile onto the rock and hide it
     const collider = this.add.rectangle(
       x,
-      y + 4,
-      BOULDER_WIDTH - 4,
-      BOULDER_HEIGHT - 10,
+      y,
+      BOULDER_WIDTH + BOULDER_BUFFER * 2,
+      BOULDER_HEIGHT + BOULDER_BUFFER * 2,
       0x000000,
       0,
     );
@@ -761,6 +788,11 @@ export class LoveIslandScene extends BaseScene {
     this.boulderHitsText = this.add.bitmapText(0, 1, FONT, "", 5);
     this.boulderHitsLabel = this.add
       .container(x, BOULDER_LABEL_Y, [patch, this.boulderHitsText])
+      .setDepth(Number.MAX_SAFE_INTEGER);
+
+    // Health bar under the rock, always drawn over the crowd
+    this.boulderHealthBar = this.add
+      .graphics({ x: x - HEALTH_BAR_WIDTH / 2, y: HEALTH_BAR_Y })
       .setDepth(Number.MAX_SAFE_INTEGER);
 
     // The prize, sitting on the rubble for a few seconds once it cracks -
@@ -798,6 +830,7 @@ export class LoveIslandScene extends BaseScene {
 
       return {
         roundId: remote.roundId,
+        hits: remote.hits,
         // Hits we've sent come off straight away; the room catches up
         hitsRemaining: broken
           ? 0
@@ -879,6 +912,7 @@ export class LoveIslandScene extends BaseScene {
     });
 
     this.spawnRubble(3, 10);
+    this.boulderHealthFlashUntil = Date.now() + HEALTH_BAR_FLASH_MS;
     this.sound.play("dig", { volume: 0.05 });
   }
 
@@ -945,6 +979,7 @@ export class LoveIslandScene extends BaseScene {
     }
 
     this.setBoulderHits(round.broken ? undefined : round.hitsRemaining);
+    this.setBoulderHealth(round, now);
 
     // The prize sits there until the window closes or we've taken it
     const rewardOpen =
@@ -995,6 +1030,50 @@ export class LoveIslandScene extends BaseScene {
     }
 
     label.setVisible(true);
+  }
+
+  /**
+   * Health bar under the boulder, hidden while it's broken. The fill is whole
+   * pixels, and stays at least one wide until the room says it has cracked.
+   * Each of your own taps flashes the fill so every hit registers, even when
+   * it isn't enough to move the bar a pixel.
+   */
+  private setBoulderHealth(round: LoveBoulderRound, now: number) {
+    const bar = this.boulderHealthBar;
+    if (!bar) return;
+
+    if (round.broken) {
+      bar.setVisible(false);
+      this.boulderHealthFill = undefined;
+      return;
+    }
+
+    const fill = Math.max(
+      1,
+      Math.min(
+        HEALTH_BAR_INNER_WIDTH,
+        Math.ceil(
+          (HEALTH_BAR_INNER_WIDTH * round.hitsRemaining) /
+            Math.max(1, round.hits),
+        ),
+      ),
+    );
+    const flashing = now < this.boulderHealthFlashUntil;
+
+    if (
+      fill !== this.boulderHealthFill ||
+      flashing !== this.boulderHealthFlashing
+    ) {
+      this.boulderHealthFill = fill;
+      this.boulderHealthFlashing = flashing;
+      bar.clear();
+      bar.fillStyle(HEALTH_BAR_TRACK, 1);
+      bar.fillRect(0, 0, HEALTH_BAR_WIDTH, HEALTH_BAR_HEIGHT);
+      bar.fillStyle(flashing ? HEALTH_BAR_FLASH : HEALTH_BAR_FILL, 1);
+      bar.fillRect(1, 1, fill, HEALTH_BAR_HEIGHT - 2);
+    }
+
+    bar.setVisible(true);
   }
 
   /** The boulder just cracked - shatter it and leave the prize on the rubble. */


### PR DESCRIPTION
## What

- **Health bar under the Love Boulder.** A 30x5 pixel bar in the HUD's red-on-dark palette, drawn at top depth so the crowd never covers it. Fill is whole pixels of `hitsRemaining / hits`, never drops below one pixel until the room reports `brokenAt`, and hides while the boulder is broken.
- **Tap flash.** Each hit the local player lands flashes the fill a lighter red for 80ms, so every tap visibly registers even when it isn't enough to move the bar a pixel (50,000 hits over 28px).
- **Bigger boundary.** The collider is now the full 26x25 art plus an 8px buffer on every side (previously a box smaller than the sprite). Players stop with their sprite clear of the rock on all sides so everyone can see it.
- **Reach** goes from 40px to 50px so a player at the buffer's corners can still hit it.
- `LoveBoulderRound` gains `hits` (the round's starting count) so the bar knows its full width in both room and local modes.

## Why

Players were piling on top of the boulder and hiding it, and the only feedback per tap was the hit count label.

## Reviewer notes

- `docs/LOVE_ISLAND_PUZZLES.md` section 4 now says the server reach check is ~**50px** (was ~40px); the MMO room's guard should match when it lands.
- Verified in the offline preview with the player placed against the buffer's bottom, left and right edges; the rock and bar stay uncovered from each side, and a scripted tap flips the flash on and off.
- `tsc`, eslint, prettier and the 31 Love Island jest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a health bar beneath Love Boulders, showing remaining hits and briefly flashing after successful taps.
  - Health indicators now remain visible alongside the boulder’s hit counter during gameplay.

- **Improvements**
  - Expanded the boulder’s interaction area, making it easier to mine from its edges.
  - Increased the distance from which players can interact with Love Boulders.
  - Updated Love Boulder descriptions to document the new health-bar behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->