### PR TITLE
[FIX] Remove the old interior bumpkin row from the new interior

### DIFF
--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -122,8 +122,8 @@ const HudComponent: React.FC<{
       {/*
         The interior surfaces have no floating farm hand row — the Bumpkin and
         each farm hand live on the "Farm Hands" tab of the beds modal instead
-        (see BedsMigrationModal, opened by InteriorBedsButton). The row is still
-        rendered in LandscapingHud, where it's the handle for placing them.
+        (see BedsMigrationModal, opened by InteriorBedsButton), and are placed
+        from the matching tab of the landscaping quick panel.
       */}
 
       {/*

--- a/src/features/island/hud/LandscapingHud.tsx
+++ b/src/features/island/hud/LandscapingHud.tsx
@@ -50,7 +50,6 @@ import type { NFTName } from "features/game/events/landExpansion/placeNFT";
 import { LandscapingChest } from "./components/LandscapingChest";
 import { LandscapingQuickPanel } from "./components/LandscapingQuickPanel";
 import { InteriorFloorNav } from "features/interior/components/InteriorFloorNav";
-import { InteriorBumpkins } from "features/home/components/InteriorBumpkins";
 
 const compareBalance = (prev: Decimal, next: Decimal) => {
   return prev.eq(next);
@@ -246,15 +245,10 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
       )}
 
       {/*
-        Farm hand / bumpkin line — see Hud.tsx for why this lives in the HUD
-        rather than the gameboard (early home-expansion tiers have a room too
-        narrow for the row, which overlapped the in-world Upgrade button).
+        No farm hand / bumpkin line on the interior surfaces — the Bumpkin and
+        each unplaced farm hand are placed from the quick panel's "Farm Hands"
+        tab, and equipped from the beds modal (InteriorBedsButton in Hud.tsx).
       */}
-      {(location === "interior" || location === "level_one") && (
-        <div className="absolute top-16 left-1/2 -translate-x-1/2">
-          <InteriorBumpkins location={location} />
-        </div>
-      )}
 
       {removalMode && (
         <>

--- a/src/features/island/hud/components/LandscapingQuickPanel.tsx
+++ b/src/features/island/hud/components/LandscapingQuickPanel.tsx
@@ -97,7 +97,14 @@ const ALL_DIMENSIONS: Record<string, { width: number; height: number }> = {
   Bud: { width: 1, height: 1 },
   Pet: { width: 2, height: 2 },
   FarmHand: { width: 1, height: 1 },
+  Bumpkin: { width: 1, height: 1 },
 };
+
+/**
+ * `LandscapingPlaceableType` requires an id alongside the name for the
+ * Bumpkin, but there is only ever one — matches `PlacedBumpkin`'s moveable id.
+ */
+const BUMPKIN_PLACEABLE_ID = "main";
 
 const getItemDims = (name: string) =>
   ALL_DIMENSIONS[name] ?? { width: 1, height: 1 };
@@ -205,6 +212,13 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
             id: (item as { id: string }).id,
           },
           action: "farmHand.placed",
+          requirements: { coins: 0, ingredients: {} },
+          collisionDetected: false,
+        } as any);
+      } else if (item.name === "Bumpkin") {
+        freshChild.send("SELECT", {
+          placeable: { name: "Bumpkin", id: BUMPKIN_PLACEABLE_ID },
+          action: "bumpkin.placed",
           requirements: { coins: 0, ingredients: {} },
           collisionDetected: false,
         } as any);
@@ -358,6 +372,14 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
   const petsNFTs = getChestPets(state.pets?.nfts ?? {});
   const farmHands =
     location === "petHouse" ? {} : getChestFarmHands(state.farmHands);
+
+  // The interior floors have no floating farm hand row (see LandscapingHud), so
+  // this tab is where the player's own Bumpkin is placed there. Like the farm
+  // hands above, it only appears while it isn't standing somewhere already.
+  const canPlaceBumpkin =
+    (location === "interior" || location === "level_one") &&
+    !!state.bumpkin &&
+    !state.bumpkin.coordinates;
   const chestMap = getChestItems(state);
   const biome = useMemo(() => getCurrentBiome(state.island), [state.island]);
 
@@ -376,7 +398,7 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
   const specialCounts: Record<ChestSpecialCategoryId, number> = {
     buds: getKeys(buds).length,
     petNFTs: getKeys(petsNFTs).length,
-    farmHands: Object.keys(farmHands).length,
+    farmHands: Object.keys(farmHands).length + (canPlaceBumpkin ? 1 : 0),
   };
 
   // ── Tab definitions (mirror the chest categories) ──────────────────────
@@ -427,6 +449,12 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
       child.send("SELECT", {
         placeable: { name: "FarmHand", id: item.id },
         action: "farmHand.placed",
+        requirements: { coins: 0, ingredients: {} },
+      });
+    } else if (item.name === "Bumpkin") {
+      child.send("SELECT", {
+        placeable: { name: "Bumpkin", id: BUMPKIN_PLACEABLE_ID },
+        action: "bumpkin.placed",
         requirements: { coins: 0, ingredients: {} },
       });
     } else {
@@ -522,7 +550,7 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
     }
 
     if (effectiveTab === "farmHands") {
-      return Object.keys(farmHands).map((id) => {
+      const boxes = Object.keys(farmHands).map((id) => {
         const image = SUNNYSIDE.achievement.farmHand;
         const item: LandscapingPlaceableType = { name: "FarmHand", id };
         return wrapBox(
@@ -536,6 +564,31 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
           </Box>,
         );
       });
+
+      if (canPlaceBumpkin && state.bumpkin) {
+        const item: LandscapingPlaceableType = {
+          name: "Bumpkin",
+          id: BUMPKIN_PLACEABLE_ID,
+        };
+        // The player comes first, ahead of their farm hands.
+        boxes.unshift(
+          wrapBox(
+            "bumpkin",
+            item,
+            <Box
+              image={SUNNYSIDE.icons.player}
+              onClick={() => handleClick(item)}
+            >
+              <NPCPlaceable
+                parts={state.bumpkin.equipped}
+                width={PIXEL_SCALE * 12}
+              />
+            </Box>,
+          ),
+        );
+      }
+
+      return boxes;
     }
 
     const category = categories.find((c) => c.id === effectiveTab);
@@ -573,7 +626,16 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
       );
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [effectiveTab, chestMap, buds, petsNFTs, farmHands, now]);
+  }, [
+    effectiveTab,
+    chestMap,
+    buds,
+    petsNFTs,
+    farmHands,
+    canPlaceBumpkin,
+    state.bumpkin,
+    now,
+  ]);
 
   const totalPages = Math.ceil(items.length / MOBILE_ITEMS_PER_PAGE);
   const pagedItems = isMobile


