### PR TITLE
[FIX] Preserve off-farm entities when applying layouts

### DIFF
--- a/src/features/game/events/landExpansion/lib/layouts.test.ts
+++ b/src/features/game/events/landExpansion/lib/layouts.test.ts
@@ -522,6 +522,97 @@ describe("layouts lib (applyFarmLayout)", () => {
     expect(result.bumpkin.flipped).toEqual(true);
   });
 
+  it("preserves buds, pet NFTs and farmhands placed outside the farm", () => {
+    const saved = withSavedLayout({
+      ...baseFarm,
+      buds: {
+        1: { ...BUD, coordinates: { x: 1, y: 1 }, location: "home" },
+      },
+      pets: {
+        nfts: {
+          1: {
+            ...petNFT({ x: 2, y: 2 }),
+            location: "petHouse" as const,
+          },
+        },
+      },
+      farmHands: {
+        bumpkins: {
+          "fh-1": {
+            equipped: EQUIPPED,
+            coordinates: { x: 3, y: 3 },
+            location: "home",
+          },
+        },
+      },
+    });
+
+    const result = applyLayout({ state: cloneDeep(saved) });
+
+    expect(result.buds![1]).toMatchObject({
+      coordinates: { x: 1, y: 1 },
+      location: "home",
+    });
+    expect(result.pets!.nfts![1]).toMatchObject({
+      coordinates: { x: 2, y: 2 },
+      location: "petHouse",
+    });
+    expect(result.farmHands.bumpkins["fh-1"]).toMatchObject({
+      coordinates: { x: 3, y: 3 },
+      location: "home",
+    });
+  });
+
+  it("does not pull layout entities out of other locations", () => {
+    const saved = withSavedLayout({
+      ...baseFarm,
+      buds: {
+        1: { ...BUD, coordinates: { x: 1, y: 1 }, location: "farm" },
+      },
+      pets: { nfts: { 1: petNFT({ x: 2, y: 2 }) } },
+      farmHands: {
+        bumpkins: {
+          "fh-1": {
+            equipped: EQUIPPED,
+            coordinates: { x: 3, y: 3 },
+            location: "farm",
+          },
+        },
+      },
+    });
+    const moved = cloneDeep(saved);
+    moved.buds![1] = {
+      ...moved.buds![1],
+      coordinates: { x: -1, y: -1 },
+      location: "home",
+    };
+    moved.pets!.nfts![1] = {
+      ...moved.pets!.nfts![1],
+      coordinates: { x: -2, y: -2 },
+      location: "petHouse",
+    };
+    moved.farmHands.bumpkins["fh-1"] = {
+      ...moved.farmHands.bumpkins["fh-1"],
+      coordinates: { x: -3, y: -3 },
+      location: "home",
+    };
+
+    const result = applyLayout({ state: moved });
+
+    expect(result.buds![1]).toMatchObject({
+      coordinates: { x: -1, y: -1 },
+      location: "home",
+    });
+    expect(result.pets!.nfts![1]).toMatchObject({
+      coordinates: { x: -2, y: -2 },
+      location: "petHouse",
+    });
+    expect(result.farmHands.bumpkins["fh-1"]).toMatchObject({
+      coordinates: { x: -3, y: -3 },
+      location: "home",
+    });
+  });
+
   it("places farmhands by count, ignoring the saved id", () => {
     const saved = withSavedLayout({
       ...baseFarm,

--- a/src/features/game/events/landExpansion/lib/layouts.ts
+++ b/src/features/game/events/landExpansion/lib/layouts.ts
@@ -876,7 +876,7 @@ export function applyFarmLayout(
   // skipped silently). Pets must be revealed to be placed.
   Object.entries(layout.buds ?? {}).forEach(([id, coordinates]) => {
     const bud = state.buds?.[Number(id)];
-    if (!bud) return;
+    if (!bud || (bud.coordinates && !isOnFarm(bud))) return;
     const original = bud.coordinates;
     bud.coordinates = undefined; // lift
     slots.push({
@@ -900,7 +900,7 @@ export function applyFarmLayout(
   Object.entries(layout.petNFTs ?? {}).forEach(([id, coordinates]) => {
     // Owned by id (a pet in a layout was placed once, so it's already revealed).
     const pet = state.pets?.nfts?.[Number(id)];
-    if (!pet) return;
+    if (!pet || (pet.coordinates && !isOnFarm(pet))) return;
     const original = pet.coordinates;
     pet.coordinates = undefined; // lift
     slots.push({
@@ -922,12 +922,17 @@ export function applyFarmLayout(
     });
   });
 
-  // FarmHands: prefer the saved farmhand id if the player owns it (keeps each
-  // bumpkin's equipment + flip at its saved spot), else bind any other unlocked
-  // farmhand by count. No creation — you can't mint farmhands.
-  const farmHandIds = Object.keys(state.farmHands?.bumpkins ?? {}).sort(
-    (a, b) => a.localeCompare(b),
-  );
+  // FarmHands: prefer the saved farmhand id when it is available to the farm
+  // (keeps each bumpkin's equipment + flip at its saved spot), else bind any
+  // other unlocked farmhand by count. Farmhands placed in another location are
+  // not available. No creation — you can't mint farmhands.
+  const farmHandIds = Object.keys(state.farmHands?.bumpkins ?? {})
+    .filter((id) => {
+      const farmHand = state.farmHands.bumpkins[id];
+      return !farmHand.coordinates || isOnFarm(farmHand);
+    })
+    .sort((a, b) => a.localeCompare(b));
+  const availableFarmHandIds = new Set(farmHandIds);
   const farmHandOriginals = new Map(
     farmHandIds.map((id) => [id, state.farmHands.bumpkins[id].coordinates]),
   );
@@ -943,7 +948,7 @@ export function applyFarmLayout(
     fhEntries
       .slice(0, fhCapacity)
       .map(([id]) => id)
-      .filter((id) => state.farmHands.bumpkins[id] !== undefined),
+      .filter((id) => availableFarmHandIds.has(id)),
   );
   const farmHandPool = farmHandIds.filter((id) => !ownedFarmHandIds.has(id));
   let fhPoolIdx = 0;
@@ -952,10 +957,9 @@ export function applyFarmLayout(
       noInventory += 1;
       return;
     }
-    const id =
-      state.farmHands.bumpkins[savedId] !== undefined
-        ? savedId
-        : farmHandPool[fhPoolIdx++];
+    const id = availableFarmHandIds.has(savedId)
+      ? savedId
+      : farmHandPool[fhPoolIdx++];
     if (id === undefined) {
       noInventory += 1;
       return;
@@ -1008,11 +1012,13 @@ export function applyFarmLayout(
     });
   }
 
-  // Exact restore: applying a layout yields exactly the saved snapshot, so lift
-  // every placed item the layout does NOT represent too — its instance (with any
-  // timers) is kept; it simply returns to inventory. Resources are lifted in full
-  // above; mirror that for the name/id-keyed categories. The player's own Bumpkin
-  // is intentionally left alone — it is the avatar and is always captured on-farm.
+  // Exact restore: applying a layout yields exactly the saved farm snapshot, so
+  // lift every item placed on the farm that the layout does NOT represent too —
+  // its instance (with any timers) is kept; it simply returns to inventory.
+  // Resources are lifted in full above; mirror that for the name/id-keyed
+  // categories without touching placements in other locations. The player's own
+  // Bumpkin is intentionally left alone — it is the avatar and is always captured
+  // on-farm.
   getObjectEntries(state.collectibles).forEach(([name, items]) => {
     if (layout.collectibles[name]) return;
     items?.forEach((item) => {
@@ -1026,13 +1032,13 @@ export function applyFarmLayout(
     });
   });
   Object.entries(state.buds ?? {}).forEach(([id, bud]) => {
-    if (!layout.buds?.[id]) bud.coordinates = undefined;
+    if (!layout.buds?.[id] && isOnFarm(bud)) bud.coordinates = undefined;
   });
   Object.entries(state.pets?.nfts ?? {}).forEach(([id, pet]) => {
-    if (!layout.petNFTs?.[id]) pet.coordinates = undefined;
+    if (!layout.petNFTs?.[id] && isOnFarm(pet)) pet.coordinates = undefined;
   });
   Object.entries(state.farmHands?.bumpkins ?? {}).forEach(([id, fh]) => {
-    if (!layout.farmHands?.[id]) fh.coordinates = undefined;
+    if (!layout.farmHands?.[id] && isOnFarm(fh)) fh.coordinates = undefined;
   });
 
   // Everything is now lifted. Place each slot in turn against the live draft


### PR DESCRIPTION
## Problem

Players reported that opening a new ascension island could remove Buds and NFT Pets from the Home and Pet House and make them appear in the chest.

The island transition itself was not directly removing those entities. The issue happened when the saved farm layout was re-applied after a later ascension:

1. The pre-ascension snapshot correctly captured only entities placed on the farm.
2. Buds in the Home and NFT Pets in the Pet House were intentionally excluded from that farm snapshot.
3. `applyFarmLayout` performed an exact restore by clearing coordinates from every Bud and NFT Pet absent from the snapshot, without checking its current location.
4. Because the chest treats an NFT without coordinates as unplaced, the affected entities appeared in the chest even though they had been placed outside the farm.

The same location-boundary issue also applied to Farm Hands, and a saved layout could pull a matching Bud, NFT Pet, or Farm Hand out of another location to satisfy a farm layout slot.

## Fix

- Limit exact-restore cleanup to Buds, NFT Pets, and Farm Hands currently placed on the farm.
- Treat entities placed in another location as unavailable when filling farm layout slots.
- Preserve the existing exact-restore behavior for extra entities that are actually placed on the farm.

## Tests

- Added regression coverage proving that applying a farm layout preserves Buds in the Home, NFT Pets in the Pet House, and Farm Hands in the Home.
- Added coverage proving that a saved farm layout cannot pull those entities out of another location.

Validation:

- `yarn test src/features/game/events/landExpansion/upgradeFarm.test.ts src/features/game/events/landExpansion/lib/layouts.test.ts --runInBand` (71 passed)
- `yarn tsc --noEmit`
- Targeted ESLint
- Prettier check
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Farm layouts now preserve buds, pets, and farmhands placed outside the farm.
  * Applying a layout no longer pulls entities from locations such as the home or pet house back onto the farm.
  * Layout restoration more accurately retains valid saved farmhand assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->