### PR TITLE
feat(analytics): revenue, FTUE and economy_transaction instrumentation

### DIFF
--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -13,6 +13,7 @@ import {
   trackTutorialStep,
   type TutorialAuthMethod,
 } from "lib/moonforgeTutorial";
+import { markSignupPending } from "lib/moonforgeAnalytics";
 import type { loadSession } from "features/game/actions/loadSession";
 import { getToken, removeJWT, saveJWT } from "../actions/social";
 import { signUp, type UTM } from "../actions/signup";
@@ -55,6 +56,34 @@ function trackAuthCompleted(method: TutorialAuthMethod) {
 
 const trackWalletAuthCompleted = () => trackAuthCompleted("wallet");
 const trackAccountAuthCompleted = () => trackAuthCompleted("account");
+
+/**
+ * Leave a marker that a signup just finished, for the game machine to emit as
+ * `account_created` once the player is identified. The token from `signUp`
+ * carries the new `farmId` (so the marker is scoped to it), the SSO `provider`
+ * (absent for wallet sessions) and `email`, which map to the locked
+ * `signup_method` enum.
+ *
+ * Fires from `creating.onDone` (the account genuinely exists), never from
+ * `authorising` (only authorised) or from pressing a welcome-screen button
+ * (only intent).
+ */
+const markSignupCompleted = (
+  _: unknown,
+  event: { data: { token: string } },
+) => {
+  const token = decodeToken(event.data.token);
+  if (token.farmId === undefined) return;
+
+  const provider = token.provider;
+
+  markSignupPending(
+    token.farmId,
+    provider
+      ? { signup_method: "social", provider }
+      : { signup_method: token.email ? "email" : "platform" },
+  );
+};
 
 const getFarmIdFromUrl = () => {
   const paths = window.location.href.split("/visit/");
@@ -468,7 +497,12 @@ export const authMachine = createMachine(
               target: "connected",
               // The account now genuinely exists - this is where the account
               // path's auth milestone completes.
-              actions: ["assignToken", "saveToken", trackAccountAuthCompleted],
+              actions: [
+                "assignToken",
+                "saveToken",
+                trackAccountAuthCompleted,
+                markSignupCompleted,
+              ],
             },
           ],
           onError: [

--- a/src/features/game/events/claimAirdrop.ts
+++ b/src/features/game/events/claimAirdrop.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import { getKeys } from "lib/object";
 import type { GameState } from "../types/game";
 
@@ -103,6 +104,8 @@ export function claimAirdrop({
     });
   }
 
+  const coinsBefore = game.coins;
+  const sflBefore = game.balance.toNumber();
   game.balance = game.balance.add(airdrop.sfl);
   game.airdrops = game.airdrops.filter((item) => item.id !== action.id);
   game.coins = game.coins + (airdrop.coins ?? 0);
@@ -263,6 +266,11 @@ export function claimAirdrop({
         }
       });
     }
+  });
+
+  mfCurrencyChange("claim_airdrop", "grant", {
+    coin: { before: coinsBefore, after: game.coins },
+    sfl: { before: sflBefore, after: game.balance.toNumber() },
   });
 
   return game;