### PR DESCRIPTION
## Summary

The old floating farm hand / bumpkin row was still showing on the new interior floors. `InteriorBumpkins` had already been dropped from the non-landscaping interior HUD when `InteriorBedsButton` (the player + `＋` button at the bottom of the right-hand HUD column) replaced it, but `LandscapingHud` still rendered it on `/interior` and `/level_one` — so anyone entering landscaping mode in the new interior still saw the old row. This removes it there too.

## Context / motivation

Follow-up to #7457, which moved the row out of the gameboard and into the HUD, and to the beds-button work that made it redundant. The comment in `Hud.tsx` already described the row as legacy and pointed at `LandscapingHud` as the last remaining render site; this finishes that job.

One thing worth a reviewer's attention: that row was the **only** handle for placing the player's own Bumpkin into the interior. Farm hands can already be placed from the chest and the landscaping quick panel, but `Chest.tsx` explicitly excludes the Bumpkin (`// Bumpkin is not placeable from the chest`), and the beds modal's "Farm Hands" tab is equip-only. Removing the row on its own would mean a Bumpkin shovelled out of the interior falls back to the farm with no way to bring it back in.

So the Bumpkin is now offered in the landscaping quick panel's **Farm Hands** tab on the interior floors, alongside the farm hands. Like them, it only appears while it isn't placed somewhere already, and the tab hides itself once there is nothing left to place.

`InteriorBumpkins` itself is untouched and still used by the legacy `/home`.

## How to test

Requires the interiors experiment (`settings.interiorsEnabled`, Settings → Experiments) and the `HOME_EXPANSIONS` beta flag.

1. Go to your new interior (`/#/interior`).
2. Enter landscaping mode (hammer button, top right). **Before:** the old bumpkin row floated at the top-centre of the screen. **After:** no row.
3. Open the quick panel's "Farm Hands" tab — your Bumpkin is listed first, ahead of any farm hands.
4. Click it, drag it onto a valid floor tile, confirm. The Bumpkin is placed in the room and the tab disappears (nothing left to place).
5. Shovel the Bumpkin out again — it reappears in the "Farm Hands" tab, ready to re-place.
6. Repeat on `/#/level_one`.

## Screenshots or screen recording

Verified locally in art mode on the offline farm (interiors setting temporarily enabled, reverted before committing):

- Landscaping the interior: no floating row; quick panel shows a "Farm Hands" tab containing the Bumpkin.
- Placing it drops the character into the room, after which the tab disappears.
- Back out of landscaping: the Bumpkin stands in the room, and the beds button sits at the bottom of the right-hand HUD column as before.

## Related issues

Related #7457

---

## Checklist

### PR and scope

- [x] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [x] I have read the contributing guidelines and agree to the T&Cs

### UI (if applicable)

- [x] Screenshots or recording are attached above
- [x] Copy and layout match existing patterns where relevant

### Code quality

- [x] I have performed a self-review of my own code
- [x] I have commented code only where it helps future readers (non-obvious logic, invariants, gotchas)
- [x] I have updated documentation if behaviour or public APIs changed
- [x] My changes do not introduce new warnings

### Tests

- [ ] I have added or updated tests that cover this change — no unit tests exist for these HUD components; verified in the running app instead. `placeBumpkin` and `getHomeRoute` suites pass, `tsc --noEmit` is clean, and eslint reports only the file's pre-existing `any` warnings.
- [x] New and existing unit tests pass locally

### Dependencies and coordination

- [x] Any required changes in other repos (e.g. API) are merged or linked in the description
- [x] Any dependent packages or downstream modules are already published / coordinated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to place the player’s Bumpkin in interior and level-one locations through the landscaping quick panel.
  * The farm-hands panel now displays the Bumpkin when placement is available.
* **Bug Fixes**
  * Updated HUD guidance to accurately reflect that interior farm hands are managed through the Beds Migration modal and landscaping quick panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->