### PR TITLE
[FEAT] Referral list: open player profile on row click

### DIFF
--- a/src/features/island/hud/components/referral/Referral.tsx
+++ b/src/features/island/hud/components/referral/Referral.tsx
@@ -40,6 +40,7 @@ import classNames from "classnames";
 import { getRelativeTime } from "lib/utils/time";
 import { useNow } from "lib/utils/hooks/useNow";
 import { onboardingAnalytics } from "lib/onboardingAnalytics";
+import { playerModalManager } from "features/social/lib/playerModalManager";
 
 interface ReferralProps {
   onHide: () => void;
@@ -118,9 +119,15 @@ export const Referrees: React.FC = () => {
             <tr
               key={index}
               style={{ border: "1px solid #b96f50" }}
-              className={classNames({
+              className={classNames("cursor-pointer", {
                 "bg-[#ead4aa]": index % 2 === 0,
               })}
+              onClick={() =>
+                playerModalManager.open({
+                  farmId: id,
+                  username,
+                })
+              }
             >
               <td className="p-1.5 flex">
                 <img


### PR DESCRIPTION
## Problem

The referred-players list (Referral > Referred) rendered each row as static text — there was no way to open a referred player's profile or follow them from that screen.

## Solution

- Make each row in `Referrees` (`src/features/island/hud/components/referral/Referral.tsx`) clickable, opening the standard player profile modal via `playerModalManager.open({ farmId, username })` — the same mechanism used by leaderboards (e.g. `TicketTable`) and the social feed.
- The profile modal already fetches full player data (clothing, followers/following) and exposes follow/unfollow, report, and trade-history actions, so no changes were needed there.
- Added `cursor-pointer` styling to signal the rows are interactive.

## Validation

- `yarn tsc --noEmit`
- ESLint / Prettier via pre-commit hook on the changed file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Referral table rows are now clickable, allowing users to open the corresponding player profile modal directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->