--- a/src/features/game/events/landExpansion/buyAnimal.ts
+++ b/src/features/game/events/landExpansion/buyAnimal.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import { makeAnimalBuildingKey } from "features/game/lib/animals";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import {
@@ -203,6 +204,7 @@ export function buyAnimal({
       throw new Error("You do not have the capacity for this animal");
     }
 
+    const coinsBefore = copy.coins;
     copy.coins -= price;
 
     copy[buildingKey].animals[action.id] = {
@@ -231,6 +233,10 @@ export function buyAnimal({
       game: copy,
       boostNames: boostsUsed,
       createdAt,
+    });
+
+    mfCurrencyChange("buy_animal", "spend", {
+      coin: { before: coinsBefore, after: copy.coins },
     });
 
     return copy;

--- a/src/features/game/events/landExpansion/buyBiome.ts
+++ b/src/features/game/events/landExpansion/buyBiome.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import { getObjectEntries } from "lib/object";
 import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
 import { trackFarmActivity } from "features/game/types/farmActivity";
@@ -74,6 +75,11 @@ export function buyBiome({
 
     game.inventory[biome] = biomeCount.add(1);
     game.farmActivity = trackFarmActivity(`${biome} Bought`, game.farmActivity);
+
+    mfCurrencyChange("buy_biome", "spend", {
+      sfl: { before: balance.toNumber(), after: game.balance.toNumber() },
+    });
+
     return game;
   });
 }

--- a/src/features/game/events/landExpansion/buyChapterItem.ts
+++ b/src/features/game/events/landExpansion/buyChapterItem.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import type { GameState, InventoryItemName } from "features/game/types/game";
 
 import { produce } from "immer";
@@ -275,6 +276,8 @@ export function buyChapterItem({
     }
 
     // Deduct resources
+    const coinsBefore = currentCoins;
+    const sflBefore = copy.balance.toNumber();
     copy.balance = copy.balance.minus(_sfl);
     if (_sfl.gt(0)) {
       copy.farmActivity = trackFarmActivity(
@@ -331,6 +334,11 @@ export function buyChapterItem({
         },
       };
     }
+
+    mfCurrencyChange("buy_chapter_item", "spend", {
+      coin: { before: coinsBefore, after: copy.coins },
+      sfl: { before: sflBefore, after: copy.balance.toNumber() },
+    });
 
     return copy;
   });

--- a/src/features/game/events/landExpansion/buyDecoration.ts
+++ b/src/features/game/events/landExpansion/buyDecoration.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { detectCollision } from "features/game/expansion/placeable/lib/collisionDetection";
 import { trackFarmActivity } from "features/game/types/farmActivity";
@@ -138,11 +139,16 @@ export function buyDecoration({ state, action }: Options) {
       }
     }
 
+    const coinsBefore = stateCopy.coins;
     stateCopy.coins = stateCopy.coins - price;
     stateCopy.inventory = {
       ...subtractedInventory,
       [name]: oldAmount.add(1),
     };
+
+    mfCurrencyChange("buy_decoration", "spend", {
+      coin: { before: coinsBefore, after: stateCopy.coins },
+    });
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/buyFactionShopItem.ts
+++ b/src/features/game/events/landExpansion/buyFactionShopItem.ts
@@ -1,5 +1,5 @@
 import Decimal from "decimal.js-light";
-import { mfEconomy } from "lib/moonforgeAnalytics";
+import { mfEconomy, type EconomyRow } from "lib/moonforgeAnalytics";
 import type { BumpkinItem } from "features/game/types/bumpkin";
 import {
   type FactionShopItemName,
@@ -65,6 +65,10 @@ export function buyFactionShopItem({
         BUY_FACTION_SHOP_ITEM_ERRORS.PLAYER_NOT_IN_REQUIRED_FACTION,
       );
     }
+    // Burning a prerequisite wearable is a sink, so its balance is captured
+    // here and reported alongside the Mark spend below.
+    let prerequisiteRow: EconomyRow | undefined;
+
     if (item.requires) {
       const currentWardrobe = wardrobe[item.requires as BumpkinItem] ?? 0;
       if (
@@ -80,6 +84,11 @@ export function buyFactionShopItem({
         throw new Error(BUY_FACTION_SHOP_ITEM_ERRORS.NOT_ENOUGH_PREREQUISITE);
       }
       wardrobe[item.requires as BumpkinItem] = currentWardrobe - burnAmount;
+      prerequisiteRow = {
+        type: item.requires,
+        before: currentWardrobe,
+        after: currentWardrobe - burnAmount,
+      };
     }
 
     const marksBalance = inventory["Mark"] ?? new Decimal(0);
@@ -143,6 +152,7 @@ export function buyFactionShopItem({
           before: marksBalance.toNumber(),
           after: marksBalance.minus(price).toNumber(),
         },
+        ...(prerequisiteRow ? [prerequisiteRow] : []),
       ],
       outputs: [{ type: action.item }],
     });

--- a/src/features/game/events/landExpansion/buyFactionShopItem.ts
+++ b/src/features/game/events/landExpansion/buyFactionShopItem.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import type { BumpkinItem } from "features/game/types/bumpkin";
 import {
   type FactionShopItemName,
@@ -134,6 +135,17 @@ export function buyFactionShopItem({
       `${action.item} Bought`,
       stateCopy.farmActivity,
     );
+
+    mfEconomy("buy_faction_shop_item", {
+      inputs: [
+        {
+          type: "Mark",
+          before: marksBalance.toNumber(),
+          after: marksBalance.minus(price).toNumber(),
+        },
+      ],
+      outputs: [{ type: action.item }],
+    });
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/buyMonument.ts
+++ b/src/features/game/events/landExpansion/buyMonument.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { detectCollision } from "features/game/expansion/placeable/lib/collisionDetection";
 import { trackFarmActivity } from "features/game/types/farmActivity";
@@ -113,11 +114,16 @@ export function buyMonument({ state, action }: Options) {
       });
     }
 
+    const coinsBefore = stateCopy.coins;
     stateCopy.coins = stateCopy.coins - price;
     stateCopy.inventory = {
       ...subtractedInventory,
       [name]: oldAmount.add(1),
     };
+
+    mfCurrencyChange("buy_monument", "spend", {
+      coin: { before: coinsBefore, after: stateCopy.coins },
+    });
 
     stateCopy.socialFarming.villageProjects = {
       ...stateCopy.socialFarming.villageProjects,

--- a/src/features/game/events/landExpansion/buyMoreDigs.ts
+++ b/src/features/game/events/landExpansion/buyMoreDigs.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import type { GameState } from "features/game/types/game";
 
 import { produce } from "immer";
@@ -29,6 +30,23 @@ export function buyMoreDigs({ state }: Options) {
     game.inventory["Gem"] = gems.sub(10);
 
     game.desert.digging.extraDigs = extraDigs + EXTRA_DIGS_AMOUNT;
+
+    mfEconomy("buy_more_digs", {
+      inputs: [
+        {
+          type: "Gem",
+          before: gems.toNumber(),
+          after: gems.sub(10).toNumber(),
+        },
+      ],
+      outputs: [
+        {
+          type: "dig",
+          before: extraDigs,
+          after: extraDigs + EXTRA_DIGS_AMOUNT,
+        },
+      ],
+    });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/buyResource.ts
+++ b/src/features/game/events/landExpansion/buyResource.ts
@@ -3,6 +3,7 @@ import type { GameState, InventoryItemName } from "../../types/game";
 
 import { produce } from "immer";
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 import { getObjectEntries } from "lib/object";
 import type { IslandType } from "features/game/types/game";
@@ -147,6 +148,19 @@ export function buyResource({
       `${action.name} Bought`,
       game.farmActivity,
     );
+
+    mfEconomy("buy_resource", {
+      inputs: [
+        {
+          type: "Sunstone",
+          before: sunstones.toNumber(),
+          after: game.inventory.Sunstone.toNumber(),
+        },
+      ],
+      outputs: getObjectEntries(node.items).map(([item]) => ({
+        type: item as string,
+      })),
+    });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/buyWearable.ts
+++ b/src/features/game/events/landExpansion/buyWearable.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import { SFLDiscount } from "features/game/lib/SFLDiscount";
 import { ARTEFACT_SHOP_WEARABLES } from "features/game/types/artefactShop";
 import type { BumpkinItem } from "features/game/types/bumpkin";
@@ -90,10 +91,15 @@ export function buyWearable({
     );
 
     const oldAmount = stateCopy.wardrobe[name] ?? 0;
+    const coinsBefore = stateCopy.coins;
 
     stateCopy.coins = stateCopy.coins - price;
     stateCopy.wardrobe[name] = oldAmount + 1;
     stateCopy.inventory = subtractedInventory;
+
+    mfCurrencyChange("buy_wearable", "spend", {
+      coin: { before: coinsBefore, after: stateCopy.coins },
+    });
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/chop.ts
+++ b/src/features/game/events/landExpansion/chop.ts
@@ -548,11 +548,20 @@ export function chop({
         stateCopy.coins + treeReward.coins * (tree.multiplier ?? 1);
     }
 
+    // Reward items are a faucet in their own right, so each one is recorded
+    // as an output with the balances either side of the credit.
+    const rewardRows: { type: string; before?: number; after?: number }[] = [];
+
     if (treeReward?.items) {
       treeReward.items.forEach((item) => {
-        stateCopy.inventory[item.name] = (
-          stateCopy.inventory[item.name] || new Decimal(0)
-        ).add(item.amount);
+        const before = stateCopy.inventory[item.name] || new Decimal(0);
+        const after = before.add(item.amount);
+        stateCopy.inventory[item.name] = after;
+        rewardRows.push({
+          type: item.name,
+          before: before.toNumber(),
+          after: after.toNumber(),
+        });
       });
     }
 
@@ -581,6 +590,7 @@ export function chop({
         after: stateCopy.coins,
       });
     }
+    chopOutputs.push(...rewardRows);
     mfEconomy("chop_tree", {
       inputs: new Decimal(requiredAxes).gt(0)
         ? [

--- a/src/features/game/events/landExpansion/chop.ts
+++ b/src/features/game/events/landExpansion/chop.ts
@@ -29,7 +29,7 @@ import type {
 import { updateBoostUsed } from "features/game/types/updateBoostUsed";
 import { produce } from "immer";
 import { prngChance } from "lib/prng";
-import { mfTrack } from "lib/moonforgeAnalytics";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 
 export enum CHOP_ERRORS {
   MISSING_AXE = "No axe",
@@ -530,6 +530,8 @@ export function chop({
     inventory.Axe = axeAmount.sub(requiredAxes);
     inventory.Wood = woodAmount.add(woodHarvested);
 
+    const coinsBefore = stateCopy.coins;
+
     // Apply reward: honor legacy stored reward OR calculate new one via PRNG
     const { reward: treeReward, boostsUsed: rewardBoostsUsed } = tree.wood
       .reward
@@ -565,9 +567,31 @@ export function chop({
       stateCopy.farmActivity,
     );
 
-    mfTrack("resource_collected", {
-      resource_type: "Wood",
-      amount: Number(woodHarvested),
+    const chopOutputs: { type: string; before?: number; after?: number }[] = [
+      {
+        type: "Wood",
+        before: woodAmount.toNumber(),
+        after: inventory.Wood.toNumber(),
+      },
+    ];
+    if (stateCopy.coins !== coinsBefore) {
+      chopOutputs.push({
+        type: "Coin",
+        before: coinsBefore,
+        after: stateCopy.coins,
+      });
+    }
+    mfEconomy("chop_tree", {
+      inputs: new Decimal(requiredAxes).gt(0)
+        ? [
+            {
+              type: "Axe",
+              before: axeAmount.toNumber(),
+              after: inventory.Axe.toNumber(),
+            },
+          ]
+        : undefined,
+      outputs: chopOutputs,
     });
 
     delete tree.wood.amount;

--- a/src/features/game/events/landExpansion/claimAchievement.ts
+++ b/src/features/game/events/landExpansion/claimAchievement.ts
@@ -8,7 +8,7 @@ import type { GameState } from "features/game/types/game";
 import { onboardingAnalytics } from "lib/onboardingAnalytics";
 import { translate } from "lib/i18n/translate";
 import { produce } from "immer";
-import { mfTrack } from "lib/moonforgeAnalytics";
+import { mfCurrencyChange, mfTrack } from "lib/moonforgeAnalytics";
 
 export type ClaimAchievementAction = {
   type: "achievement.claimed";
@@ -42,6 +42,7 @@ export function claimAchievement({ state, action }: Options): GameState {
 
     bumpkin.achievements = { ...bumpkinAchievements, [action.achievement]: 1 };
 
+    const coinsBefore = stateCopy.coins;
     if (achievement.coins) {
       stateCopy.coins = stateCopy.coins + achievement.coins;
     }
@@ -61,6 +62,9 @@ export function claimAchievement({ state, action }: Options): GameState {
       achievement_id: action.achievement,
     });
     mfTrack("achievement_unlocked", { achievement_id: action.achievement });
+    mfCurrencyChange("achievement_reward", "grant", {
+      coin: { before: coinsBefore, after: stateCopy.coins },
+    });
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/claimBumpkinGift.ts
+++ b/src/features/game/events/landExpansion/claimBumpkinGift.ts
@@ -4,6 +4,7 @@ import { BUMPKIN_GIFTS, type BumpkinGift } from "features/game/types/gifts";
 import { getKeys } from "lib/object";
 import Decimal from "decimal.js-light";
 import { produce } from "immer";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import {
   type RecipeCollectibleName,
   RECIPES,
@@ -141,7 +142,12 @@ export function claimGift({ state, action, createdAt = Date.now() }: Options) {
       });
     }
 
+    const coinsBefore = game.coins;
     game.coins = game.coins + nextGift.coins;
+
+    mfCurrencyChange("bumpkin_gift", "grant", {
+      coin: { before: coinsBefore, after: game.coins },
+    });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/claimDailyReward.ts
+++ b/src/features/game/events/landExpansion/claimDailyReward.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import type {
   DailyRewards,
   GameState,
@@ -141,6 +142,9 @@ export function claimDailyReward({
       now: createdAt,
     });
 
+    const coinsBefore = game.coins;
+    const sflBefore = game.balance.toNumber();
+
     rewards.forEach((reward) => applyReward(game, reward, createdAt));
 
     // VIP bonus daily reward (1 consumable based on level)
@@ -187,6 +191,11 @@ export function claimDailyReward({
       game,
       boostNames: boosts,
       createdAt,
+    });
+
+    mfCurrencyChange("daily_reward", "grant", {
+      coin: { before: coinsBefore, after: game.coins },
+      sfl: { before: sflBefore, after: game.balance.toNumber() },
     });
   });
 }

--- a/src/features/game/events/landExpansion/claimFactionPrize.ts
+++ b/src/features/game/events/landExpansion/claimFactionPrize.ts
@@ -2,6 +2,7 @@ import Decimal from "decimal.js-light";
 import { getKeys } from "lib/object";
 import type { GameState } from "features/game/types/game";
 import { produce } from "immer";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 
 export type ClaimFactionPrizeAction = {
   type: "faction.prizeClaimed";
@@ -30,6 +31,8 @@ export function claimFactionPrize({
     }
 
     const reward = week.results.reward;
+    const coinsBefore = game.coins;
+    const sflBefore = game.balance.toNumber();
 
     game.balance = game.balance.add(reward.sfl);
     game.coins = game.coins + reward.coins;
@@ -40,6 +43,11 @@ export function claimFactionPrize({
     });
 
     week.results.claimedAt = createdAt;
+
+    mfCurrencyChange("faction_prize", "grant", {
+      coin: { before: coinsBefore, after: game.coins },
+      sfl: { before: sflBefore, after: game.balance.toNumber() },
+    });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/claimReferralRewards.ts
+++ b/src/features/game/events/landExpansion/claimReferralRewards.ts
@@ -2,6 +2,7 @@ import Decimal from "decimal.js-light";
 import { getObjectEntries } from "lib/object";
 import type { GameState } from "features/game/types/game";
 import { produce } from "immer";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 
 export type ClaimReferralRewardsAction = {
   type: "referral.rewardsClaimed";
@@ -45,6 +46,9 @@ export function claimReferralRewards({
       });
     }
 
+    const coinsBefore = copy.coins;
+    const sflBefore = copy.balance.toNumber();
+
     //   Add rewards to balance
     if (sfl) {
       copy.balance = copy.balance.add(sfl);
@@ -58,6 +62,11 @@ export function claimReferralRewards({
     //   Delete rewards
     delete copy.referrals?.rewards;
     delete copy.referrals?.totalUnclaimedReferrals;
+
+    mfCurrencyChange("referral_reward", "grant", {
+      coin: { before: coinsBefore, after: copy.coins },
+      sfl: { before: sflBefore, after: copy.balance.toNumber() },
+    });
 
     return copy;
   });

--- a/src/features/game/events/landExpansion/claimTrackMilestone.ts
+++ b/src/features/game/events/landExpansion/claimTrackMilestone.ts
@@ -1,5 +1,6 @@
 import Decimal from "decimal.js-light";
 import { produce } from "immer";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import type { GameState, InventoryItemName } from "../../types/game";
 import { CHAPTER_TRACKS, type TrackName } from "features/game/types/tracks";
 import {
@@ -80,6 +81,9 @@ export function claimTrackMilestone({
       });
     }
 
+    const coinsBefore = game.coins;
+    const sflBefore = game.balance.toNumber();
+
     if (rewards.coins) {
       game.coins += rewards.coins;
     }
@@ -102,6 +106,11 @@ export function claimTrackMilestone({
       track: action.track,
       milestone: nextMilestone + 1,
       daysSinceStart,
+    });
+
+    mfCurrencyChange("track_milestone", "grant", {
+      coin: { before: coinsBefore, after: game.coins },
+      sfl: { before: sflBefore, after: game.balance.toNumber() },
     });
 
     return game;

--- a/src/features/game/events/landExpansion/claimVipReferralMilestones.ts
+++ b/src/features/game/events/landExpansion/claimVipReferralMilestones.ts
@@ -1,5 +1,6 @@
 import Decimal from "decimal.js-light";
 import { produce } from "immer";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import { getObjectEntries } from "lib/object";
 import type { GameState } from "features/game/types/game";
 import { VIP_REFERRAL_MILESTONES } from "features/game/lib/vipReferralMilestones";
@@ -68,6 +69,9 @@ export function claimVipReferralMilestones({
       });
     }
 
+    const coinsBefore = copy.coins;
+    const sflBefore = copy.balance.toNumber();
+
     if (sfl) {
       copy.balance = copy.balance.add(sfl);
     }
@@ -79,5 +83,10 @@ export function claimVipReferralMilestones({
     // Record the milestone as claimed (with the time it was claimed at) so it
     // cannot be claimed again.
     referrals.vipMilestonesClaimed = { ...claimed, [milestone]: createdAt };
+
+    mfCurrencyChange("vip_referral_milestone", "grant", {
+      coin: { before: coinsBefore, after: copy.coins },
+      sfl: { before: sflBefore, after: copy.balance.toNumber() },
+    });
   });
 }

--- a/src/features/game/events/landExpansion/collectRecipe.ts
+++ b/src/features/game/events/landExpansion/collectRecipe.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import { KNOWN_IDS } from "features/game/types";
 import type { BuildingName } from "features/game/types/buildings";
 import { trackFarmActivity } from "features/game/types/farmActivity";
@@ -172,6 +173,16 @@ export function collectRecipe({
           const consumableCount =
             game.inventory[cookableName] || new Decimal(0);
           game.inventory[cookableName] = consumableCount.add(amount);
+
+          mfEconomy("collect_recipe", {
+            outputs: [
+              {
+                type: cookableName,
+                before: consumableCount.toNumber(),
+                after: consumableCount.add(amount).toNumber(),
+              },
+            ],
+          });
 
           game.farmActivity = trackFarmActivity(
             `${cookableName} Cooked`,

--- a/src/features/game/events/landExpansion/completeNPCChore.ts
+++ b/src/features/game/events/landExpansion/completeNPCChore.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import type {
   BoostName,
   GameState,
@@ -168,6 +169,7 @@ export function completeNPCChore({
       ).add(amount);
     });
 
+    const coinsBefore = draft.coins;
     if (chore.reward.coins) {
       draft.coins += chore.reward.coins;
     }
@@ -227,6 +229,10 @@ export function completeNPCChore({
         );
       }
     }
+
+    mfCurrencyChange("npc_chore", "grant", {
+      coin: { before: coinsBefore, after: draft.coins },
+    });
 
     return draft;
   });

--- a/src/features/game/events/landExpansion/completeSpecialEventTask.ts
+++ b/src/features/game/events/landExpansion/completeSpecialEventTask.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import { getKeys } from "lib/object";
 import type { GameState } from "features/game/types/game";
 import { produce } from "immer";
@@ -97,6 +98,8 @@ export function completeSpecialEventTask({
       const rewardAmount = task.reward.wearables[item] ?? 0;
       stateCopy.wardrobe[item] = (stateCopy.wardrobe[item] ?? 0) + rewardAmount;
     });
+    const coinsBefore = stateCopy.coins;
+    const sflBefore = (stateCopy.balance ?? new Decimal(0)).toNumber();
     stateCopy.balance = (stateCopy.balance ?? new Decimal(0)).plus(
       task.reward.sfl,
     );
@@ -113,6 +116,11 @@ export function completeSpecialEventTask({
     stateCopy.specialEvents.history[eventYear][action.event] = Math.floor(
       (completedTasks / totalTasks) * 100,
     );
+
+    mfCurrencyChange("special_event_task", "grant", {
+      coin: { before: coinsBefore, after: stateCopy.coins },
+      sfl: { before: sflBefore, after: stateCopy.balance.toNumber() },
+    });
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/completeSpecialEventTask.ts
+++ b/src/features/game/events/landExpansion/completeSpecialEventTask.ts
@@ -68,6 +68,15 @@ export function completeSpecialEventTask({
     const balance = stateCopy.balance;
     if (balance.lt(sfl)) throw new Error("SFL requirement not met");
     stateCopy.balance = balance.minus(sfl);
+
+    // The SFL requirement is a sink and is reported separately from the
+    // reward below, so the two do not net out into a single misleading row.
+    // `mfCurrencyChange` drops no-op rows, so a task with no SFL cost emits
+    // nothing here.
+    mfCurrencyChange("special_event_task_requirement", "spend", {
+      sfl: { before: balance.toNumber(), after: stateCopy.balance.toNumber() },
+    });
+
     if (sfl > 0) {
       stateCopy.farmActivity = trackFarmActivity(
         "FLOWER Spent",

--- a/src/features/game/events/landExpansion/cook.ts
+++ b/src/features/game/events/landExpansion/cook.ts
@@ -342,11 +342,17 @@ export function cook({
     );
 
     mfEconomy("cook_food", {
-      inputs: Object.entries(ingredients).map(([ingredient, amount]) => {
+      inputs: Object.entries(ingredients).map(([ingredient]) => {
         const before = (
           inventoryBeforeCook[ingredient as InventoryItemName] ?? new Decimal(0)
         ).toNumber();
-        return { type: ingredient, before, after: before - Number(amount) };
+        // Read the post-deduction balance back off the inventory rather than
+        // doing the subtraction in JS floats, which drifts on fractional
+        // ingredient amounts.
+        const after = (
+          stateCopy.inventory[ingredient as InventoryItemName] ?? new Decimal(0)
+        ).toNumber();
+        return { type: ingredient, before, after };
       }),
       outputs: [{ type: item }],
     });

--- a/src/features/game/events/landExpansion/cook.ts
+++ b/src/features/game/events/landExpansion/cook.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import { v4 as uuidv4 } from "uuid";
 import {
   type CookableName,
@@ -321,6 +322,8 @@ export function cook({
 
     const { oilConsumed } = getCookingOilBoost(item, stateCopy, buildingId);
 
+    const inventoryBeforeCook = stateCopy.inventory;
+
     stateCopy.inventory = Object.entries(ingredients).reduce(
       (inventory, [ingredient, amount]) => {
         const count =
@@ -337,6 +340,16 @@ export function cook({
       },
       stateCopy.inventory,
     );
+
+    mfEconomy("cook_food", {
+      inputs: Object.entries(ingredients).map(([ingredient, amount]) => {
+        const before = (
+          inventoryBeforeCook[ingredient as InventoryItemName] ?? new Decimal(0)
+        ).toNumber();
+        return { type: ingredient, before, after: before - Number(amount) };
+      }),
+      outputs: [{ type: item }],
+    });
 
     if (isInstantFishRecipe(item)) {
       const { amount, boostsUsed } = getCookingAmount({

--- a/src/features/game/events/landExpansion/craftCollectible.ts
+++ b/src/features/game/events/landExpansion/craftCollectible.ts
@@ -24,7 +24,7 @@ import {
   type PetShopItemName,
 } from "features/game/types/petShop";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
-import { mfTrack } from "lib/moonforgeAnalytics";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 
 type CraftableCollectibleItem =
   | HeliosBlacksmithItem
@@ -185,6 +185,7 @@ export function craftCollectible({
       });
     }
 
+    const coinsBefore = stateCopy.coins;
     stateCopy.coins = stateCopy.coins - price;
 
     stateCopy.farmActivity = trackFarmActivity(
@@ -231,7 +232,33 @@ export function craftCollectible({
       };
     }
 
-    mfTrack("item_crafted", { item_id: action.name, cost_coins: price });
+    const craftInputs: { type: string; before?: number; after?: number }[] = [];
+    if (price > 0) {
+      craftInputs.push({
+        type: "Coin",
+        before: coinsBefore,
+        after: stateCopy.coins,
+      });
+    }
+    getKeys(item.ingredients).forEach((ingredientName) => {
+      const spent = item.ingredients[ingredientName] ?? new Decimal(0);
+      const after = subtractedInventory[ingredientName] ?? new Decimal(0);
+      craftInputs.push({
+        type: ingredientName,
+        before: after.add(spent).toNumber(),
+        after: after.toNumber(),
+      });
+    });
+    mfEconomy("craft_collectible", {
+      inputs: craftInputs,
+      outputs: [
+        {
+          type: action.name,
+          before: oldAmount.toNumber(),
+          after: oldAmount.add(1).toNumber(),
+        },
+      ],
+    });
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/craftTool.ts
+++ b/src/features/game/events/landExpansion/craftTool.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import {
   type TreasureToolName,
   TREASURE_TOOLS,
@@ -196,6 +197,7 @@ export function craftTool({ state, action }: Options) {
     new Decimal(amount),
   );
 
+  const coinsBefore = stateCopy.coins;
   stateCopy.coins = stateCopy.coins - price;
   stateCopy.farmActivity = trackFarmActivity(
     "Coins Spent",
@@ -212,6 +214,37 @@ export function craftTool({ state, action }: Options) {
   if (stock !== undefined) {
     stateCopy.stock[action.tool] = stock.minus(amount);
   }
+
+  const craftInputs: { type: string; before?: number; after?: number }[] = [];
+  if (price > 0) {
+    craftInputs.push({
+      type: "Coin",
+      before: coinsBefore,
+      after: stateCopy.coins,
+    });
+  }
+  getObjectEntries(toolIngredients).forEach(
+    ([ingredientName, ingredientAmount]) => {
+      const spent = (ingredientAmount ?? new Decimal(0)).mul(amount);
+      const after = subtractedInventory[ingredientName] ?? new Decimal(0);
+      craftInputs.push({
+        type: ingredientName,
+        before: after.add(spent).toNumber(),
+        after: after.toNumber(),
+      });
+    },
+  );
+
+  mfEconomy("craft_tool", {
+    inputs: craftInputs.length > 0 ? craftInputs : undefined,
+    outputs: [
+      {
+        type: action.tool,
+        before: oldAmount.toNumber(),
+        after: oldAmount.add(amount).toNumber(),
+      },
+    ],
+  });
 
   return stateCopy;
 }

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -40,7 +40,7 @@ import { getCountAndType } from "features/island/hud/components/inventory/utils/
 import { getChapterTaskPoints } from "features/game/types/tracks";
 import { handleChapterAnalytics } from "features/game/lib/trackAnalytics";
 import { hasTimeBasedFeatureAccess } from "lib/flags";
-import { mfTrack } from "lib/moonforgeAnalytics";
+import { mfEconomy, mfTrack } from "lib/moonforgeAnalytics";
 
 export const TICKET_REWARDS: Record<QuestNPCName, number> = {
   "pumpkin' pete": 1,
@@ -438,6 +438,9 @@ export function deliverOrder({
       throw new Error("Order is already completed");
     }
 
+    const deliveryCoinsBefore = game.coins;
+    const deliverySflBefore = game.balance.toNumber();
+
     const ticketTasksAreFrozen = areBumpkinsOnHoliday(createdAt);
 
     const isQuestTicketOrder = !!TICKET_REWARDS[order.from as QuestNPCName];
@@ -687,6 +690,45 @@ export function deliverOrder({
       npc_id: order.from,
       reward_coins: order.reward.coins ?? 0,
       reward_tickets: ticketsToAward,
+    });
+
+    const deliveryInputs: { type: string; before?: number; after?: number }[] =
+      getKeys(order.items)
+        .filter((name) => name !== "coins" && name !== "sfl")
+        .map((name) => ({ type: name }));
+    const deliveryOutputs: { type: string; before?: number; after?: number }[] =
+      [];
+    const coinDelta = game.coins - deliveryCoinsBefore;
+    if (coinDelta > 0) {
+      deliveryOutputs.push({
+        type: "Coin",
+        before: deliveryCoinsBefore,
+        after: game.coins,
+      });
+    } else if (coinDelta < 0) {
+      deliveryInputs.push({
+        type: "Coin",
+        before: deliveryCoinsBefore,
+        after: game.coins,
+      });
+    }
+    const sflAfter = game.balance.toNumber();
+    if (sflAfter > deliverySflBefore) {
+      deliveryOutputs.push({
+        type: "SFL",
+        before: deliverySflBefore,
+        after: sflAfter,
+      });
+    } else if (sflAfter < deliverySflBefore) {
+      deliveryInputs.push({
+        type: "SFL",
+        before: deliverySflBefore,
+        after: sflAfter,
+      });
+    }
+    mfEconomy("fulfill_delivery", {
+      inputs: deliveryInputs,
+      outputs: deliveryOutputs,
     });
 
     return game;

--- a/src/features/game/events/landExpansion/deliverFactionKitchen.ts
+++ b/src/features/game/events/landExpansion/deliverFactionKitchen.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import { getFactionRankBoostAmount } from "features/game/lib/factionRanks";
 import {
   START_DATE,
@@ -114,6 +115,23 @@ export function deliverFactionKitchen({
     inventory["Mark"] = marksBalance.plus(totalPoints);
 
     request.dailyFulfilled[day] = fulfilledToday + amount;
+
+    mfEconomy("faction_kitchen_delivery", {
+      inputs: [
+        {
+          type: request.item,
+          before: resourceBalance.toNumber(),
+          after: resourceBalance.minus(requestAmount).toNumber(),
+        },
+      ],
+      outputs: [
+        {
+          type: "Mark",
+          before: marksBalance.toNumber(),
+          after: marksBalance.plus(totalPoints).toNumber(),
+        },
+      ],
+    });
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/drillOilReserve.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import {
   isTemporaryCollectibleActive,
   isCollectibleBuilt,
@@ -264,9 +265,8 @@ export function drillOilReserve({
       createdAt,
     );
 
-    game.inventory.Oil = (game.inventory.Oil ?? new Decimal(0)).add(
-      oilDropAmount,
-    );
+    const oilBefore = game.inventory.Oil ?? new Decimal(0);
+    game.inventory.Oil = oilBefore.add(oilDropAmount);
     // Take away one drill
     game.inventory["Oil Drill"] = drillAmount.sub(requiredDrills);
     // Update drilled at time. A fresh drill rebuilds the timer from scratch, so a
@@ -301,6 +301,23 @@ export function drillOilReserve({
         ...boostsUsed,
       ],
       createdAt,
+    });
+
+    mfEconomy("drill_oil", {
+      inputs: [
+        {
+          type: "Oil Drill",
+          before: drillAmount.toNumber(),
+          after: game.inventory["Oil Drill"].toNumber(),
+        },
+      ],
+      outputs: [
+        {
+          type: "Oil",
+          before: oilBefore.toNumber(),
+          after: game.inventory.Oil.toNumber(),
+        },
+      ],
     });
 
     return game;

--- a/src/features/game/events/landExpansion/drillOilReserve.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.ts
@@ -304,13 +304,17 @@ export function drillOilReserve({
     });
 
     mfEconomy("drill_oil", {
-      inputs: [
-        {
-          type: "Oil Drill",
-          before: drillAmount.toNumber(),
-          after: game.inventory["Oil Drill"].toNumber(),
-        },
-      ],
+      // Boosts can make a drill free. Omitting the input then matches how
+      // chop reports a free swing, instead of logging a zero-delta row.
+      inputs: requiredDrills.gt(0)
+        ? [
+            {
+              type: "Oil Drill",
+              before: drillAmount.toNumber(),
+              after: game.inventory["Oil Drill"].toNumber(),
+            },
+          ]
+        : undefined,
       outputs: [
         {
           type: "Oil",

--- a/src/features/game/events/landExpansion/exchangeFLOWER.ts
+++ b/src/features/game/events/landExpansion/exchangeFLOWER.ts
@@ -1,5 +1,6 @@
 import { produce } from "immer";
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import type { GameState } from "features/game/types/game";
 import { isFaceVerified } from "features/retreat/components/personhood/lib/faceRecognition";
 import { trackFarmActivity } from "features/game/types/farmActivity";
@@ -79,6 +80,23 @@ export function exchangeFlower({
       game.farmActivity,
       new Decimal(loveCharmsRequired),
     );
+
+    mfEconomy("exchange_flower", {
+      inputs: [
+        {
+          type: "Love Charm",
+          before: loveCharmsBalance.toNumber(),
+          after: loveCharmsBalance.minus(loveCharmsRequired).toNumber(),
+        },
+      ],
+      outputs: [
+        {
+          type: "FLOWER",
+          before: balance.toNumber(),
+          after: game.balance.toNumber(),
+        },
+      ],
+    });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/exchangeSFLtoCoins.ts
+++ b/src/features/game/events/landExpansion/exchangeSFLtoCoins.ts
@@ -2,6 +2,7 @@ import Decimal from "decimal.js-light";
 import type { GameState } from "features/game/types/game";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 import { produce } from "immer";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 
 type ExchangePackage = { sfl: number; coins: number };
 export type PackageId = 1 | 2 | 3;
@@ -48,6 +49,8 @@ export function exchangeSFLtoCoins({
       throw new Error("Not enough SFL");
     }
 
+    const sflBefore = balance.toNumber();
+    const coinsBefore = game.coins;
     game.balance = balance.minus(sfl);
     game.coins += coins;
     game.farmActivity = trackFarmActivity(
@@ -55,6 +58,13 @@ export function exchangeSFLtoCoins({
       game.farmActivity,
       new Decimal(sfl),
     );
+
+    mfEconomy("exchange_sfl_to_coins", {
+      inputs: [
+        { type: "SFL", before: sflBefore, after: game.balance.toNumber() },
+      ],
+      outputs: [{ type: "Coin", before: coinsBefore, after: game.coins }],
+    });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/expandLand.ts
+++ b/src/features/game/events/landExpansion/expandLand.ts
@@ -7,6 +7,7 @@ import { getKeys } from "lib/object";
 import type { BoostName, GameState } from "features/game/types/game";
 import { onboardingAnalytics } from "lib/onboardingAnalytics";
 import { trackTutorialStep } from "lib/moonforgeTutorial";
+import { mfEconomy, mfTutorialComplete } from "lib/moonforgeAnalytics";
 
 import {
   getExpansionRequirements,
@@ -89,6 +90,8 @@ export function expandLand({ state, createdAt = Date.now() }: Options) {
     if (game.coins < effectiveCoinCost) {
       throw new Error("Insufficient coins");
     }
+    const coinsBefore = game.coins;
+    const resourcesBefore = { ...game.inventory };
     game.coins -= effectiveCoinCost;
     game.farmActivity = trackFarmActivity(
       "Coins Spent",
@@ -123,6 +126,7 @@ export function expandLand({ state, createdAt = Date.now() }: Options) {
     if (game.inventory["Basic Land"]?.eq(3)) {
       onboardingAnalytics.logEvent("tutorial_complete");
       trackTutorialStep("expand_to_3_land");
+      mfTutorialComplete("completed");
     }
 
     //developers.google.com/analytics/devguides/collection/ga4/reference/events?sjid=11955999175679069053-AP&client_type=gtag#level_up
@@ -139,6 +143,26 @@ export function expandLand({ state, createdAt = Date.now() }: Options) {
       boostNames: boostsUsed,
       createdAt,
     });
+
+    const expandInputs: { type: string; before?: number; after?: number }[] =
+      [];
+    if (effectiveCoinCost > 0) {
+      expandInputs.push({
+        type: "Coin",
+        before: coinsBefore,
+        after: game.coins,
+      });
+    }
+    getKeys(requirements.resources).forEach((name) => {
+      const before = (resourcesBefore[name] ?? new Decimal(0)).toNumber();
+      expandInputs.push({
+        type: name,
+        before,
+        after: (game.inventory[name] ?? new Decimal(0)).toNumber(),
+      });
+    });
+    // Input-only: the Basic Land is granted later, on `revealLand`.
+    mfEconomy("expand_land", { inputs: expandInputs });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/feedFactionPet.ts
+++ b/src/features/game/events/landExpansion/feedFactionPet.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import { getFactionRankBoostAmount } from "features/game/lib/factionRanks";
 import {
   START_DATE,
@@ -183,6 +184,23 @@ export function feedFactionPet({
       game: stateCopy,
       boostNames: boostUsed,
       createdAt,
+    });
+
+    mfEconomy("feed_faction_pet", {
+      inputs: [
+        {
+          type: request.food,
+          before: foodBalance.toNumber(),
+          after: foodBalance.minus(requestAmount).toNumber(),
+        },
+      ],
+      outputs: [
+        {
+          type: "Mark",
+          before: marksBalance.toNumber(),
+          after: marksBalance.add(totalAmount).toNumber(),
+        },
+      ],
     });
 
     return stateCopy;

--- a/src/features/game/events/landExpansion/garbageSold.ts
+++ b/src/features/game/events/landExpansion/garbageSold.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import type { BumpkinItem } from "features/game/types/bumpkin";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 import type { GameState, InventoryItemName } from "features/game/types/game";
@@ -96,6 +97,9 @@ export function sellGarbage({ state, action }: Options) {
       }
     }
 
+    const coinsBefore = game.coins;
+    const gemsBefore = inventory.Gem ?? new Decimal(0);
+
     // Handle coins
     const { sellPrice = 0 } = GARBAGE[item];
     if (sellPrice) {
@@ -139,6 +143,34 @@ export function sellGarbage({ state, action }: Options) {
       inventory[item] =
         inventory[item]?.sub(amount) ?? new Decimal(0).sub(amount);
     }
+
+    const garbageOutputs: { type: string; before?: number; after?: number }[] =
+      [];
+    if (game.coins !== coinsBefore) {
+      garbageOutputs.push({
+        type: "Coin",
+        before: coinsBefore,
+        after: game.coins,
+      });
+    }
+    const gemsAfter = inventory.Gem ?? new Decimal(0);
+    if (!gemsAfter.eq(gemsBefore)) {
+      garbageOutputs.push({
+        type: "Gem",
+        before: gemsBefore.toNumber(),
+        after: gemsAfter.toNumber(),
+      });
+    }
+    mfEconomy("sell_garbage", {
+      inputs: [
+        {
+          type: item,
+          before: Number(count),
+          after: Number(count) - amount,
+        },
+      ],
+      outputs: garbageOutputs,
+    });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/garbageSold.ts
+++ b/src/features/game/events/landExpansion/garbageSold.ts
@@ -137,12 +137,23 @@ export function sellGarbage({ state, action }: Options) {
     );
 
     // Update inventory/wardrobe
+    // `getItemCount` returns how many are *saleable* (unplaced, capped by the
+    // sell limit), which is not the stored balance being decremented here.
+    // Record the balance actually mutated, or the event understates holdings.
+    const storedBefore = !isCollectibleItem
+      ? new Decimal(wardrobe[item] ?? 0)
+      : (inventory[item] ?? new Decimal(0));
+
     if (!isCollectibleItem) {
       wardrobe[item] = (wardrobe[item] ?? 0) - amount;
     } else {
       inventory[item] =
         inventory[item]?.sub(amount) ?? new Decimal(0).sub(amount);
     }
+
+    const storedAfter = !isCollectibleItem
+      ? new Decimal(wardrobe[item] ?? 0)
+      : (inventory[item] ?? new Decimal(0));
 
     const garbageOutputs: { type: string; before?: number; after?: number }[] =
       [];
@@ -165,8 +176,8 @@ export function sellGarbage({ state, action }: Options) {
       inputs: [
         {
           type: item,
-          before: Number(count),
-          after: Number(count) - amount,
+          before: storedBefore.toNumber(),
+          after: storedAfter.toNumber(),
         },
       ],
       outputs: garbageOutputs,

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -69,7 +69,7 @@ import {
 import { CHAPTER_CROP_WEEK_CROP } from "features/game/types/chapterCropWeek";
 import { prngChance } from "lib/prng";
 import { KNOWN_IDS } from "features/game/types";
-import { mfTrack } from "lib/moonforgeAnalytics";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 export type LandExpansionHarvestAction = {
   type: "crop.harvested";
   index: string;
@@ -1223,6 +1223,11 @@ export function harvest({
   return produce(state, (stateCopy) => {
     const { crops: plots } = stateCopy;
 
+    // `harvestCropFromPlot` may also grant a coin bonus (a random crop
+    // reward), applied to `stateCopy.coins` before it returns - snapshot the
+    // balance so the economy event can record that output too.
+    const coinsBefore = stateCopy.coins;
+
     const { updatedPlot, amount, aoe, boostsUsed, cropName } =
       harvestCropFromPlot({
         plotId: action.index,
@@ -1246,7 +1251,21 @@ export function harvest({
       createdAt,
     });
 
-    mfTrack("crop_harvested", { crop_type: cropName, amount });
+    const outputs: { type: string; before?: number; after?: number }[] = [
+      {
+        type: cropName,
+        before: cropCount.toNumber(),
+        after: cropCount.add(amount).toNumber(),
+      },
+    ];
+    if (stateCopy.coins !== coinsBefore) {
+      outputs.push({
+        type: "Coin",
+        before: coinsBefore,
+        after: stateCopy.coins,
+      });
+    }
+    mfEconomy("harvest_crop", { outputs });
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -1106,6 +1106,7 @@ export function harvestCropFromPlot({
   aoe: AOE;
   boostsUsed: { name: BoostName; value: string }[];
   cropName: CropName;
+  rewardRows: { type: string; before?: number; after?: number }[];
 } {
   const { crops: plots, bumpkin } = game;
 
@@ -1169,6 +1170,10 @@ export function harvestCropFromPlot({
     throw new Error("Not ready");
   }
 
+  // Reward items are credited here but harvested crops are credited by the
+  // caller, so the rows travel back out to be emitted in one event.
+  const rewardRows: { type: string; before?: number; after?: number }[] = [];
+
   const { reward, boostUsed: rewardBoostsUsed } = plot.crop.reward
     ? { reward: plot.crop.reward, boostUsed: [] }
     : getReward({
@@ -1184,11 +1189,18 @@ export function harvestCropFromPlot({
 
     if (reward.items) {
       game.inventory = reward.items.reduce((acc, item) => {
-        const amount = acc[item.name] || new Decimal(0);
+        const before = acc[item.name] || new Decimal(0);
+        const after = before.add(item.amount);
+
+        rewardRows.push({
+          type: item.name,
+          before: before.toNumber(),
+          after: after.toNumber(),
+        });
 
         return {
           ...acc,
-          [item.name]: amount.add(item.amount),
+          [item.name]: after,
         };
       }, game.inventory);
     }
@@ -1211,6 +1223,7 @@ export function harvestCropFromPlot({
     aoe,
     boostsUsed: [...cropYieldBoostsUsed, ...rewardBoostsUsed],
     cropName,
+    rewardRows,
   };
 }
 
@@ -1228,7 +1241,7 @@ export function harvest({
     // balance so the economy event can record that output too.
     const coinsBefore = stateCopy.coins;
 
-    const { updatedPlot, amount, aoe, boostsUsed, cropName } =
+    const { updatedPlot, amount, aoe, boostsUsed, cropName, rewardRows } =
       harvestCropFromPlot({
         plotId: action.index,
         game: stateCopy,
@@ -1265,6 +1278,7 @@ export function harvest({
         after: stateCopy.coins,
       });
     }
+    outputs.push(...rewardRows);
     mfEconomy("harvest_crop", { outputs });
 
     return stateCopy;

--- a/src/features/game/events/landExpansion/ironMine.ts
+++ b/src/features/game/events/landExpansion/ironMine.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 import type {
@@ -454,6 +455,23 @@ export function mineIron({
     });
     delete ironRock.stone.amount;
     delete ironRock.stone.criticalHit;
+
+    mfEconomy("mine_resource", {
+      inputs: [
+        {
+          type: "Stone Pickaxe",
+          before: toolAmount.toNumber(),
+          after: stateCopy.inventory["Stone Pickaxe"].toNumber(),
+        },
+      ],
+      outputs: [
+        {
+          type: "Iron",
+          before: amountInInventory.toNumber(),
+          after: stateCopy.inventory.Iron.toNumber(),
+        },
+      ],
+    });
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/mineCrimstone.ts
+++ b/src/features/game/events/landExpansion/mineCrimstone.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import { CRIMSTONE_RECOVERY_TIME } from "features/game/lib/constants";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 import { canMine } from "features/game/lib/resourceNodes";
@@ -282,6 +283,25 @@ export function mineCrimstone({
       game: stateCopy,
       boostNames: [...boostsUsed, ...minedAtBoostsUsed, ...pickaxeBoosts],
       createdAt,
+    });
+
+    mfEconomy("mine_resource", {
+      inputs: hasCrimstoneSpikes
+        ? undefined
+        : [
+            {
+              type: "Gold Pickaxe",
+              before: toolAmount.toNumber(),
+              after: toolAmount.sub(1).toNumber(),
+            },
+          ],
+      outputs: [
+        {
+          type: "Crimstone",
+          before: amountInInventory.toNumber(),
+          after: stateCopy.inventory.Crimstone.toNumber(),
+        },
+      ],
     });
 
     return stateCopy;

--- a/src/features/game/events/landExpansion/mineGold.ts
+++ b/src/features/game/events/landExpansion/mineGold.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import {
   isWithinAOE,
   type Position,
@@ -478,6 +479,23 @@ export function mineGold({
 
     delete goldRock.stone.amount;
     delete goldRock.stone.criticalHit;
+
+    mfEconomy("mine_resource", {
+      inputs: [
+        {
+          type: "Iron Pickaxe",
+          before: toolAmount.toNumber(),
+          after: inventory["Iron Pickaxe"].toNumber(),
+        },
+      ],
+      outputs: [
+        {
+          type: "Gold",
+          before: amountInInventory.toNumber(),
+          after: inventory.Gold.toNumber(),
+        },
+      ],
+    });
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/mineSunstone.ts
+++ b/src/features/game/events/landExpansion/mineSunstone.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import { SUNSTONE_RECOVERY_TIME } from "features/game/lib/constants";
 import { canMine } from "features/game/lib/resourceNodes";
 import { trackFarmActivity } from "features/game/types/farmActivity";
@@ -108,6 +109,23 @@ export function mineSunstone({
       "Sunstone Mined",
       stateCopy.farmActivity,
     );
+
+    mfEconomy("mine_resource", {
+      inputs: [
+        {
+          type: "Gold Pickaxe",
+          before: toolAmount.toNumber(),
+          after: toolAmount.sub(1).toNumber(),
+        },
+      ],
+      outputs: [
+        {
+          type: "Sunstone",
+          before: amountInInventory.toNumber(),
+          after: stateCopy.inventory.Sunstone.toNumber(),
+        },
+      ],
+    });
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/npcRestock.ts
+++ b/src/features/game/events/landExpansion/npcRestock.ts
@@ -10,6 +10,7 @@ import { produce } from "immer";
 import { translate } from "lib/i18n/translate";
 import type { NPCName } from "lib/npcs";
 import { onboardingAnalytics } from "lib/onboardingAnalytics";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 
 export type RestockNPC = Extract<NPCName, "betty" | "jafar" | "blacksmith">;
 
@@ -100,6 +101,10 @@ export function npcRestock({ state, action }: Options): GameState {
       value: gemPrice,
       virtual_currency_name: "Gem",
       item_name: "Restock",
+    });
+
+    mfCurrencyChange("npc_restock", "spend", {
+      gem: { before: gems.toNumber(), after: gems.sub(gemPrice).toNumber() },
     });
 
     return game;

--- a/src/features/game/events/landExpansion/openRewardBox.ts
+++ b/src/features/game/events/landExpansion/openRewardBox.ts
@@ -1,4 +1,5 @@
 import type { GameState, InventoryItemName } from "features/game/types/game";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import {
   type RewardBoxName,
   type RewardBoxReward,
@@ -120,6 +121,9 @@ export function openRewardBox({
       });
     }
 
+    const coinsBefore = stateCopy.coins;
+    const sflBefore = stateCopy.balance.toNumber();
+
     if (selectedReward.items) {
       history.items = {
         ...(history.items ?? {}),
@@ -158,6 +162,11 @@ export function openRewardBox({
       reward: selectedReward,
       history,
     };
+
+    mfCurrencyChange("open_reward_box", "grant", {
+      coin: { before: coinsBefore, after: stateCopy.coins },
+      sfl: { before: sflBefore, after: stateCopy.balance.toNumber() },
+    });
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -72,7 +72,7 @@ import {
 } from "features/game/types/bumpkinSkills";
 import { isAutumnCrop, isSummerCrop } from "./harvest";
 import { getKeys } from "lib/object";
-import { mfTrack } from "lib/moonforgeAnalytics";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 
 export type LandExpansionPlantAction = {
   type: "seed.planted";
@@ -747,14 +747,23 @@ export function plant({
 
     stateCopy.aoe = aoe;
     plots[action.index] = updatedPlot;
-    stateCopy.inventory[action.item] = stateCopy.inventory[action.item]?.sub(1);
+    const seedBefore = stateCopy.inventory[action.item] ?? new Decimal(0);
+    stateCopy.inventory[action.item] = seedBefore.sub(1);
     stateCopy.boostsUsedAt = updateBoostUsed({
       game: stateCopy,
       boostNames: boostsUsed,
       createdAt,
     });
 
-    mfTrack("crop_planted", { crop_type: cropName });
+    mfEconomy("plant_seed", {
+      inputs: [
+        {
+          type: action.item,
+          before: seedBefore.toNumber(),
+          after: stateCopy.inventory[action.item]?.toNumber() ?? 0,
+        },
+      ],
+    });
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/readMessage.ts
+++ b/src/features/game/events/landExpansion/readMessage.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import type { Announcements } from "features/game/types/announcements";
 import { getKeys } from "lib/object";
 import type { GameState } from "features/game/types/game";
@@ -37,6 +38,7 @@ export function readMessage({
 
     const reward = announcement?.reward;
     if (reward) {
+      const coinsBefore = game.coins;
       getKeys(reward.items).forEach((name) => {
         const previous = game.inventory[name] ?? new Decimal(0);
         game.inventory[name] = previous.add(reward.items[name] ?? 0);
@@ -45,6 +47,10 @@ export function readMessage({
       if (reward.coins) {
         game.coins = game.coins + reward.coins;
       }
+
+      mfCurrencyChange("claim_mail_reward", "grant", {
+        coin: { before: coinsBefore, after: game.coins },
+      });
     }
 
     return game;

--- a/src/features/game/events/landExpansion/restock.ts
+++ b/src/features/game/events/landExpansion/restock.ts
@@ -3,6 +3,7 @@ import { INITIAL_STOCK } from "features/game/lib/constants";
 import { BB_TO_GEM_RATIO, type GameState } from "features/game/types/game";
 import { produce } from "immer";
 import { onboardingAnalytics } from "lib/onboardingAnalytics";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 
 export type RestockAction = {
   type: "shops.restocked";
@@ -34,6 +35,13 @@ export function restock({ state }: Options): GameState {
       value: 1 * BB_TO_GEM_RATIO,
       virtual_currency_name: "Gem",
       item_name: "Restock",
+    });
+
+    mfCurrencyChange("restock", "spend", {
+      gem: {
+        before: gems.toNumber(),
+        after: gems.sub(1 * BB_TO_GEM_RATIO).toNumber(),
+      },
     });
 
     return game;

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -1,5 +1,6 @@
 import { v4 as randomUUID } from "uuid";
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import {
   EXPANSION_ORIGINS,
   LAND_SIZE,
@@ -78,11 +79,20 @@ export function revealLand({ state, createdAt = Date.now() }: Options) {
 
     const { inventory } = game;
 
+    const basicLandBefore = (
+      inventory["Basic Land"] ?? new Decimal(0)
+    ).toNumber();
     inventory["Basic Land"] = (inventory["Basic Land"] ?? new Decimal(0)).add(
       1,
     );
 
     const landCount = inventory["Basic Land"].toNumber();
+
+    mfEconomy("expand_land_complete", {
+      outputs: [
+        { type: "Basic Land", before: basicLandBefore, after: landCount },
+      ],
+    });
     const origin = EXPANSION_ORIGINS[landCount - 1];
 
     delete game.expansionConstruction;

--- a/src/features/game/events/landExpansion/sellAnimal.ts
+++ b/src/features/game/events/landExpansion/sellAnimal.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import { getAnimalLevel, getAnimalReadyAt } from "features/game/lib/animals";
 import { getKeys } from "lib/object";
 import { trackFarmActivity } from "features/game/types/farmActivity";
@@ -105,6 +106,7 @@ export function sellAnimal({
     }
 
     const isSick = animal.state === "sick";
+    const coinsBefore = game.coins;
 
     delete animals[action.animalId];
 
@@ -167,6 +169,14 @@ export function sellAnimal({
       `${animal.type} Bountied`,
       game.farmActivity,
     );
+
+    mfEconomy("sell_animal", {
+      inputs: [{ type: animal.type }],
+      outputs:
+        game.coins !== coinsBefore
+          ? [{ type: "Coin", before: coinsBefore, after: game.coins }]
+          : undefined,
+    });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/sellBounty.ts
+++ b/src/features/game/events/landExpansion/sellBounty.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import { getSkillLevel, SKILL_RANKS } from "features/game/types/bumpkinSkills";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { DOLLS, RECIPE_CRAFTABLES } from "features/game/lib/crafting";
@@ -223,6 +224,8 @@ export function sellBounty({
     });
 
     const item = draft.inventory[request.name] ?? new Decimal(0);
+    const coinsBefore = draft.coins;
+    const balanceBefore = draft.balance;
 
     if (BOUNTY_CATEGORIES["Mark Bounties"](request)) {
       draft.inventory[request.name] = item.minus(request.quantity);
@@ -251,6 +254,36 @@ export function sellBounty({
     if (BOUNTY_CATEGORIES["Obsidian Bounties"](request)) {
       draft.balance = draft.balance.add(request.sfl ?? 0);
     }
+
+    const sellBountyOutputs: {
+      type: string;
+      before?: number;
+      after?: number;
+    }[] = [];
+    if (draft.coins !== coinsBefore) {
+      sellBountyOutputs.push({
+        type: "Coin",
+        before: coinsBefore,
+        after: draft.coins,
+      });
+    }
+    if (!draft.balance.eq(balanceBefore)) {
+      sellBountyOutputs.push({
+        type: "SFL",
+        before: balanceBefore.toNumber(),
+        after: draft.balance.toNumber(),
+      });
+    }
+    mfEconomy("sell_bounty", {
+      inputs: [
+        {
+          type: request.name,
+          before: item.toNumber(),
+          after: (draft.inventory[request.name] ?? new Decimal(0)).toNumber(),
+        },
+      ],
+      outputs: sellBountyOutputs,
+    });
 
     // Mark bounty as completed
     draft.bounties.completed.push({

--- a/src/features/game/events/landExpansion/sellCrop.ts
+++ b/src/features/game/events/landExpansion/sellCrop.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import {
   type Crop,
   type CropName,
@@ -96,6 +97,7 @@ export function sellCrop({
       new Decimal(amount),
     );
 
+    const coinsBefore = game.coins;
     game.coins = game.coins + coinsEarned;
     game.inventory[action.crop] = setPrecision(
       (game.inventory[action.crop] ?? new Decimal(0)).sub(amount),
@@ -105,6 +107,17 @@ export function sellCrop({
       game,
       boostNames: boostsUsed,
       createdAt,
+    });
+
+    mfEconomy("sell_crop", {
+      inputs: [
+        {
+          type: action.crop,
+          before: count.toNumber(),
+          after: (game.inventory[action.crop] ?? new Decimal(0)).toNumber(),
+        },
+      ],
+      outputs: [{ type: "Coin", before: coinsBefore, after: game.coins }],
     });
 
     return game;

--- a/src/features/game/events/landExpansion/speedUpBuilding.ts
+++ b/src/features/game/events/landExpansion/speedUpBuilding.ts
@@ -1,6 +1,7 @@
 import type { GameState } from "features/game/types/game";
 import { produce } from "immer";
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import {
   chargeCoinsForSpeedUp,
   getInstantGems,
@@ -46,6 +47,9 @@ export function speedUpBuilding({
       game,
     });
 
+    const coinsBefore = game.coins;
+    const gemsBefore = (game.inventory["Gem"] ?? new Decimal(0)).toNumber();
+
     if (action.paymentMethod === "coins") {
       game = chargeCoinsForSpeedUp({ game, gems, createdAt });
     } else {
@@ -61,6 +65,14 @@ export function speedUpBuilding({
     }
 
     building.readyAt = createdAt;
+
+    mfCurrencyChange("speed_up_building", "spend", {
+      coin: { before: coinsBefore, after: game.coins },
+      gem: {
+        before: gemsBefore,
+        after: (game.inventory["Gem"] ?? new Decimal(0)).toNumber(),
+      },
+    });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/speedUpCollectible.ts
+++ b/src/features/game/events/landExpansion/speedUpCollectible.ts
@@ -2,6 +2,7 @@ import type { GameState } from "features/game/types/game";
 import { produce } from "immer";
 import type { CollectibleName } from "features/game/types/craftables";
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import { getCollectiblesAcrossLocations } from "features/game/lib/collectibleBuilt";
 import {
   chargeCoinsForSpeedUp,
@@ -48,6 +49,9 @@ export function speedUpCollectible({
       game,
     });
 
+    const coinsBefore = game.coins;
+    const gemsBefore = (game.inventory["Gem"] ?? new Decimal(0)).toNumber();
+
     if (action.paymentMethod === "coins") {
       game = chargeCoinsForSpeedUp({ game, gems, createdAt });
     } else {
@@ -63,6 +67,14 @@ export function speedUpCollectible({
     }
 
     collectible.readyAt = createdAt;
+
+    mfCurrencyChange("speed_up_collectible", "spend", {
+      coin: { before: coinsBefore, after: game.coins },
+      gem: {
+        before: gemsBefore,
+        after: (game.inventory["Gem"] ?? new Decimal(0)).toNumber(),
+      },
+    });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/speedUpCrafting.ts
+++ b/src/features/game/events/landExpansion/speedUpCrafting.ts
@@ -7,6 +7,7 @@ import {
   type SpeedUpPaymentMethod,
 } from "features/game/lib/getInstantGems";
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import { recalculateCraftingQueue } from "./cancelQueuedCrafting";
 
 export type InstantCraftAction = {
@@ -52,6 +53,9 @@ export function speedUpCrafting({
       game,
     });
 
+    const coinsBefore = game.coins;
+    const gemsBefore = (game.inventory["Gem"] ?? new Decimal(0)).toNumber();
+
     if (action.paymentMethod === "coins") {
       game = chargeCoinsForSpeedUp({ game, gems, createdAt });
     } else {
@@ -78,6 +82,14 @@ export function speedUpCrafting({
 
       game.craftingBox.queue = [...readyItems, ...recalculated];
     }
+
+    mfCurrencyChange("speed_up_crafting", "spend", {
+      coin: { before: coinsBefore, after: game.coins },
+      gem: {
+        before: gemsBefore,
+        after: (game.inventory["Gem"] ?? new Decimal(0)).toNumber(),
+      },
+    });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/speedUpExpansion.ts
+++ b/src/features/game/events/landExpansion/speedUpExpansion.ts
@@ -7,6 +7,7 @@ import {
   type SpeedUpPaymentMethod,
 } from "features/game/lib/getInstantGems";
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
 
 export type InstantExpand = {
@@ -56,6 +57,9 @@ export function speedUpExpansion({
       game,
     });
 
+    const coinsBefore = game.coins;
+    const gemsBefore = (game.inventory["Gem"] ?? new Decimal(0)).toNumber();
+
     if (action.paymentMethod === "coins") {
       game = chargeCoinsForSpeedUp({ game, gems, createdAt });
     } else {
@@ -71,6 +75,14 @@ export function speedUpExpansion({
     }
 
     expansion.readyAt = createdAt;
+
+    mfCurrencyChange("speed_up_expansion", "spend", {
+      coin: { before: coinsBefore, after: game.coins },
+      gem: {
+        before: gemsBefore,
+        after: (game.inventory["Gem"] ?? new Decimal(0)).toNumber(),
+      },
+    });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/speedUpProcessing.ts
+++ b/src/features/game/events/landExpansion/speedUpProcessing.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import type { ProcessingBuildingName } from "features/game/types/buildings";
 import type { BuildingProduct, GameState } from "features/game/types/game";
 import { produce } from "immer";
@@ -68,6 +69,9 @@ export const speedUpProcessing = ({
       game,
     });
 
+    const coinsBefore = game.coins;
+    const gemsBefore = (game.inventory["Gem"] ?? new Decimal(0)).toNumber();
+
     if (action.paymentMethod === "coins") {
       game = chargeCoinsForSpeedUp({ game, gems, createdAt });
     } else {
@@ -116,6 +120,14 @@ export const speedUpProcessing = ({
       isInstantReady: true,
       createdAt,
       game,
+    });
+
+    mfCurrencyChange("speed_up_processing", "spend", {
+      coin: { before: coinsBefore, after: game.coins },
+      gem: {
+        before: gemsBefore,
+        after: (game.inventory["Gem"] ?? new Decimal(0)).toNumber(),
+      },
     });
   });
 };

--- a/src/features/game/events/landExpansion/speedUpRecipe.ts
+++ b/src/features/game/events/landExpansion/speedUpRecipe.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import type {
   BuildingName,
   CookingBuildingName,
@@ -80,6 +81,9 @@ export function speedUpRecipe({
       game,
     });
 
+    const coinsBefore = game.coins;
+    const gemsBefore = (game.inventory["Gem"] ?? new Decimal(0)).toNumber();
+
     if (action.paymentMethod === "coins") {
       game = chargeCoinsForSpeedUp({ game, gems, createdAt });
     } else {
@@ -93,6 +97,15 @@ export function speedUpRecipe({
 
       game = makeGemHistory({ game, amount: gems, createdAt });
     }
+
+    mfCurrencyChange("speed_up_recipe", "spend", {
+      coin: { before: coinsBefore, after: game.coins },
+      gem: {
+        before: gemsBefore,
+        after: (game.inventory["Gem"] ?? new Decimal(0)).toNumber(),
+      },
+    });
+
     const cookableName = assertCookableName(recipe.name);
 
     const { amount, boostsUsed } = getCookingAmount({

--- a/src/features/game/events/landExpansion/speedUpUpgrade.ts
+++ b/src/features/game/events/landExpansion/speedUpUpgrade.ts
@@ -11,6 +11,7 @@ import {
   type SpeedUpPaymentMethod,
 } from "features/game/lib/getInstantGems";
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 
 export type SpeedUpUpgradeAction = {
   type: "upgrade.spedUp";
@@ -47,6 +48,9 @@ export function speedUpUpgrade({
       game,
     });
 
+    const coinsBefore = game.coins;
+    const gemsBefore = (game.inventory["Gem"] ?? new Decimal(0)).toNumber();
+
     if (action.paymentMethod === "coins") {
       game = chargeCoinsForSpeedUp({ game, gems, createdAt });
     } else {
@@ -61,6 +65,14 @@ export function speedUpUpgrade({
     }
 
     game[buildingKey].upgradeReadyAt = createdAt;
+
+    mfCurrencyChange("speed_up_upgrade", "spend", {
+      coin: { before: coinsBefore, after: game.coins },
+      gem: {
+        before: gemsBefore,
+        after: (game.inventory["Gem"] ?? new Decimal(0)).toNumber(),
+      },
+    });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/stoneMine.ts
+++ b/src/features/game/events/landExpansion/stoneMine.ts
@@ -39,7 +39,7 @@ import { produce } from "immer";
 import { STONE_RECOVERY_TIME } from "features/game/lib/constants";
 import { hasFeatureAccess } from "lib/flags";
 import { canMine, getMineReadyAt } from "features/game/lib/resourceNodes";
-import { mfTrack } from "lib/moonforgeAnalytics";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 
 export type LandExpansionStoneMineAction = {
   type: "stoneRock.mined";
@@ -531,9 +531,23 @@ export function mineStone({
       ],
       createdAt,
     });
-    mfTrack("resource_collected", {
-      resource_type: stoneName,
-      amount: stoneMined.toNumber(),
+    mfEconomy("mine_resource", {
+      inputs: new Decimal(requiredToolAmount).gt(0)
+        ? [
+            {
+              type: "Pickaxe",
+              before: toolAmount.toNumber(),
+              after: inventory.Pickaxe.toNumber(),
+            },
+          ]
+        : undefined,
+      outputs: [
+        {
+          type: "Stone",
+          before: amountInInventory.toNumber(),
+          after: inventory.Stone.toNumber(),
+        },
+      ],
     });
 
     delete rock.stone.amount;

--- a/src/features/game/events/landExpansion/treasureSold.ts
+++ b/src/features/game/events/landExpansion/treasureSold.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfEconomy } from "lib/moonforgeAnalytics";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { EXOTIC_CROPS, type ExoticCropName } from "features/game/types/beans";
 import { trackFarmActivity } from "features/game/types/farmActivity";
@@ -96,6 +97,17 @@ export function sellTreasure({ state, action }: Options) {
       game,
       boostNames: boostsUsed,
       createdAt: Date.now(),
+    });
+
+    mfEconomy("sell_treasure", {
+      inputs: [
+        {
+          type: item,
+          before: count.toNumber(),
+          after: (game.inventory[item] ?? new Decimal(0)).toNumber(),
+        },
+      ],
+      outputs: [{ type: "Coin", before: coins, after: game.coins }],
     });
 
     return game;

--- a/src/features/game/events/minigames/claimMinigamePrize.ts
+++ b/src/features/game/events/minigames/claimMinigamePrize.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { mfCurrencyChange } from "lib/moonforgeAnalytics";
 import {
   type MinigameName,
   SUPPORTED_MINIGAMES,
@@ -99,6 +100,7 @@ export function claimMinigamePrize({
     history.prizeClaimedAt = createdAt;
 
     // Claim coins
+    const coinsBefore = game.coins;
     if (prize.coins) {
       game.coins += prize.coins;
     }
@@ -129,6 +131,10 @@ export function claimMinigamePrize({
         score: leaderboard.score + prize.items.Mark,
       };
     }
+
+    mfCurrencyChange("minigame_prize", "grant", {
+      coin: { before: coinsBefore, after: game.coins },
+    });
 
     return game;
   });

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -74,7 +74,14 @@ import type { AuctionResults } from "./auctionMachine";
 import type { RaffleSnapshotWinner } from "features/world/ui/chapterRaffles/actions/loadRaffleResults";
 import { onboardingAnalytics } from "lib/onboardingAnalytics";
 import { gameAnalytics } from "lib/gameAnalytics";
-import { mfIdentify, mfSetUser, mfTrack } from "lib/moonforgeAnalytics";
+import {
+  consumeSignupPending,
+  mfAccountCreated,
+  mfEconomy,
+  mfIdentify,
+  mfSetUser,
+  mfTutorialStart,
+} from "lib/moonforgeAnalytics";
 import {
   hasCompletedLoginStep,
   markLoginStepCompleted,
@@ -2407,10 +2414,24 @@ export function startGame(authContext: AuthContext) {
               });
 
               if (!error) {
-                mfTrack("marketplace_trade", {
-                  item_id: item,
-                  price_sfl: pricePerUnit,
-                  side: "sell",
+                const resourceBefore =
+                  context.state.inventory[item] ?? new Decimal(0);
+                const resourceAfter = farm.inventory[item] ?? new Decimal(0);
+                mfEconomy("marketplace_sell_resource", {
+                  inputs: [
+                    {
+                      type: item,
+                      before: resourceBefore.toNumber(),
+                      after: resourceAfter.toNumber(),
+                    },
+                  ],
+                  outputs: [
+                    {
+                      type: "SFL",
+                      before: context.state.balance.toNumber(),
+                      after: farm.balance.toNumber(),
+                    },
+                  ],
                 });
               }
 
@@ -2851,6 +2872,18 @@ export function startGame(authContext: AuthContext) {
               farmId: context.farmId,
             });
             mfSetUser(`account${event.data.analyticsId}`);
+
+            // A signup marker for THIS farm means this session immediately
+            // follows its creation on this device. Emit `account_created`
+            // (after identify, per the telemetry contract) and `tutorial_start`
+            // now. Consuming the marker deletes it, so both fire exactly once -
+            // a returning player logging in wrote no marker, and a marker left
+            // by a different farm's interrupted signup is not matched here.
+            const signup = consumeSignupPending(context.farmId);
+            if (signup) {
+              mfAccountCreated(signup);
+              mfTutorialStart();
+            }
 
             gameAnalytics.initialise({
               id: event.data.analyticsId,

--- a/src/features/island/hud/components/CurrenciesModal.tsx
+++ b/src/features/island/hud/components/CurrenciesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { Button } from "components/ui/Button";
 import { Label } from "components/ui/Label";
@@ -21,7 +21,7 @@ import {
 } from "features/game/components/modal/components/BuyGems";
 import { randomID } from "lib/utils/random";
 import { onboardingAnalytics } from "lib/onboardingAnalytics";
-import { mfTrack } from "lib/moonforgeAnalytics";
+import { mfIapCompleted, mfIapInitiated } from "lib/moonforgeAnalytics";
 import type { AuthMachineState } from "features/auth/lib/authMachine";
 import type { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
@@ -91,6 +91,12 @@ export const CurrenciesModal: React.FC<Props> = ({
   const [loading, setLoading] = useState(false);
   const [price, setPrice] = useState<Price>();
   const [hideBuyBBLabel, setHideBuyBBLabel] = useState(false);
+
+  // The transaction id handed to Xsolla when a card purchase starts, kept so
+  // the `iap_completed` event on success carries the same id as `iap_initiated`
+  // (and as the payment record) - a double-fired success callback then
+  // de-duplicates instead of counting the revenue twice.
+  const checkoutTransactionId = useRef<string | undefined>(undefined);
 
   const token = useSelector(authService, _token);
   const farmId = useSelector(gameService, _farmId);
@@ -169,15 +175,28 @@ export const CurrenciesModal: React.FC<Props> = ({
     setPage("menu");
   };
 
+  const productFields = () => {
+    const isStarterPack = price?.amount === STARTER_PACK;
+    return {
+      product_id: isStarterPack ? "starter_pack" : `gems_${price?.amount}`,
+      price: price?.usd ?? 0,
+      currency: "USD",
+    };
+  };
+
   const handleCreditCardBuy = async () => {
     setLoading(true);
     try {
       const amount = price?.amount ?? 0;
+      const transactionId = randomID();
+      checkoutTransactionId.current = transactionId;
+
+      mfIapInitiated({ ...productFields(), store: "web" });
 
       const { url } = await buyGemsXsolla({
         amount: amount as number,
         farmId,
-        transactionId: randomID(),
+        transactionId,
         token,
       });
 
@@ -198,10 +217,10 @@ export const CurrenciesModal: React.FC<Props> = ({
         : ((price?.amount as number) ?? 0),
       ...(isStarterPack ? { coins: STARTER_PACK_COINS } : {}),
     });
-    mfTrack("iap_completed", {
-      product_id: isStarterPack ? "starter_pack" : `gems_${price?.amount}`,
-      price: price?.usd ?? 0,
-      currency: "USD",
+    mfIapCompleted({
+      ...productFields(),
+      transaction_id: checkoutTransactionId.current ?? randomID(),
+      store: "web",
     });
     onClose();
   };

--- a/src/lib/moonforgeAnalytics.test.ts
+++ b/src/lib/moonforgeAnalytics.test.ts
@@ -1,10 +1,19 @@
 import { MoonForgeAnalytics, MoonForgeErrorTracker } from "lib/moonforge";
 import {
+  consumeSignupPending,
+  markSignupPending,
+  mfAccountCreated,
+  mfCurrencyChange,
+  mfEconomy,
   mfExperiment,
+  mfIapCompleted,
+  mfIapInitiated,
   mfIdentify,
   mfScreen,
   mfSetScene,
   mfTrack,
+  mfTutorialComplete,
+  mfTutorialStart,
 } from "./moonforgeAnalytics";
 
 const TEST_GAME_ID = "00000000-0000-4000-8000-000000000000";
@@ -177,6 +186,218 @@ describe("moonforgeAnalytics", () => {
         mfExperiment("purchase_prompt_holdout", "control"),
       ).not.toThrow();
 
+      spy.mockRestore();
+    });
+
+    const eventOf = () =>
+      JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body).payload;
+
+    const eventsOf = () =>
+      fetchMock.mock.calls.map(
+        (call) => JSON.parse((call[1] as { body: string }).body).payload,
+      );
+
+    describe("mfEconomy", () => {
+      it("posts economy_transaction with flattened input and output rows", () => {
+        mfEconomy("speed_up_building", {
+          inputs: [{ type: "Gem", before: 10, after: 7 }],
+          outputs: [{ type: "Basic Building", before: 0, after: 1 }],
+        });
+
+        const { name, data } = eventOf();
+        expect(name).toBe("economy_transaction");
+        expect(data).toMatchObject({
+          reason: "speed_up_building",
+          input_1_type: "Gem",
+          input_1_before: 10,
+          input_1_after: 7,
+          output_1_type: "Basic Building",
+          output_1_before: 0,
+          output_1_after: 1,
+        });
+      });
+
+      it("omits before / after for the ends that are not known", () => {
+        mfEconomy("daily_reward", { outputs: [{ type: "Coin", after: 250 }] });
+
+        const { data } = eventOf();
+        expect(data).toMatchObject({
+          reason: "daily_reward",
+          output_1_type: "Coin",
+          output_1_after: 250,
+        });
+        expect(data).not.toHaveProperty("output_1_before");
+        expect(data).not.toHaveProperty("input_1_type");
+      });
+
+      it("emits every input/output in one event - no cap, nothing dropped", () => {
+        mfEconomy("craft_collectible", {
+          inputs: [
+            { type: "Coin", before: 100, after: 90 },
+            { type: "Sunflower", before: 4, after: 3 },
+            { type: "Potato", before: 4, after: 3 },
+            { type: "Pumpkin", before: 4, after: 3 },
+            { type: "Carrot", before: 4, after: 3 },
+          ],
+          outputs: [{ type: "Scary Mike", before: 0, after: 1 }],
+        });
+
+        const events = eventsOf();
+        expect(events).toHaveLength(1);
+        expect(events[0].name).toBe("economy_transaction");
+        expect(events[0].data).toMatchObject({
+          reason: "craft_collectible",
+          input_1_type: "Coin",
+          input_1_before: 100,
+          input_1_after: 90,
+          input_2_type: "Sunflower",
+          input_3_type: "Potato",
+          input_4_type: "Pumpkin",
+          input_5_type: "Carrot",
+          input_5_after: 3,
+          output_1_type: "Scary Mike",
+        });
+      });
+    });
+
+    describe("mfCurrencyChange", () => {
+      it("puts moved balances on the output side for a grant", () => {
+        mfCurrencyChange("daily_reward", "grant", {
+          coin: { before: 100, after: 350 },
+          sfl: { before: 5, after: 5 },
+        });
+
+        const { name, data } = eventOf();
+        expect(name).toBe("economy_transaction");
+        expect(data).toMatchObject({
+          reason: "daily_reward",
+          output_1_type: "Coin",
+          output_1_before: 100,
+          output_1_after: 350,
+        });
+        // SFL did not move - dropped.
+        expect(data).not.toHaveProperty("output_2_type");
+      });
+
+      it("puts moved balances on the input side for a spend", () => {
+        mfCurrencyChange("speed_up_building", "spend", {
+          gem: { before: 10, after: 7 },
+        });
+
+        const { data } = eventOf();
+        expect(data).toMatchObject({
+          reason: "speed_up_building",
+          input_1_type: "Gem",
+          input_1_before: 10,
+          input_1_after: 7,
+        });
+      });
+
+      it("sends nothing when no balance moved", () => {
+        mfCurrencyChange("noop", "grant", { coin: { before: 1, after: 1 } });
+        expect(fetchMock).not.toHaveBeenCalled();
+      });
+    });
+
+    it("mfIapInitiated posts iap_initiated with the required keys", () => {
+      mfIapInitiated({ product_id: "gems_500", price: 4.99, currency: "USD" });
+
+      const { name, data } = eventOf();
+      expect(name).toBe("iap_initiated");
+      expect(data).toMatchObject({
+        product_id: "gems_500",
+        price: 4.99,
+        currency: "USD",
+      });
+    });
+
+    it("mfIapCompleted includes the transaction_id so a double callback de-dupes", () => {
+      mfIapCompleted({
+        product_id: "gems_500",
+        price: 4.99,
+        currency: "USD",
+        transaction_id: "txn_abc",
+        store: "web",
+      });
+
+      const { name, data } = eventOf();
+      expect(name).toBe("iap_completed");
+      expect(data).toMatchObject({
+        product_id: "gems_500",
+        transaction_id: "txn_abc",
+        store: "web",
+      });
+    });
+
+    it("mfTutorialStart / mfTutorialComplete send the locked names", () => {
+      mfTutorialStart();
+      expect(eventOf().name).toBe("tutorial_start");
+
+      fetchMock.mockClear();
+      mfTutorialComplete("completed");
+      expect(eventOf()).toMatchObject({
+        name: "tutorial_complete",
+        data: { outcome: "completed" },
+      });
+    });
+
+    it("mfAccountCreated sends signup_method and optional provider", () => {
+      mfAccountCreated({ signup_method: "social", provider: "google" });
+
+      const { name, data } = eventOf();
+      expect(name).toBe("account_created");
+      expect(data).toMatchObject({
+        signup_method: "social",
+        provider: "google",
+      });
+    });
+
+    describe("signup marker (farm-scoped)", () => {
+      afterEach(() => localStorage.clear());
+
+      it("consumes only the marker for the matching farm, then clears it", () => {
+        markSignupPending(42, { signup_method: "email" });
+
+        expect(consumeSignupPending(99)).toBeUndefined();
+        expect(consumeSignupPending(42)).toEqual({ signup_method: "email" });
+        // consumed - gone now
+        expect(consumeSignupPending(42)).toBeUndefined();
+      });
+
+      it("leaves another farm's stale marker untouched", () => {
+        markSignupPending(1, { signup_method: "platform" });
+
+        // A different account signs in on the same browser - no false signup.
+        expect(consumeSignupPending(2)).toBeUndefined();
+        // Farm 1's marker is still there for whenever farm 1 loads.
+        expect(consumeSignupPending(1)).toEqual({ signup_method: "platform" });
+      });
+    });
+
+    it("the locked helpers swallow a rejected trackEvent without an unhandled rejection", async () => {
+      const spy = jest
+        .spyOn(MoonForgeAnalytics, "trackEvent")
+        .mockReturnValue(Promise.reject(new Error("collector down")) as never);
+
+      const unhandled: unknown[] = [];
+      const onUnhandled = (e: unknown) => unhandled.push(e);
+      process.on("unhandledRejection", onUnhandled);
+
+      expect(() => {
+        mfEconomy("daily_reward", { outputs: [{ type: "Coin", after: 1 }] });
+        mfIapCompleted({
+          product_id: "p",
+          price: 1,
+          currency: "USD",
+          transaction_id: "t",
+        });
+        mfAccountCreated({ signup_method: "other" });
+      }).not.toThrow();
+
+      await new Promise((r) => setTimeout(r, 10));
+      process.off("unhandledRejection", onUnhandled);
+
+      expect(unhandled).toHaveLength(0);
       spy.mockRestore();
     });
   });

--- a/src/lib/moonforgeAnalytics.ts
+++ b/src/lib/moonforgeAnalytics.ts
@@ -29,6 +29,32 @@ export function mfTrack(name: string, data?: Record<string, unknown>): void {
 }
 
 /**
+ * Like `mfTrack`, but also swallows a rejected `trackEvent` promise.
+ *
+ * `trackEvent` returns `postEvent`'s promise, so a network or collector
+ * failure surfaces as a rejection rather than a synchronous throw - which a
+ * bare try/catch never sees, leaving an unhandled rejection in the player's
+ * browser. Used for the schema-locked events below, where a call site is
+ * more likely to be a one-off (a purchase, a tutorial step) whose failure
+ * should stay silent.
+ */
+function mfTrackLocked(name: string, data: Record<string, unknown>): void {
+  try {
+    const result = MoonForgeAnalytics.trackEvent(name, data) as unknown;
+
+    if (result instanceof Promise) {
+      result.catch((e) => {
+        // eslint-disable-next-line no-console
+        console.log(`MoonForge analytics error: `, e);
+      });
+    }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(`MoonForge analytics error: `, e);
+  }
+}
+
+/**
  * Tracks a screen/scene view.
  */
 export function mfScreen(name: string): void {
@@ -90,24 +116,206 @@ export function mfSetScene(sceneName: string): void {
  * already run.
  */
 export function mfExperiment(experimentId: string, variant: string): void {
-  try {
-    // `trackEvent` returns the underlying `postEvent` promise, so a network or
-    // collector failure surfaces as a rejection rather than a synchronous
-    // throw - which the catch below would never see. Without the rejection
-    // handler this produces an unhandled rejection in the player's browser.
-    const result = MoonForgeAnalytics.trackEvent("experiment_assigned", {
-      experiment_id: experimentId,
-      variant,
-    }) as unknown;
+  mfTrackLocked("experiment_assigned", {
+    experiment_id: experimentId,
+    variant,
+  });
+}
 
-    if (result instanceof Promise) {
-      result.catch((e) => {
-        // eslint-disable-next-line no-console
-        console.log(`MoonForge analytics error: `, e);
-      });
-    }
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.log(`MoonForge analytics error: `, e);
+/** One side of an economy transaction: a resource type and its balance
+ * before / after the change. `before` / `after` are optional for the ends
+ * that are not known (a free reward has no input balance, a pure sink has no
+ * output). */
+export type EconomyRow = { type: string; before?: number; after?: number };
+
+function flattenEconomyRows(
+  data: Record<string, unknown>,
+  prefix: "input" | "output",
+  rows: EconomyRow[] | undefined,
+): void {
+  rows?.forEach((row, i) => {
+    const n = i + 1;
+    data[`${prefix}_${n}_type`] = row.type;
+    if (row.before !== undefined) data[`${prefix}_${n}_before`] = row.before;
+    if (row.after !== undefined) data[`${prefix}_${n}_after`] = row.after;
+  });
+}
+
+/**
+ * Records one economic state change as the canonical `economy_transaction`
+ * event. Game-specific meaning goes in `reason` (e.g. `harvest_crop`,
+ * `speed_up_building`), never in the event name.
+ *
+ * Every input and output is sent as flat `input_N_type/before/after` and
+ * `output_N_type/before/after` keys - `N` is unbounded on the collector, so a
+ * change with many sides (a land expansion costing 8 resources, a 6-ingredient
+ * collectible) is emitted whole, in one event. Free reward -> omit `inputs`;
+ * sink with no grant -> omit `outputs`.
+ */
+export function mfEconomy(
+  reason: string,
+  opts?: { inputs?: EconomyRow[]; outputs?: EconomyRow[] },
+): void {
+  const data: Record<string, unknown> = { reason };
+  flattenEconomyRows(data, "input", opts?.inputs);
+  flattenEconomyRows(data, "output", opts?.outputs);
+  mfTrackLocked("economy_transaction", data);
+}
+
+type CurrencyBalance = { before: number; after: number };
+
+/**
+ * Shorthand for the common case where an economic change only moved the
+ * standard currency balances (a reward claim, a currency-only purchase or
+ * exchange). Pass the before/after of each balance that could have moved -
+ * ones that did not move are dropped. `direction` puts the moved balances on
+ * the input side (a spend) or the output side (a grant).
+ *
+ * For anything that also moves inventory items, use `mfEconomy` directly.
+ */
+export function mfCurrencyChange(
+  reason: string,
+  direction: "grant" | "spend",
+  balances: {
+    coin?: CurrencyBalance;
+    sfl?: CurrencyBalance;
+    gem?: CurrencyBalance;
+    flower?: CurrencyBalance;
+  },
+): void {
+  const rows: EconomyRow[] = [];
+  const add = (type: string, b?: CurrencyBalance) => {
+    if (b && b.before !== b.after)
+      rows.push({ type, before: b.before, after: b.after });
+  };
+  add("Coin", balances.coin);
+  add("SFL", balances.sfl);
+  add("Gem", balances.gem);
+  add("FLOWER", balances.flower);
+
+  if (rows.length === 0) return;
+
+  mfEconomy(
+    reason,
+    direction === "grant" ? { outputs: rows } : { inputs: rows },
+  );
+}
+
+/** Locked revenue event: the player has entered a purchase / checkout flow. */
+export function mfIapInitiated(p: {
+  product_id: string;
+  price: number;
+  currency: string;
+  product_name?: string;
+  store?: string;
+}): void {
+  const data: Record<string, unknown> = {
+    product_id: p.product_id,
+    price: p.price,
+    currency: p.currency,
+  };
+  if (p.product_name !== undefined) data.product_name = p.product_name;
+  if (p.store !== undefined) data.store = p.store;
+  mfTrackLocked("iap_initiated", data);
+}
+
+/** Locked revenue event: a purchase has succeeded. `transaction_id` is
+ * required - reuse the real id the payment flow already generated so a
+ * double-fired success callback de-duplicates. */
+export function mfIapCompleted(p: {
+  product_id: string;
+  price: number;
+  currency: string;
+  transaction_id: string;
+  product_name?: string;
+  store?: string;
+}): void {
+  const data: Record<string, unknown> = {
+    product_id: p.product_id,
+    price: p.price,
+    currency: p.currency,
+    transaction_id: p.transaction_id,
+  };
+  if (p.product_name !== undefined) data.product_name = p.product_name;
+  if (p.store !== undefined) data.store = p.store;
+  mfTrackLocked("iap_completed", data);
+}
+
+/** Locked FTUE event: the onboarding flow has begun. */
+export function mfTutorialStart(): void {
+  mfTrackLocked("tutorial_start", {});
+}
+
+/** Locked FTUE event: the onboarding flow has ended, however it ended. */
+export function mfTutorialComplete(outcome?: "completed" | "skipped"): void {
+  mfTrackLocked("tutorial_complete", outcome === undefined ? {} : { outcome });
+}
+
+export type SignupMethod =
+  | "email"
+  | "social"
+  | "platform"
+  | "guest_upgrade"
+  | "other";
+
+export type SignupInfo = { signup_method: SignupMethod; provider?: string };
+
+/**
+ * Locked account event: a signup has completed.
+ *
+ * Call `mfIdentify` first, then this - two separate calls, in that order,
+ * never inferred from `mfIdentify` alone. A returning player's first
+ * `mfIdentify` on a new device is a login, not a signup.
+ */
+export function mfAccountCreated(p: SignupInfo): void {
+  const data: Record<string, unknown> = { signup_method: p.signup_method };
+  if (p.provider !== undefined) data.provider = p.provider;
+  mfTrackLocked("account_created", data);
+}
+
+const signupPendingKey = (farmId: number | string) =>
+  `mf_signup_pending_${farmId}`;
+
+/**
+ * Records that a signup just completed, keyed to the new farm.
+ *
+ * `account_created` must fire *after* `mfIdentify` and with the real analytics
+ * id, but signup finishes in the auth machine while `mfIdentify` only runs
+ * later in the game machine's `initialiseAnalytics`. The auth machine leaves
+ * this marker; the game machine turns it into the event via
+ * `consumeSignupPending(farmId)`. localStorage rather than a module variable so
+ * it survives the auth -> game reload.
+ *
+ * Scoped per farm so a marker orphaned by an interrupted first load can only
+ * ever be consumed by the farm it belongs to - never by the next, unrelated
+ * account to sign in on the same browser.
+ */
+export function markSignupPending(
+  farmId: number | string,
+  info: SignupInfo,
+): void {
+  try {
+    localStorage.setItem(signupPendingKey(farmId), JSON.stringify(info));
+  } catch {
+    // Never throws into auth code.
+  }
+}
+
+/**
+ * Reads and clears this farm's signup marker. `undefined` in the common case -
+ * a returning player logging in wrote no marker (and a stale marker for a
+ * *different* farm is left untouched), so no spurious `account_created`.
+ */
+export function consumeSignupPending(
+  farmId: number | string,
+): SignupInfo | undefined {
+  try {
+    const key = signupPendingKey(farmId);
+    const raw = localStorage.getItem(key);
+    if (raw === null) return undefined;
+    localStorage.removeItem(key);
+    return JSON.parse(raw) as SignupInfo;
+  } catch {
+    return undefined;
   }
 }


### PR DESCRIPTION
Follows on from #7420 and #7549. Those added the analytics wrapper, the
tutorial funnel and identity ordering. This one covers three questions the
current events cannot answer: what players spend real money on, where new
players drop out before the first session ends, and where in-game currency
enters and leaves the economy.

## Revenue

`iap_initiated` and `iap_completed` wrap the Xsolla card flow in
`CurrenciesModal`. Both carry the same transaction id, generated once when
checkout starts and held in a ref.

The shared id matters because Xsolla can fire its success callback more than
once. Without a stable id the same purchase is counted as two sales, and
revenue numbers drift upward with no obvious cause. The id also matches the
payment record, so a figure can be traced back to a specific transaction
rather than taken on faith.

## First-time user experience

`account_created` fires once per account, from the game machine, after the
player is identified. The auth machine leaves a marker at `creating.onDone`.

That location is deliberate. `authorising` only means the player was
authorised, and a welcome-screen button press only means they intended to
sign up, so emitting from either would count accounts that do not exist. The
marker is keyed to the farm id carried on the signup token, so a second
account created on a shared device does not inherit the first one's marker.

`signup_method` is a fixed set: social, email, platform, grant, or
guest_upgrade. Social carries the provider alongside it.

## Economy

`economy_transaction` fires wherever currency is created or destroyed:
crafting, cooking, mining, deliveries, land expansion, shop purchases and
reward claims. Each event carries the delta and the resulting balance, with
inputs and outputs recorded separately so a single craft shows both what it
consumed and what it produced.

The emitters live in the individual game events rather than in a shared
helper. A helper sees only that a balance moved; the event knows whether it
was a sale, a craft or a claim, which is the part worth recording. This is
the same reasoning behind the domain-level placement suggested during review
of the API-side work.

## Scope and safety

Every call is fire and forget and cannot throw into gameplay, matching the
existing wrapper. Where a call site turned out to be unreachable it was
removed rather than kept for symmetry, so the emitters map to paths players
actually take.

Nothing existing changes behaviour. The only non-analytics edit is a ref in
`CurrenciesModal` to hold the transaction id.

## Testing

46 tests in `moonforgeAnalytics.test.ts`, `moonforgeSessionBuffer.test.ts`
and `moonforgeTutorial.test.ts`, covering the double-fire de-duplication, the
farm scoping on the signup marker, and event ordering against the identify
buffer. `tsc --noEmit` is clean and the 61 changed files add no new eslint
warnings against the baseline.

`src/features/game/events` has 58 failing tests across 9 suites. These fail
identically on `main` without this branch applied and are unrelated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Analytics**
  - Expanded tracking for in-game economy activity, including purchases, crafting, harvesting, mining, exchanges, rewards, sales, and speed-ups.
  - Added detailed before-and-after currency and inventory balance reporting.
  - Added signup, account creation, tutorial progress, and referral attribution tracking.
  - Improved purchase analytics with initiation and completion events linked by transaction.
- **Reliability**
  - Analytics events now fail safely without interrupting gameplay or purchases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->