### PR TITLE
[FEAT] Remove beta flag from bulk mixer

### DIFF
--- a/src/features/feederMachine/FeederMachineModal.tsx
+++ b/src/features/feederMachine/FeederMachineModal.tsx
@@ -38,7 +38,6 @@ import { getIngredients, getMaxFeedMixAmount } from "./feedMixed";
 import { InventoryItemDetails } from "components/ui/layouts/InventoryItemDetails";
 import { getBulkMixRequirements } from "./getBulkMixRequirements";
 import { formatNumber } from "lib/utils/formatNumber";
-import { hasFeatureAccess } from "lib/flags";
 import { BulkMixModal } from "./BulkMixModal";
 
 interface Props {
@@ -84,8 +83,6 @@ export const FeederMachineModal: React.FC<Props> = ({
   const [showBulkMixModal, setShowBulkMixModal] = useState(false);
   const [customMixAmount, setCustomMixAmount] = useState(new Decimal(0));
   const { coins } = ANIMAL_FOODS[selectedName];
-
-  const showBulkMixer = hasFeatureAccess(state, "BULK_MIXER");
 
   const { ingredients } = getIngredients({ state, name: selectedName });
   const maxMixAmount = getMaxFeedMixAmount({ state, name: selectedName });
@@ -320,15 +317,11 @@ export const FeederMachineModal: React.FC<Props> = ({
               icon: ITEM_DETAILS.Hay.image,
               name: t("feeder.foodTypes.food"),
             },
-            ...(showBulkMixer
-              ? [
-                  {
-                    id: "automaticMixer" as const,
-                    icon: ITEM_DETAILS["Mixed Grain"].image,
-                    name: t("feeder.bulkMixer"),
-                  },
-                ]
-              : []),
+            {
+              id: "automaticMixer",
+              icon: ITEM_DETAILS["Mixed Grain"].image,
+              name: t("feeder.bulkMixer"),
+            },
           ]}
           currentTab={tab}
           setCurrentTab={setTab}
@@ -428,7 +421,7 @@ export const FeederMachineModal: React.FC<Props> = ({
               }
             />
           )}
-          {tab === "automaticMixer" && showBulkMixer && (
+          {tab === "automaticMixer" && (
             <InnerPanel className="flex flex-col gap-2 p-1 w-full">
               {freeFeeding ? (
                 <>

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -195,10 +195,6 @@ const FEATURE_FLAGS = {
   // baseDurationMs + true plantedAt model; when off, boosts stay discount-at-start.
   SPEED_BOOSTS: betaFeatureFlag,
 
-  // Bulk Mixer tab in the feeder machine: mix the missing feed for every
-  // waiting animal at once. Beta-pass / testnet only until it ships.
-  BULK_MIXER: betaFeatureFlag,
-
   // Beta testers can grab a Yakkamon pre-registration code before the level
   // tiers open to everyone else. The server enforces the same rule.
   YAKKAMON_BETA_ACCESS: betaFeatureFlag,


### PR DESCRIPTION
## Problem

The Bulk Mixer tab in the feeder machine is still gated behind the `BULK_MIXER` beta feature flag, limiting it to beta-pass and testnet players after the feature has been validated.

## Solution

- Remove the `BULK_MIXER` entry from `FEATURE_FLAGS` in `src/lib/flags.ts`.
- Always include the Bulk Mixer tab in `FeederMachineModal`.
- Remove the now-unused feature-access check and import.

## Validation

- `yarn tsc --noEmit`
- ESLint on the changed files
- Prettier on the changed files
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Automatic Mixer tab and its panel are now available without feature-flag gating.

- **Removals**
  - Removed the Bulk Mixer beta feature flag and its associated beta-access restriction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->