### PR TITLE
[FEAT] Remove beta flag from recent gift flowers shortlist

### DIFF
--- a/src/features/world/ui/deliveries/BumpkinDelivery.tsx
+++ b/src/features/world/ui/deliveries/BumpkinDelivery.tsx
@@ -73,7 +73,7 @@ import { hasReputation, Reputation } from "features/game/lib/reputation";
 import { getCountAndType } from "features/island/hud/components/inventory/utils/inventory";
 import { getChapterTaskPoints } from "features/game/types/tracks";
 import chapterPointsIcon from "assets/icons/red_medal_short.webp";
-import { hasFeatureAccess, hasTimeBasedFeatureAccess } from "lib/flags";
+import { hasTimeBasedFeatureAccess } from "lib/flags";
 
 const OrderCard: React.FC<{
   order: Order;
@@ -468,17 +468,11 @@ export const Gifts: React.FC<{
     )
     .sort((a, b) => getKeys(FLOWERS).indexOf(a) - getKeys(FLOWERS).indexOf(b));
 
-  // Beta-gated: the recent-gifts shortlist UX is still being validated.
-  const hasRecentGiftFlowersAccess = hasFeatureAccess(
-    game,
-    "RECENT_GIFT_FLOWERS",
-  );
-
   // No favoriting step: the shortlist is derived from this NPC's own gift
   // history (most recent first), so it's populated automatically the moment
   // the player has gifted them anything.
   const [recentFlowers, setRecentFlowers] = useState<FlowerName[]>(() =>
-    hasRecentGiftFlowersAccess ? getRecentGiftFlowers(name) : [],
+    getRecentGiftFlowers(name),
   );
   const recentOwnedFlowers = recentFlowers.filter((flower) =>
     flowers.includes(flower),
@@ -501,7 +495,7 @@ export const Gifts: React.FC<{
     const difference =
       (state.context.state.npcs?.[name]?.friendship?.points ?? 0) - previous;
 
-    if (hasRecentGiftFlowersAccess && selected) {
+    if (selected) {
       const updated = recordRecentGiftFlower(name, selected);
       setRecentFlowers(updated);
     }
@@ -601,7 +595,7 @@ export const Gifts: React.FC<{
         )}
         {flowers.length > 0 && (
           <>
-            {hasRecentGiftFlowersAccess && recentOwnedFlowers.length > 0 && (
+            {recentOwnedFlowers.length > 0 && (
               <>
                 <Label
                   type="default"

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -205,12 +205,6 @@ const FEATURE_FLAGS = {
   // Beta testers can grab a Yakkamon pre-registration code before the level
   // tiers open to everyone else. The server enforces the same rule.
   YAKKAMON_BETA_ACCESS: betaFeatureFlag,
-
-  // Surfaces the 3 flowers most recently gifted to each NPC as a quick-pick
-  // shortlist in the gift flow, with no manual favoriting step. Client-side
-  // only (localStorage), but still gated behind beta access while the UX is
-  // validated.
-  RECENT_GIFT_FLOWERS: betaFeatureFlag,
 } satisfies Record<string, FeatureFlag>;
 
 export type FeatureName = keyof typeof FEATURE_FLAGS;


### PR DESCRIPTION
## Problem

The recent-gifts quick-pick shortlist (3 most recently gifted flowers per NPC) in the gift flow was still gated behind `RECENT_GIFT_FLOWERS`, a `betaFeatureFlag` in `flags.ts`, while the UX was being validated.

## Solution

- Remove the `RECENT_GIFT_FLOWERS` entry from `FEATURE_FLAGS` in `src/lib/flags.ts`.
- Remove all `hasRecentGiftFlowersAccess` checks in `src/features/world/ui/deliveries/BumpkinDelivery.tsx` (Gifts component): the recent-flowers list is now always populated, recorded on gift, and shown in the UI.
- Drop the now-unused `hasFeatureAccess` import.

## Validation

- `yarn tsc --noEmit`
- ESLint / Prettier via pre-commit hook on the changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Recently gifted flowers are now consistently available in the flower-gifting experience.
  - Gifted flowers are automatically saved to the recent-gifts list.
  - The recent-gifts section appears whenever recently gifted flowers are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->