### PR TITLE
[FIX] Barn / Hen House: align the bulk-sell disc and scale the skull icon correctly

### DIFF
--- a/src/features/barn/BarnInside.tsx
+++ b/src/features/barn/BarnInside.tsx
@@ -356,8 +356,11 @@ export const BarnInside: React.FC = () => {
                   <div
                     role="button"
                     aria-label="Sell Animals"
-                    className="absolute top-[18px] cursor-pointer z-10 hover:img-highlight"
+                    className="absolute cursor-pointer z-10 hover:img-highlight"
                     style={{
+                      // The shop disc has a 2px bag sprite above its disc, so its disc face sits
+                      // 2 native px lower than the plain disc. Match that so the two discs line up.
+                      top: `${18 + PIXEL_SCALE * 2}px`,
                       width: `${PIXEL_SCALE * 18}px`,
                       right: `${18 + PIXEL_SCALE * 19}px`,
                     }}
@@ -368,7 +371,7 @@ export const BarnInside: React.FC = () => {
                       className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
                       src={SUNNYSIDE.icons.death}
                       alt=""
-                      style={{ width: `${PIXEL_SCALE * 9}px` }}
+                      style={{ width: `${PIXEL_SCALE * 7}px` }}
                     />
                   </div>
 

--- a/src/features/henHouse/HenHouseInside.tsx
+++ b/src/features/henHouse/HenHouseInside.tsx
@@ -246,8 +246,11 @@ export const HenHouseInside: React.FC = () => {
                   <div
                     role="button"
                     aria-label="Sell Animals"
-                    className="absolute top-[18px] cursor-pointer z-10 hover:img-highlight"
+                    className="absolute cursor-pointer z-10 hover:img-highlight"
                     style={{
+                      // The shop disc has a 2px bag sprite above its disc, so its disc face sits
+                      // 2 native px lower than the plain disc. Match that so the two discs line up.
+                      top: `${18 + PIXEL_SCALE * 2}px`,
                       width: `${PIXEL_SCALE * 18}px`,
                       right: `${18 + PIXEL_SCALE * 19}px`,
                     }}
@@ -258,7 +261,7 @@ export const HenHouseInside: React.FC = () => {
                       className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
                       src={SUNNYSIDE.icons.death}
                       alt=""
-                      style={{ width: `${PIXEL_SCALE * 9}px` }}
+                      style={{ width: `${PIXEL_SCALE * 7}px` }}
                     />
                   </div>
 


### PR DESCRIPTION
## Summary
- The bulk-sell (skull) disc in the Barn and Hen House sat higher than the buy (shop) disc next to it. The shop disc sprite is 18x21 with a 2px bag above the disc, while the plain disc is 18x19, so pinning both to the same top offset misaligned the disc faces. The sell disc now sits 2 native px lower so the rims line up.
- The skull icon is 7px wide natively but was rendered at a 9px width, giving a non-integer upscale that made its pixels much larger than the shop icon's. It now renders at its native width times the pixel scale.

## Test plan
- [x] Prettier and eslint pass on both files
- [x] Verified in the running game (art mode, static offline farm): both disc rims are at the same Y in the DOM, and the skull is centred on the disc with pixels matching the neighbouring icon
- [ ] Open the Barn and Hen House and confirm the skull disc lines up with the shop disc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the “Sell Animals” button positioning to align with the shop button.
  - Resized the skull icon on the button for improved visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->