### PR TITLE
[FIX] Cancel Fish Market items from unordered queues

### DIFF
--- a/src/features/game/events/landExpansion/cancelProcessedResource.test.ts
+++ b/src/features/game/events/landExpansion/cancelProcessedResource.test.ts
@@ -250,4 +250,79 @@ describe("cancelProcessedResource", () => {
       readyAt: firstReady + DURATION("Fish Oil"),
     });
   });
+
+  it("cancels the selected product when the server queue is not chronological", () => {
+    const firstReady = createdAt + DURATION("Fish Flake");
+    const secondReady = firstReady + DURATION("Fish Stick");
+    const thirdReady = secondReady + DURATION("Fish Oil");
+
+    const state: GameState = {
+      ...BASE_STATE,
+      buildings: {
+        "Fish Market": [
+          {
+            ...(BASE_STATE.buildings["Fish Market"]?.[0] as PlacedItem),
+            processing: [
+              {
+                name: "Fish Oil",
+                readyAt: thirdReady,
+                startedAt: secondReady,
+                requirements: { Anchovy: new Decimal(4) },
+              },
+              {
+                name: "Fish Flake",
+                readyAt: firstReady,
+                startedAt: createdAt,
+                requirements: { Anchovy: new Decimal(2) },
+              },
+              {
+                name: "Fish Stick",
+                readyAt: secondReady,
+                startedAt: firstReady,
+                requirements: {
+                  Anchovy: new Decimal(3),
+                  Porgy: new Decimal(1),
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const updated = cancelProcessedResource({
+      state,
+      action: {
+        type: "processedResource.cancelled",
+        buildingId: "123",
+        buildingName: "Fish Market",
+        queueItem: {
+          name: "Fish Stick",
+          readyAt: secondReady,
+          startedAt: firstReady,
+        },
+      },
+      createdAt,
+    });
+
+    expect(updated.inventory.Anchovy).toEqual(
+      BASE_STATE.inventory.Anchovy?.add(new Decimal(3)),
+    );
+    expect(updated.inventory.Porgy).toEqual(
+      BASE_STATE.inventory.Porgy?.add(new Decimal(1)),
+    );
+
+    const processing = updated.buildings["Fish Market"]?.[0].processing ?? [];
+    expect(processing).toHaveLength(2);
+    expect(processing[0]).toMatchObject({
+      name: "Fish Flake",
+      readyAt: firstReady,
+      startedAt: createdAt,
+    });
+    expect(processing[1]).toMatchObject({
+      name: "Fish Oil",
+      startedAt: firstReady,
+      readyAt: firstReady + DURATION("Fish Oil"),
+    });
+  });
 });

--- a/src/features/game/events/landExpansion/cancelProcessedResource.ts
+++ b/src/features/game/events/landExpansion/cancelProcessedResource.ts
@@ -31,20 +31,13 @@ type Options = {
 };
 
 function getCurrentProcessingItem({
-  building,
+  queue,
   createdAt,
 }: {
-  building: { processing?: BuildingProduct[] };
+  queue: BuildingProduct[];
   createdAt: number;
 }) {
-  const queue = building.processing;
-  const sortedByReadyAt = queue?.sort(
-    (a: BuildingProduct, b: BuildingProduct) => a.readyAt - b.readyAt,
-  );
-
-  if (!queue) return;
-
-  return sortedByReadyAt?.find((item) => item.readyAt > createdAt);
+  return queue.find((item) => item.readyAt > createdAt);
 }
 
 export function assertProcessedFood(name: string): ProcessedResource {
@@ -129,7 +122,12 @@ export function cancelProcessedResource({
       throw new Error("Required building does not exist");
     }
 
-    const queue = building.processing ?? [];
+    // Server-loaded processing arrays are not guaranteed to be chronological.
+    // Work from an ordered copy so queue indices stay stable while identifying
+    // the active and cancelled products, and so recalculation preserves the chain.
+    const queue = [...(building.processing ?? [])].sort(
+      (a, b) => a.readyAt - b.readyAt,
+    );
 
     if (!queue.length) {
       throw new Error("No queue exists");
@@ -144,7 +142,7 @@ export function cancelProcessedResource({
     }
 
     const currentProcessingItem = getCurrentProcessingItem({
-      building,
+      queue,
       createdAt,
     });
 


### PR DESCRIPTION
## Problem

https://discord.com/channels/880987707214544966/1347190192745742336/1546507600151974048

Cancelling a queued Fish Market product can stop working after the game is refreshed. The confirmation modal closes, but the selected product remains in the queue and its ingredients are not refunded.

The Fish Market UI displays a copy sorted by `readyAt`, while the cancellation reducer previously looked up `productIndex` in the stored array and then sorted that same array in place while finding the active product. When a server-loaded processing array was not chronological, the saved index no longer referred to the selected product. The reducer could therefore treat the wrong product as active, refund the wrong requirements, or remove the wrong queue entry.

## Solution

- Create a chronological copy of the processing queue before identifying the selected and active products.
- Stop sorting the reducer queue in place inside `getCurrentProcessingItem`.
- Pass the same ordered queue through identification, removal, and queue-time recalculation so indices remain stable.
- Add regression coverage using a non-chronological server-loaded Fish Market queue and verify the selected product, refund, and recalculated ready times.

## Validation

- `yarn test src/features/game/events/landExpansion/cancelProcessedResource.test.ts src/features/game/events/landExpansion/speedUpProcessing.test.ts src/features/game/events/landExpansion/processResource.test.ts src/features/game/events/landExpansion/collectProcessedResource.test.ts --runInBand` (42 tests passed)
- `yarn tsc --noEmit`
- ESLint on the two changed files
- Prettier check on the two changed files
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed resource cancellation when the processing queue is not in chronological order.
  - Ensured the selected product is removed, requirements are refunded, and remaining items retain the correct order.
  - Corrected recalculation of processing start and ready times after cancellation.

- **Tests**
  - Added regression coverage for cancellation and queue reordering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->