### PR TITLE
[FIX] Lover's Push: boulder depth, lights always in view, double shoves

### DIFF
--- a/src/features/world/scenes/LoveIslandScene.ts
+++ b/src/features/world/scenes/LoveIslandScene.ts
@@ -152,6 +152,20 @@ const PUSH_GRID_COLOUR = 0x3e2731;
 const PUSH_BUBBLE_COOLDOWN_MS = 3000;
 /** The lights sit in a label above the grid. */
 const PUSH_LIGHTS_Y = PUSH_GRID_ORIGIN.y - 14;
+/**
+ * While the player is on the grid the label follows the camera so it's
+ * always in view - a phone's camera is zoomed in enough that the top of
+ * the grid is off screen from the bottom of it. This keeps it clear of
+ * the edges (and the HUD along the top).
+ */
+const PUSH_LIGHTS_MARGIN = 26;
+/**
+ * How long a shove waits for the room to answer before the boulder can be
+ * shoved again. The room's state still has it where it was until then, so
+ * without this a player leaning on it sends a second shove and it goes two
+ * tiles.
+ */
+const PUSH_ANSWER_MS = 2000;
 const LAMP_SIZE = 6;
 const LAMP_GAP = 3;
 const LAMP_OFF_COLOUR = 0xc0b7a8;
@@ -982,7 +996,8 @@ export class LoveIslandScene extends BaseScene {
   /**
    * The local player is pressing against a boulder. If they're walking
    * into it (not just standing there) it goes one tile the way they're
-   * heading - first come, first served, one shove per slide.
+   * heading - first come, first served, one shove per slide, and not again
+   * until the last shove has landed (or the room has had time to refuse it).
    */
   private walkIntoBoulder(collider: Phaser.GameObjects.Rectangle) {
     const player = this.currentPlayer;
@@ -993,7 +1008,9 @@ export class LoveIslandScene extends BaseScene {
     if (this.movementAngle === undefined) return;
 
     const now = Date.now();
-    if (now - (this.lastPushAt[boulder] ?? 0) < LOVE_PUSH_MOVE_MS) return;
+    const sincePush = now - (this.lastPushAt[boulder] ?? 0);
+    if (sincePush < LOVE_PUSH_MOVE_MS) return;
+    if (this.pendingPushes[boulder] && sincePush < PUSH_ANSWER_MS) return;
 
     // Which side are we on? The bigger offset from the boulder decides
     const dx = collider.x - body.center.x;
@@ -1150,6 +1167,7 @@ export class LoveIslandScene extends BaseScene {
       this.renderedLit = round.lit;
       this.setPushLights(round.lit);
     }
+    this.positionPushLights();
 
     if (!round.solved) {
       this.sawPushUnsolved = true;
@@ -1166,6 +1184,40 @@ export class LoveIslandScene extends BaseScene {
         .setFillStyle(on ? WIN_COLOUR : LAMP_OFF_COLOUR)
         .setStrokeStyle(1, on ? LAMP_ON_STROKE : LAMP_OFF_STROKE);
     });
+  }
+
+  /**
+   * Keep the lights in view while the player is on the grid: the label
+   * stays above the grid until the camera would leave it behind, then
+   * rides along the top of the view. Off the grid it sits above the grid.
+   */
+  private positionPushLights() {
+    const label = this.pushLightsLabel;
+    const player = this.currentPlayer;
+    if (!label || !player) return;
+
+    const { x: left, y: top } = PUSH_GRID_ORIGIN;
+    const size = LOVE_PUSH_GRID_SIZE * PUSH_TILE;
+    const onGrid =
+      player.x >= left - PUSH_TILE &&
+      player.x <= left + size + PUSH_TILE &&
+      player.y >= top - PUSH_TILE &&
+      player.y <= top + size + PUSH_TILE;
+
+    const view = this.cameras.main.worldView;
+    if (!onGrid || view.width === 0) {
+      label.setPosition(CENTRE.x, PUSH_LIGHTS_Y);
+      return;
+    }
+
+    label.setPosition(
+      Phaser.Math.Clamp(
+        CENTRE.x,
+        view.left + PUSH_LIGHTS_MARGIN,
+        view.right - PUSH_LIGHTS_MARGIN,
+      ),
+      Math.max(PUSH_LIGHTS_Y, view.top + PUSH_LIGHTS_MARGIN),
+    );
   }
 
   /** The fourth light just came on - celebrate and settle up. */

--- a/src/features/world/scenes/LoveIslandScene.ts
+++ b/src/features/world/scenes/LoveIslandScene.ts
@@ -1140,6 +1140,16 @@ export class LoveIslandScene extends BaseScene {
       );
       this.renderedPushTiles = round.boulders.map(toLovePushTileIndex);
     } else {
+      // A shove the room hasn't answered by now was refused - forget it,
+      // so someone else moving the boulder the same way isn't credited
+      // to us
+      Object.keys(this.pendingPushes).forEach((key) => {
+        const boulder = Number(key);
+        if (now - (this.lastPushAt[boulder] ?? 0) >= PUSH_ANSWER_MS) {
+          delete this.pendingPushes[boulder];
+        }
+      });
+
       round.boulders.forEach((tile, boulder) => {
         const index = toLovePushTileIndex(tile);
         const rendered = this.renderedPushTiles[boulder];

--- a/src/features/world/scenes/LoveIslandScene.ts
+++ b/src/features/world/scenes/LoveIslandScene.ts
@@ -1081,6 +1081,9 @@ export class LoveIslandScene extends BaseScene {
       y: base,
       duration: LOVE_PUSH_MOVE_MS,
       ease: "Quad.easeOut",
+      // Keep the depth in step with the base as it slides, so a player
+      // walking into the vacated tile isn't drawn beneath the boulder.
+      onUpdate: () => sprite.setDepth(sprite.y),
       onComplete: () => sprite.setDepth(base),
     });
     this.sound.play("dig", { volume: 0.05 });


### PR DESCRIPTION
## Summary

Three fixes to the Lover's Push puzzle on Love Island, all in `LoveIslandScene.ts`.

### 1. Boulder drawn over the player while sliding

`slideBoulder` only set the sprite's depth in the tween's `onComplete`, so mid-slide it kept the depth of the tile it left. Pushing upward, the player walks into the vacated tile while the sprite is still sliding and gets drawn beneath it. The tween now updates depth from the sprite's `y` every frame.

### 2. Lights off screen on mobile

The four lights sat in a world-space label above the grid. On a phone the camera is zoomed 3x, so from the bottom of the grid the label was out of frame and players couldn't see how many were lit. While the player is on the grid (plus one tile of margin) the label now follows the camera: it stays above the grid until that spot would leave the view, then rides along the top edge of the view, clamped horizontally. Off the grid it sits above the grid as before.

### 3. Double shove

A shove was only rate limited by the 300 ms slide duration, not the room's round trip. Until the room answers, its state still has the boulder on its old tile and the collider hasn't moved, so a player still leaning on it passed `canLovePush` again and sent a second shove. The boulder then went two tiles. A boulder with a shove pending now can't be shoved again until the move lands or two seconds pass (in case the room refuses it).

## Testing

- ESLint, Prettier and the project typecheck pass.
- Not visually verified in-game, as the push puzzle needs a live room round to interact with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boulder movement visuals by keeping its layering aligned with its position while sliding.
  * Prevented boulders from being pushed again while a previous push is still awaiting a response.
  * Kept the Lover’s Push lights label within the visible camera area while the player is on the grid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->