### PR TITLE
[FIX] Remove the always-on desert insect ambience loop from the farm

### DIFF
--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -60,7 +60,6 @@ import { VIPOffer } from "../components/modal/components/VIPItems";
 import { StarterOfferModal } from "../components/modal/components/StarterOfferModal";
 import { RoninWaypointLoginModal } from "features/roninMigration/RoninWaypointLoginModal";
 import { GreenhouseInside } from "features/greenhouse/GreenhouseInside";
-import { useSound } from "lib/utils/hooks/useSound";
 import { SomethingArrived } from "./components/SomethingArrived";
 import { TradeAlreadyFulfilled } from "../components/TradeAlreadyFulfilled";
 import { NPC_WEARABLES } from "lib/npcs";
@@ -357,7 +356,6 @@ const _isVisiting = (state: MachineState) =>
 
 const GameContent: React.FC = () => {
   const { gameService } = useContext(Context);
-  useSound("desert", true);
 
   const isVisiting = useSelector(gameService, _isVisiting);
 


### PR DESCRIPTION
## Summary

The farm autoplayed a looping insect-ambience track the entire time a player was on it, which players hear as a constant high-pitched buzz. This removes it. There is no other always-on ambience bed on the farm, so the farm goes back to being quiet between actions — every event-triggered sound effect is untouched.

## Context / motivation

`GameContent` called `useSound("desert", true)` as its first statement, autoplaying `SOUNDS.loops.desert` → `Farm_Game_Loop_Nature_Ambience_Hot_Dry_Summer_Day_with_Bugs_Atmosphere.mp3` on mount, on loop, forever.

**It is audibly a buzz.** I pulled the asset off the CDN and measured it. There is a sustained resonant band at 7–9 kHz running unbroken across all 64 seconds, and it measures *louder* than the band below it:

| Band | Mean level |
|---|---|
| 0–300 Hz | −18.7 dB |
| 300–2000 Hz | −27.5 dB |
| 2000–5000 Hz | −33.4 dB |
| 5000–7000 Hz | −38.7 dB |
| **7000–10000 Hz** | **−37.3 dB** |
| 10000–16000 Hz | −42.0 dB |

Natural ambience rolls off monotonically with frequency; this doesn't. That bump is a tonal insect layer sitting on top of the noise floor, and it lands in the ear's most sensitive region, which is why it cuts through even at `volume: 0.02`. The loop seam itself is clean (first and last 200 ms match within 0.3 dB), so it reads as a continuous buzz rather than a periodic click.

**It was never gated on island or biome.** The call sat above every selector in `GameContent`, so desert bug ambience played on basic land, spring, volcano and swamp alike.

**It looks like an accident rather than a design choice.** `git log -S` traces the Howl, the asset key and the call site to one commit, 9c4446b98 (#3738 "[CHORE] HUD Sound Update") — a three-line addition to `Game.tsx` inside an otherwise pure HUD/button-sounds PR, with no biome logic ever written. The sibling entries `SOUNDS.loops.shoreline` and `SOUNDS.loops.windy` have never had a single consumer in the codebase, which suggests a per-biome ambience system that only ever got `desert` wired up, and wired it up globally. Before that PR the farm had no looping bed at all — the predecessor module `src/lib/utils/sfx.ts` was purely event-triggered one-shots.

**Players could not turn it off on its own.** Music play/pause only touches the `musicPlayer` `HTMLAudioElement` in `AudioControlsContext`, so pausing the music left the buzz running. Only the sound-effects mute (`Howler.mute`) silenced it — meaning the only way to stop it was to mute every sound effect in the game. A 64-second always-on ambience bed arguably shouldn't live under the SFX toggle in the first place.

## How to test

No feature flag; affects every player on the farm.

1. Check out `main`, load a farm, and leave the tab focused with the sound-effects toggle on. Listen for the continuous high-pitched insect buzz under everything (easiest with headphones, and with the music paused via Settings → Audio so only SFX remain).
2. Confirm on `main` that pausing the music does **not** stop the buzz — only muting sound effects entirely does.
3. Check out this branch and repeat. The buzz is gone.
4. Confirm nothing else regressed: click a building (bakery/shop), harvest a crop, mine a rock, click the Fountain and the Wicker Man. All event sounds still fire, and the sound-effects mute toggle still silences them.

## Screenshots or screen recording

N/A — audio-only change, no UI. The evidence is the band table above; a spectrogram of the removed asset shows the same thing visually as an unbroken bright band at ~7–9 kHz spanning the full 64 s, and I can drop it in the thread if it's useful.

## Related issues

Related #3738

## Notes for the reviewer

- The `desert` entry in `HOWLERS` (`useSound.ts`) is deliberately left in place. It is `preload: false`, so with no caller it never fetches the mp3 — inert dead config, kept in case a real per-biome ambience system revives it. Happy to strip it along with the unused `shoreline`/`windy` asset keys if you'd rather not carry it.
- Only the call and its now-unused import are removed; nothing else in the audio stack changed.
- I confirmed no other reference to the sound survives. Remaining `"desert"` hits in the repo are the island type (`island: { type: "desert" }`, `requiredIsland`) and an image-directory entry in `sw.ts`, none of them audio.
- No tests added: this is the deletion of a side-effecting autoplay call in a React component, and per repo convention there are no component tests. Verified with `tsc --noEmit` (no errors in `Game.tsx`) and `eslint` (0 errors; the 4 remaining warnings are pre-existing, in `GameWrapper` code at lines 552/593/603 that this PR does not touch).
- Whether the farm *should* have an ambience bed is a game-feel call. If the answer is yes, the follow-up is to build the per-biome system properly and give ambience its own volume control separate from the SFX mute. Note that `useSound`'s autoplay effect has deps `[sound]` while reading `play`, so gating it by passing a changing boolean will not work as currently written — that needs fixing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the desert background sound from the game experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->