### PR TITLE
[FEAT] Love Boulder: show the day's box or coin prize on the rubble

### DIFF
--- a/src/features/game/events/landExpansion/claimFloatingIslandPrize.test.ts
+++ b/src/features/game/events/landExpansion/claimFloatingIslandPrize.test.ts
@@ -125,6 +125,75 @@ describe("claimFloatingIslandPrize", () => {
     });
   });
 
+  /**
+   * The Love Boulder's prize (a box or coins) is rolled on the API, so this
+   * copy only records the claim; the server pays and the next sync brings it.
+   */
+  describe("a puzzle the server pays", () => {
+    const claimBoulder = (
+      state: GameState,
+      amount = 0,
+      createdAt = now,
+    ): GameState =>
+      claimFloatingIslandPrize({
+        state,
+        action: {
+          type: "floatingIslandPrize.claimed",
+          amount,
+          game: "love_boulder",
+          roundId: 1_757_000_000,
+        },
+        createdAt,
+      });
+
+    it("records the claim as worth 0 and pays nothing locally", () => {
+      const state = claimBoulder(vipFarm);
+
+      expect(state.inventory).toEqual(vipFarm.inventory);
+      expect(state.coins).toBe(vipFarm.coins);
+      expect(state.floatingIsland.prizeClaims).toEqual([
+        {
+          claimedAt: now,
+          amount: 0,
+          game: "love_boulder",
+          roundId: 1_757_000_000,
+        },
+      ]);
+    });
+
+    it("ignores a Love Charm amount an older client sends", () => {
+      const state = claimBoulder(INITIAL_FARM, 5);
+
+      expect(state.inventory["Love Charm"]).toBeUndefined();
+      expect(state.floatingIsland.prizeClaims?.[0].amount).toBe(0);
+    });
+
+    it("is not refused by a Love Charm cap the player has already hit", () => {
+      const spent: GameState = {
+        ...INITIAL_FARM,
+        floatingIsland: {
+          ...INITIAL_FARM.floatingIsland,
+          prizeClaims: [
+            { claimedAt: now - 1000, amount: 5, game: "love_dilemma" },
+          ],
+        },
+      };
+
+      expect(claimBoulder(spent, 20).floatingIsland.prizeClaims).toHaveLength(
+        2,
+      );
+    });
+
+    it("leaves the day's Love Charm budget for the other puzzles", () => {
+      expect(
+        getFloatingIslandLoveCharmsRemainingToday({
+          state: claimBoulder(INITIAL_FARM, 20),
+          createdAt: now,
+        }),
+      ).toBe(5);
+    });
+  });
+
   it("rejects a second claim for the same game and round", () => {
     const state = claimFloatingIslandPrize({
       state: vipFarm,

--- a/src/features/game/events/landExpansion/claimFloatingIslandPrize.ts
+++ b/src/features/game/events/landExpansion/claimFloatingIslandPrize.ts
@@ -40,6 +40,21 @@ export const FLOATING_ISLAND_GAME_ITEM_PRIZE: Partial<
   love_push: { item: "Bronze Love Box", amount: 1 },
 };
 
+/**
+ * Puzzles whose prize only the server knows.
+ *
+ * The Love Boulder pays a box or coins rolled per UTC day on the API - a
+ * Bronze Love Box, a Bronze Food Box, 250 coins or 500 coins. The client
+ * can't roll it (the room previews it, but the seed stays server-side), so
+ * this copy records the claim as worth 0 Love Charms and pays nothing; the
+ * API's copy pays the prize and the next sync brings it down. Like an item
+ * prize, it neither counts toward the daily Love Charm cap nor is refused
+ * by it.
+ */
+export const FLOATING_ISLAND_SERVER_PAID_GAMES: FloatingIslandGameName[] = [
+  "love_boulder",
+];
+
 export type FloatingIslandPrizeClaim = {
   claimedAt: number;
   amount: number;
@@ -179,13 +194,17 @@ export function claimFloatingIslandPrize({
     }
 
     // What this puzzle actually pays. An item prize pays no Love Charms, so
-    // the Love Charm cap neither refuses the claim nor records anything.
+    // the Love Charm cap neither refuses the claim nor records anything. A
+    // server-paid prize is the same from here, minus the item.
     const itemPrize = gameName
       ? FLOATING_ISLAND_GAME_ITEM_PRIZE[gameName]
       : undefined;
-    const loveCharms = itemPrize ? 0 : amount;
+    const serverPaid =
+      !!gameName && FLOATING_ISLAND_SERVER_PAID_GAMES.includes(gameName);
+    const paysLoveCharms = !itemPrize && !serverPaid;
+    const loveCharms = paysLoveCharms ? amount : 0;
 
-    if (!itemPrize) {
+    if (paysLoveCharms) {
       const claimedToday = claimsToday.reduce(
         (total, claim) => total + claim.amount,
         0,
@@ -214,7 +233,7 @@ export function claimFloatingIslandPrize({
     if (itemPrize) {
       const held = game.inventory[itemPrize.item] ?? new Decimal(0);
       game.inventory[itemPrize.item] = held.add(itemPrize.amount);
-    } else {
+    } else if (paysLoveCharms) {
       const previous = game.inventory["Love Charm"] ?? new Decimal(0);
       game.inventory["Love Charm"] = previous.add(loveCharms);
     }

--- a/src/features/world/lib/loveIsland.test.ts
+++ b/src/features/world/lib/loveIsland.test.ts
@@ -25,9 +25,11 @@ import {
   LOVE_BOULDER_LOCAL_BOT_HITS_PER_SEC,
   LOVE_BOULDER_PRIZE,
   LOVE_BOULDER_RESPAWN_MS,
+  LOVE_BOULDER_COINS_PRIZE,
   canClaimLoveBoulder,
   createLoveBoulderLocalRound,
-  getLoveBoulderPayout,
+  fromLoveBoulderRoomPrize,
+  getLoveBoulderPrizeKey,
   hasClaimedLoveBoulderRound,
   hasClaimedLoveBoulderToday,
   isLoveBoulderRewardOpen,
@@ -357,7 +359,8 @@ describe("Love Boulder", () => {
       ...vipFarm.floatingIsland,
       prizeClaims: claims.map((claim) => ({
         ...claim,
-        amount: LOVE_BOULDER_PRIZE,
+        // The prize is a box or coins, recorded as worth 0 Love Charms
+        amount: 0,
         game: "love_boulder" as const,
       })),
     },
@@ -495,59 +498,80 @@ describe("Love Boulder", () => {
       ).toBe(false);
     });
 
-    it("caps the payout to what is left today", () => {
-      expect(getLoveBoulderPayout({ state: vipFarm, now })).toBe(
-        LOVE_BOULDER_PRIZE,
-      );
-
-      const standard: GameState = {
+    it("is not gated by the Love Charm cap - a capped player can still claim", () => {
+      const capped: GameState = {
         ...INITIAL_FARM,
         floatingIsland: {
           ...INITIAL_FARM.floatingIsland,
           prizeClaims: [
-            { claimedAt: now - 1000, amount: 3, game: "love_dilemma" },
-          ],
-        },
-      };
-
-      expect(getLoveBoulderPayout({ state: standard, now })).toBe(2);
-    });
-
-    it("pays the room's roll for the day when it has one", () => {
-      expect(getLoveBoulderPayout({ state: vipFarm, prize: 30, now })).toBe(30);
-      expect(getLoveBoulderPayout({ state: vipFarm, prize: 5, now })).toBe(5);
-    });
-
-    it("trims a windfall day to what is left today", () => {
-      const nearlyCapped: GameState = {
-        ...vipFarm,
-        floatingIsland: {
-          ...vipFarm.floatingIsland,
-          prizeClaims: [
-            { claimedAt: now - 1000, amount: 90, game: "love_dilemma" },
+            { claimedAt: now - 1000, amount: 5, game: "love_dilemma" },
           ],
         },
       };
 
       expect(
-        getLoveBoulderPayout({ state: nearlyCapped, prize: 30, now }),
-      ).toBe(10);
-      // A non-VIP never sees more than their 5 a day, whatever the roll
+        canClaimLoveBoulder({ state: capped, myHits: 1, roundId: 3, now }),
+      ).toBe(true);
+    });
+  });
+
+  describe("room prize", () => {
+    it("reads a box from the room's item name and amount", () => {
       expect(
-        getLoveBoulderPayout({ state: INITIAL_FARM, prize: 30, now }),
-      ).toBe(5);
+        fromLoveBoulderRoomPrize({ prize: "Bronze Food Box", amount: 1 }),
+      ).toEqual({ type: "item", item: "Bronze Food Box", amount: 1 });
+    });
+
+    it("reads coins from the room's Coins name", () => {
+      expect(
+        fromLoveBoulderRoomPrize({
+          prize: LOVE_BOULDER_COINS_PRIZE,
+          amount: 250,
+        }),
+      ).toEqual({ type: "coins", amount: 250 });
+      expect(
+        fromLoveBoulderRoomPrize({
+          prize: LOVE_BOULDER_COINS_PRIZE,
+          amount: 500,
+        }),
+      ).toEqual({ type: "coins", amount: 500 });
+    });
+
+    it("falls back to the stand-in prize for a room that predates the roll", () => {
+      expect(fromLoveBoulderRoomPrize({ prize: "", amount: 0 })).toEqual(
+        LOVE_BOULDER_PRIZE,
+      );
+      expect(fromLoveBoulderRoomPrize({})).toEqual(LOVE_BOULDER_PRIZE);
+    });
+
+    it("keys each prize distinctly so the label is only rebuilt on change", () => {
+      const keys = [
+        { type: "item" as const, item: "Bronze Love Box" as const, amount: 1 },
+        { type: "item" as const, item: "Bronze Food Box" as const, amount: 1 },
+        { type: "coins" as const, amount: 250 },
+        { type: "coins" as const, amount: 500 },
+      ].map(getLoveBoulderPrizeKey);
+
+      expect(new Set(keys).size).toBe(4);
+      expect(getLoveBoulderPrizeKey({ type: "coins", amount: 250 })).toBe(
+        keys[2],
+      );
     });
 
     it("carries the prize through the local stand-in", () => {
       const round = createLoveBoulderLocalRound(now);
-      expect(round.prize).toBe(LOVE_BOULDER_PRIZE);
+      expect(round.prize).toEqual(LOVE_BOULDER_PRIZE);
 
       const broken = tickLoveBoulderLocalRound({
-        round: { ...round, hitsRemaining: 1, prize: 20 },
+        round: {
+          ...round,
+          hitsRemaining: 1,
+          prize: { type: "coins", amount: 500 },
+        },
         now: now + 10_000,
       });
       expect(broken.broken).toBe(true);
-      expect(broken.prize).toBe(20);
+      expect(broken.prize).toEqual({ type: "coins", amount: 500 });
     });
   });
 });

--- a/src/features/world/lib/loveIsland.ts
+++ b/src/features/world/lib/loveIsland.ts
@@ -298,13 +298,56 @@ export function getLoveDilemmaBotChoices(
  */
 export const LOVE_BOULDER_HITS = 10_000;
 /**
- * Love Charms for everyone who landed a hit on the boulder that broke, on an
- * ordinary day. The real prize is rolled per UTC day by the server (5 to 30)
- * and published with the boulder as `prize`; this is the floor, shown by the
- * local stand-in and by a room that predates the roll. The claim event pays
- * the server's roll whatever amount is sent, so this only affects the label.
+ * What the boulder pays everyone who landed a hit on it: a box into the
+ * inventory, or coins straight to the balance. Rolled per UTC day by the
+ * server - a Bronze Love Box, a Bronze Food Box, 250 coins or 500 coins - and
+ * published with the boulder as `prize` / `prizeAmount`. The claim event pays
+ * the server's roll whatever the client sends, so the client only shows it.
  */
-export const LOVE_BOULDER_PRIZE = 5;
+export type LoveBoulderPrize =
+  | { type: "item"; item: InventoryItemName; amount: number }
+  | { type: "coins"; amount: number };
+
+/** The boxes the roll can land on - their images are preloaded for the label. */
+export const LOVE_BOULDER_PRIZE_ITEMS: InventoryItemName[] = [
+  "Bronze Love Box",
+  "Bronze Food Box",
+];
+
+/**
+ * Shown by the local stand-in, and by a room that predates the roll (it
+ * publishes an empty `prize`). Never what is actually paid.
+ */
+export const LOVE_BOULDER_PRIZE: LoveBoulderPrize = {
+  type: "item",
+  item: "Bronze Love Box",
+  amount: 1,
+};
+
+/** The room publishes coins under this name rather than an item's. */
+export const LOVE_BOULDER_COINS_PRIZE = "Coins";
+
+/** The room's flattened `prize` / `prizeAmount` pair back into a prize. */
+export function fromLoveBoulderRoomPrize({
+  prize,
+  amount,
+}: {
+  prize?: string;
+  amount?: number;
+}): LoveBoulderPrize {
+  if (!prize || !amount) return LOVE_BOULDER_PRIZE;
+
+  if (prize === LOVE_BOULDER_COINS_PRIZE) return { type: "coins", amount };
+
+  return { type: "item", item: prize as InventoryItemName, amount };
+}
+
+/** A stable key for a prize, so the label is only rebuilt when it changes. */
+export function getLoveBoulderPrizeKey(prize: LoveBoulderPrize): string {
+  return prize.type === "coins"
+    ? `coins:${prize.amount}`
+    : `${prize.item}:${prize.amount}`;
+}
 /** The prize can be claimed this many times per UTC day. */
 export const LOVE_BOULDER_MAX_CLAIMS = 1;
 /** Fastest a single player may tap - the room drops anything quicker. */
@@ -331,8 +374,8 @@ export type LoveBoulderRound = {
   brokenAt?: number;
   /** Epoch ms a fresh boulder appears - only set once broken. */
   respawnAt?: number;
-  /** Love Charms this boulder pays - the day's roll from the room. */
-  prize: number;
+  /** What this boulder pays - the day's roll from the room. */
+  prize: LoveBoulderPrize;
 };
 
 /** Is the prize sitting on the rubble right now, waiting to be clicked? */
@@ -407,28 +450,6 @@ export function canClaimLoveBoulder({
   if (hasClaimedLoveBoulderRound({ state, roundId, now })) return false;
 
   return !hasClaimedLoveBoulderToday({ state, now });
-}
-
-/**
- * What the boulder actually pays this player right now: the day's prize,
- * capped by the Love Charms they can still earn today. The server trims its
- * own roll the same way, so this is what the label shows and what the claim
- * sends - never more than the player will receive.
- */
-export function getLoveBoulderPayout({
-  state,
-  prize = LOVE_BOULDER_PRIZE,
-  now = Date.now(),
-}: {
-  state: GameState;
-  /** The room's `prize` for this boulder; the floor when it has none. */
-  prize?: number;
-  now?: number;
-}): number {
-  return Math.min(
-    prize,
-    getFloatingIslandLoveCharmsRemainingToday({ state, createdAt: now }),
-  );
 }
 
 /** Local mode: the simulated crowd's combined tapping speed. */

--- a/src/features/world/scenes/LoveIslandScene.ts
+++ b/src/features/world/scenes/LoveIslandScene.ts
@@ -9,6 +9,7 @@ import { translate, translateForBubble } from "lib/i18n/translate";
 import { interactableModalManager } from "../ui/InteractableModals";
 import type { TemperateSeasonName } from "features/game/types/game";
 import { SUNNYSIDE } from "assets/sunnyside";
+import { ITEM_DETAILS } from "features/game/types/images";
 import { hasVipAccess } from "features/game/lib/vipAccess";
 import { hasReadLoveIslandNotice } from "../ui/loveRewardShop/LoveIslandNoticeboard";
 import type { BumpkinContainer } from "../containers/BumpkinContainer";
@@ -23,7 +24,10 @@ import {
 } from "../lib/loveIslandFixtures";
 import {
   LOVE_BOULDER_HIT_COOLDOWN_MS,
+  LOVE_BOULDER_COINS_PRIZE,
   LOVE_BOULDER_PRIZE,
+  LOVE_BOULDER_PRIZE_ITEMS,
+  type LoveBoulderPrize,
   LOVE_DILEMMA_CHOOSE_MS,
   LOVE_DILEMMA_PLATFORMS,
   LOVE_ISLAND_CENTRE_PUZZLE,
@@ -38,7 +42,8 @@ import {
   createLoveBoulderLocalRound,
   createLovePushLocalRound,
   fromLovePushTileIndex,
-  getLoveBoulderPayout,
+  fromLoveBoulderRoomPrize,
+  getLoveBoulderPrizeKey,
   getLoveDilemmaAttemptsLeft,
   getLoveDilemmaBotChoices,
   getLoveDilemmaPayout,
@@ -132,7 +137,10 @@ const HEALTH_BAR_FLASH = 0xff8e8e;
 const HEALTH_BAR_FLASH_MS = 80;
 /** Rubble colours pulled from the boulder art. */
 const RUBBLE_COLOURS = [0x9a9aa8, 0x6b6b7a, 0xc8c8d4];
-/** Clickable area of the prize label (icon + "+5"), generous for thumbs. */
+/** Texture key for a boulder prize's icon - an item name or "Coins". */
+const boulderPrizeTexture = (prize: string) => `boulder_prize_${prize}`;
+
+/** Clickable area of the prize label (icon + "+1"), generous for thumbs. */
 const REWARD_HIT_WIDTH = 36;
 const REWARD_HIT_HEIGHT = 16;
 /** The hit counter's label sits just above the boulder. */
@@ -302,8 +310,8 @@ export class LoveIslandScene extends BaseScene {
   private boulderHealthFlashUntil = 0;
   /** Love Charm prize shown on the rubble while it can be claimed. */
   private boulderReward?: Phaser.GameObjects.Container;
-  /** Amount the prize label was built with, so it's only rebuilt on change. */
-  private boulderRewardPrize?: number;
+  /** Prize the label was built for (see `getLoveBoulderPrizeKey`), so it's only rebuilt on change. */
+  private boulderRewardPrize?: string;
   /** Round whose prize the local player has clicked. */
   private claimedBoulderRoundId?: number;
   /** Simulated boulder while the room has no boulder state. */
@@ -386,6 +394,14 @@ export class LoveIslandScene extends BaseScene {
     this.load.image("platform", "world/platform.webp");
     this.load.image("love_charm_small", loveCharmSmall);
     this.load.image("boulder", SUNNYSIDE.resource.boulder);
+    // Icons for whatever the boulder can pay today
+    this.load.image(
+      boulderPrizeTexture(LOVE_BOULDER_COINS_PRIZE),
+      SUNNYSIDE.ui.coins,
+    );
+    LOVE_BOULDER_PRIZE_ITEMS.forEach((item) => {
+      this.load.image(boulderPrizeTexture(item), ITEM_DETAILS[item].image);
+    });
     this.load.image("push_boulder", "world/love_rock.png");
     this.load.image(PUSH_ARROW_TEXTURE.north, SUNNYSIDE.icons.arrow_up);
     this.load.image(PUSH_ARROW_TEXTURE.east, SUNNYSIDE.icons.arrow_right);
@@ -1780,12 +1796,14 @@ export class LoveIslandScene extends BaseScene {
   }
 
   /**
-   * The prize label on the rubble, rebuilt whenever the amount changes (a
-   * label's width is fixed at creation, and "+30" is wider than "+5"). Hidden
-   * until the boulder cracks; `updateLoveBoulder` shows it.
+   * The prize label on the rubble - the day's box or coin purse with its
+   * icon - rebuilt whenever the prize changes (a label's width and icon are
+   * fixed at creation, and "+500" is wider than "+1"). Hidden until the
+   * boulder cracks; `updateLoveBoulder` shows it.
    */
-  private refreshBoulderReward(prize: number) {
-    if (this.boulderRewardPrize === prize && this.boulderReward) return;
+  private refreshBoulderReward(prize: LoveBoulderPrize) {
+    const key = getLoveBoulderPrizeKey(prize);
+    if (this.boulderRewardPrize === key && this.boulderReward) return;
 
     const { x, y } = BOULDER_SPOT;
     const previous = this.boulderReward;
@@ -1797,7 +1815,10 @@ export class LoveIslandScene extends BaseScene {
       previous.destroy();
     }
 
-    const reward = new Label(this, `+${prize}`, "grey", "love_charm_small");
+    const icon = boulderPrizeTexture(
+      prize.type === "coins" ? LOVE_BOULDER_COINS_PRIZE : prize.item,
+    );
+    const reward = new Label(this, `+${prize.amount}`, "grey", icon);
     reward
       .setPosition(x, rewardY)
       .setDepth(Number.MAX_SAFE_INTEGER)
@@ -1808,9 +1829,9 @@ export class LoveIslandScene extends BaseScene {
     this.add.existing(reward);
 
     this.boulderReward = reward;
-    this.boulderRewardPrize = prize;
+    this.boulderRewardPrize = key;
 
-    // Keep bobbing if the prize was already on show when the amount changed
+    // Keep bobbing if the prize was already on show when it changed
     if (visible) this.bobBoulderReward();
   }
 
@@ -1855,8 +1876,11 @@ export class LoveIslandScene extends BaseScene {
         ...(broken
           ? { brokenAt: remote.brokenAt, respawnAt: remote.respawnAt }
           : {}),
-        // A room that predates the daily roll publishes 0 - the floor then
-        prize: remote.prize || LOVE_BOULDER_PRIZE,
+        // A room that predates the daily roll publishes nothing - the stand-in then
+        prize: fromLoveBoulderRoomPrize({
+          prize: remote.prize,
+          amount: remote.prizeAmount,
+        }),
       };
     }
 
@@ -2009,11 +2033,8 @@ export class LoveIslandScene extends BaseScene {
         now,
       });
 
-    // Shown amount is what this player will actually get - the day's roll,
-    // trimmed to what they can still earn today
-    this.refreshBoulderReward(
-      getLoveBoulderPayout({ state: this.freshState, prize: round.prize, now }),
-    );
+    // The day's roll, as the room publishes it
+    this.refreshBoulderReward(round.prize);
 
     if (this.boulderReward && this.boulderReward.visible !== rewardOpen) {
       this.boulderReward.setVisible(rewardOpen);
@@ -2138,25 +2159,25 @@ export class LoveIslandScene extends BaseScene {
       return;
     }
 
-    // The day's roll, capped to what's still claimable today. The server pays
-    // its own roll regardless, so this is a preview rather than the authority
-    const amount = getLoveBoulderPayout({ state, prize: round.prize, now });
-
-    // The roundId makes a reload mid-window a no-op instead of a second claim
+    // The prize is a box or coins, never Love Charms - the server rolls it
+    // for the day and pays it, recording the claim as worth 0 so the day's
+    // Love Charm budget is untouched. The roundId makes a reload mid-window a
+    // no-op instead of a second claim.
     this.gameService?.send({
       type: "floatingIslandPrize.claimed",
-      amount,
+      amount: 0,
       game: "love_boulder",
       roundId: round.roundId,
     });
 
     this.claimedBoulderRoundId = round.roundId;
 
-    if (amount > 0) {
-      player.cheer();
-      this.showWinnings(amount);
-    } else {
-      player.speak(translateForBubble("loveBoulder.dailyLimit"));
-    }
+    const { prize } = round;
+    player.cheer();
+    player.speak(
+      prize.type === "coins"
+        ? translateForBubble("loveBoulder.prizeCoins", { amount: prize.amount })
+        : translateForBubble("loveBoulder.prizeItem", { item: prize.item }),
+    );
   }
 }

--- a/src/features/world/types/Room.ts
+++ b/src/features/world/types/Room.ts
@@ -170,10 +170,13 @@ export interface LoveBoulder extends Schema {
   /** Epoch ms a fresh boulder appears; 0 while it's standing. */
   respawnAt: number;
   /**
-   * Love Charms this boulder pays - rolled per UTC day by the server (5 to
-   * 30). 0 from a room that predates the roll; treat as the floor.
+   * What this boulder pays - rolled per UTC day by the server: an inventory
+   * item name (a Bronze Love Box or Bronze Food Box) or "Coins". Empty from a
+   * room that predates the roll.
    */
-  prize: number;
+  prize: string;
+  /** How many of `prize` - 1 for a box, 250 or 500 for coins. */
+  prizeAmount: number;
   /** farmId -> hits landed this round. Proof of who helped. */
   miners: MapSchema<number>;
 }

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6299,6 +6299,8 @@
   "loveBoulder.didNotHelp": "Hit the boulder to earn the prize!",
   "loveBoulder.alreadyClaimed": "Already claimed today. Come back tomorrow!",
   "loveBoulder.dailyLimit": "Daily Love Charm limit reached",
+  "loveBoulder.prizeItem": "You won a {{item}}!",
+  "loveBoulder.prizeCoins": "You won {{amount}} coins!",
   "lovePush.waitForNextPuzzle": "Solved! Wait for the next puzzle",
   "lovePush.didNotHelp": "Help push a boulder to earn the prize!",
   "lovePush.alreadyClaimed": "Already claimed today. Come back tomorrow!",

--- a/src/lib/i18n/dictionaries/en.json
+++ b/src/lib/i18n/dictionaries/en.json
@@ -6299,6 +6299,8 @@
   "loveBoulder.didNotHelp": "Hit the boulder to earn the prize!",
   "loveBoulder.alreadyClaimed": "Already claimed today. Come back tomorrow!",
   "loveBoulder.dailyLimit": "Daily Love Charm limit reached",
+  "loveBoulder.prizeItem": "You won a {{item}}!",
+  "loveBoulder.prizeCoins": "You won {{amount}} coins!",
   "lovePush.waitForNextPuzzle": "Solved! Wait for the next puzzle",
   "lovePush.didNotHelp": "Help push a boulder to earn the prize!",
   "lovePush.alreadyClaimed": "Already claimed today. Come back tomorrow!",


### PR DESCRIPTION
## What

Follow-up to #7631, which was merged before this commit landed on its branch. The Love Boulder's prize is no longer Love Charms: it is a Bronze Love Box, a Bronze Food Box, 250 coins or 500 coins, rolled per UTC day on the API and published on the room as `state.loveBoulder.prize` (an item name or `"Coins"`) plus `prizeAmount`. The rubble label shows the matching icon and amount, and the claim bubble says what was won.

Pairs with the API change in sunflower-land/sunflower-land-api#3597. **Merge this before or together with the API PR**: the client on main today reads `prize` as a number and would render the API's item name as the label text.

## How

- `Room.ts`: `LoveBoulder.prize` becomes a string and gains `prizeAmount`. A room that predates the roll publishes an empty prize, which the scene shows as the Bronze Love Box stand-in.
- `loveIsland.ts`: `LoveBoulderPrize` (item or coins), `fromLoveBoulderRoomPrize` to read the room's flattened pair, `getLoveBoulderPrizeKey` so the label is only rebuilt when the prize changes, and `LOVE_BOULDER_PRIZE_ITEMS` so the scene knows which box images to preload. The Love Charm payout helper is gone; the boulder no longer pays Love Charms.
- `LoveIslandScene.ts`: preloads the coin icon and both box images, rebuilds the reward label with the right icon and amount when the prize changes (keeping its bob if already on show), and on claim sends `amount: 0`, cheers, and speaks `loveBoulder.prizeItem` / `loveBoulder.prizeCoins`.
- `claimFloatingIslandPrize.ts`: new `FLOATING_ISLAND_SERVER_PAID_GAMES` (`love_boulder`). This copy records the claim as worth 0 Love Charms and pays nothing, since only the API knows the day's roll; the API pays the box or coins and the next sync brings it down. Like an item prize, it neither counts toward nor is refused by the daily Love Charm cap.
- Two new dictionary keys, `loveBoulder.prizeItem` and `loveBoulder.prizeCoins`, in `dictionary.json` and `en.json` for the translation bot to pick up.

## Reviewer notes

- The server pays its own roll whatever the client sends, so an old client still receives the prize; it just shows the wrong label.
- The coins or box land after the next autosave round-trip rather than instantly, because the client can't roll the prize itself. The bubble names the prize straight away.
- `loveBoulder.dailyLimit` is now unused (there is no cap on a box or coin prize) but left in the dictionaries to avoid churning every language file.

## Tests

`fromLoveBoulderRoomPrize` (box, both coin sizes, legacy room fallback), `getLoveBoulderPrizeKey` distinctness, the prize carrying through the local stand-in, a capped player still being able to claim, and the event copy recording a server-paid claim as 0 without touching inventory, coins or the Love Charm budget. 102 tests pass across the two files; lint and tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Love Boulder rewards now rotate daily between item prizes and coin payouts.
  * Reward amounts and prize icons are displayed in the Love Island scene.
  * Item rewards are added to inventory, while coin rewards are credited to the player’s balance.
  * Added messages for winning items and coins.

* **Bug Fixes**
  * Love Boulder claims no longer incorrectly consume or count against the daily Love Charm limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->