### PR TITLE
[FIX] Instant Growth frees the yield AOEs for windowed crops

### DIFF
--- a/src/features/game/events/landExpansion/skillUsed.test.ts
+++ b/src/features/game/events/landExpansion/skillUsed.test.ts
@@ -4,6 +4,8 @@ import { CROPS } from "features/game/types/crops";
 import { COOKABLES } from "features/game/types/consumables";
 import { FLOWER_SEEDS, FLOWERS } from "features/game/types/flowers";
 import { getFlowerReadyAt } from "features/game/lib/flowerBedReadiness";
+import { harvest } from "./harvest";
+import Decimal from "decimal.js-light";
 
 describe("skillUse", () => {
   const dateNow = Date.now();
@@ -291,13 +293,16 @@ describe("skillUse", () => {
       expect(state.aoe["Basic Scarecrow"]?.[1]?.[1]).toEqual(dateNow);
     });
 
-    it("sets the aoe readyAt to the currentTime for yield AOE", () => {
+    it("frees the yield AOE for a legacy crop", () => {
       const state = skillUse({
         state: {
           ...INITIAL_FARM,
           bumpkin: {
             ...INITIAL_FARM.bumpkin,
             skills: { "Instant Growth": 1 },
+          },
+          inventory: {
+            Kale: new Decimal(0),
           },
           crops: {
             "123": {
@@ -308,34 +313,127 @@ describe("skillUse", () => {
               },
               createdAt: dateNow,
               x: 1,
-              y: 1,
+              y: 0,
             },
-            "789": {
+          },
+          collectibles: {
+            "Sir Goldensnout": [
+              {
+                id: "123",
+                createdAt: dateNow,
+                readyAt: dateNow,
+                coordinates: { x: 0, y: 0 },
+              },
+            ],
+          },
+          aoe: { "Sir Goldensnout": { 1: { 0: dateNow } } },
+        },
+        action: {
+          type: "skill.used",
+          skill: "Instant Growth",
+        },
+        createdAt: dateNow,
+      });
+
+      const stateAfterHarvest = harvest({
+        farmId: 1,
+        state,
+        action: { type: "crop.harvested", index: "123" },
+        createdAt: dateNow,
+      });
+
+      expect(stateAfterHarvest.inventory.Kale).toEqual(new Decimal(1.5));
+    });
+
+    it("frees the yield AOE for a windowed (speed-rate) crop", () => {
+      const state = skillUse({
+        state: {
+          ...INITIAL_FARM,
+          bumpkin: {
+            ...INITIAL_FARM.bumpkin,
+            skills: { "Instant Growth": 1 },
+          },
+          inventory: {
+            Kale: new Decimal(0),
+          },
+          crops: {
+            "123": {
               crop: {
-                id: "147",
+                id: "456",
+                name: "Kale",
+                plantedAt: dateNow,
+                baseDurationMs: CROPS["Kale"].harvestSeconds * 1000,
+              },
+              createdAt: dateNow,
+              x: 1,
+              y: 0,
+            },
+          },
+          collectibles: {
+            "Sir Goldensnout": [
+              {
+                id: "123",
+                createdAt: dateNow,
+                readyAt: dateNow,
+                coordinates: { x: 0, y: 0 },
+              },
+            ],
+          },
+          aoe: { "Sir Goldensnout": { 1: { 0: dateNow } } },
+        },
+        action: {
+          type: "skill.used",
+          skill: "Instant Growth",
+        },
+        createdAt: dateNow,
+      });
+
+      const stateAfterHarvest = harvest({
+        farmId: 1,
+        state,
+        action: { type: "crop.harvested", index: "123" },
+        createdAt: dateNow,
+      });
+
+      expect(stateAfterHarvest.inventory.Kale).toEqual(new Decimal(1.5));
+    });
+
+    it("leaves the yield AOE of a plot it did not grow untouched", () => {
+      const state = skillUse({
+        state: {
+          ...INITIAL_FARM,
+          bumpkin: {
+            ...INITIAL_FARM.bumpkin,
+            skills: { "Instant Growth": 1 },
+          },
+          crops: {
+            // Still growing - this is what the skill acts on.
+            "123": {
+              crop: {
+                id: "456",
                 name: "Kale",
                 plantedAt: dateNow,
               },
               createdAt: dateNow,
               x: 1,
-              y: 1,
+              y: 0,
+            },
+            // Already ready and NOT harvested yet, so its AOE cell must keep
+            // its cooldown rather than being refreshed along with the others.
+            "789": {
+              crop: {
+                id: "147",
+                name: "Eggplant",
+                plantedAt: dateNow - CROPS["Eggplant"].harvestSeconds * 1000,
+              },
+              createdAt: dateNow,
+              x: 2,
+              y: 0,
             },
           },
           aoe: {
-            "Scary Mike": {
-              1: { 1: dateNow },
-            },
-            "Laurie the Chuckle Crow": {
-              1: { 1: dateNow },
-            },
-            Gnome: {
-              1: { 1: dateNow },
-            },
-            "Queen Cornelia": {
-              1: { 1: dateNow },
-            },
             "Sir Goldensnout": {
-              1: { 1: dateNow },
+              2: { 0: dateNow },
             },
           },
         },
@@ -346,11 +444,7 @@ describe("skillUse", () => {
         createdAt: dateNow,
       });
 
-      expect(state.aoe["Scary Mike"]?.[1]?.[1]).toEqual(1);
-      expect(state.aoe["Laurie the Chuckle Crow"]?.[1]?.[1]).toEqual(1);
-      expect(state.aoe["Gnome"]?.[1]?.[1]).toEqual(1);
-      expect(state.aoe["Queen Cornelia"]?.[1]?.[1]).toEqual(1);
-      expect(state.aoe["Sir Goldensnout"]?.[1]?.[1]).toEqual(1);
+      expect(state.aoe["Sir Goldensnout"]?.[2]?.[0]).toEqual(dateNow);
     });
   });
 

--- a/src/features/game/events/landExpansion/skillUsed.ts
+++ b/src/features/game/events/landExpansion/skillUsed.ts
@@ -28,7 +28,6 @@ import { canChop } from "./chop";
 import { canDrillOilReserve } from "./drillOilReserve";
 import { isReadyToHarvest } from "./harvest";
 import { getCurrentCookingItem, recalculateQueue } from "./cancelQueuedRecipe";
-import type { AOEItemName } from "features/game/expansion/placeable/lib/collisionDetection";
 import { FLOWER_SEEDS, FLOWERS } from "features/game/types/flowers";
 import { updateBeehives } from "features/game/lib/updateBeehives";
 import { isWearableActive } from "features/game/lib/wearables";
@@ -60,11 +59,29 @@ function useInstantGrowth({
   aoe: AOE;
   createdAt?: number;
 }): Record<string, CropPlot> {
-  // Set each plot's plantedAt to 1 (making it grow instantly)
+  // Make every growing crop ready, and leave it with a grow duration of 0.
+  // `getCropGrowDurationMs` is what gates the crop-yield AOEs (Laurie, Sir
+  // Goldensnout, Gnome, ...): they only re-arm once a full grow duration has
+  // passed since their last use. An instant-grown crop is harvested early by
+  // design, so unless the duration collapses to 0 the harvest silently loses
+  // every AOE bonus.
   getKeys(crops).forEach((plot) => {
     const plantedCrop = crops[plot].crop;
-    if (plantedCrop) {
+    if (!plantedCrop) return;
+
+    if (plantedCrop.baseDurationMs !== undefined) {
+      // Windowed (speed-rate model): zero the remaining work AND re-anchor the
+      // start to now, so readyAt resolves to `createdAt` exactly and the grow
+      // duration is 0 (mirrors usePetalBlessed / useGreenhouseGuru).
+      // Back-dating plantedAt instead would re-price the grow against past
+      // boost windows and leave the duration at the FULL base grow time.
+      plantedCrop.baseDurationMs = 0;
+      plantedCrop.plantedAt = createdAt;
+    } else {
+      // Legacy: back-date to make it ready, and bank the full grow time as
+      // boostedTime so the duration (base - boosted) is likewise 0.
       plantedCrop.plantedAt = 1;
+      plantedCrop.boostedTime = CROPS[plantedCrop.name].harvestSeconds * 1000;
     }
   });
 
@@ -73,24 +90,6 @@ function useInstantGrowth({
     if (!dyObject) return;
     getKeys(dyObject).forEach((dy) => {
       dyObject[dy] = createdAt;
-    });
-  });
-
-  const cropYieldAOEItems: AOEItemName[] = [
-    "Scary Mike",
-    "Laurie the Chuckle Crow",
-    "Gnome",
-    "Queen Cornelia",
-    "Sir Goldensnout",
-  ];
-
-  cropYieldAOEItems.forEach((item) => {
-    const aoeItem = aoe[item] ?? {};
-    Object.values(aoeItem).forEach((dyObject) => {
-      if (!dyObject) return;
-      getKeys(dyObject).forEach((dy) => {
-        dyObject[dy] = 1;
-      });
     });
   });
 


### PR DESCRIPTION
Client half of sunflower-land-api#3608 — **both need to land together.**

## What

`useInstantGrowth` now collapses the crop's grow duration to 0 instead of resetting the yield-AOE map, matching the API exactly. The two implementations are byte-identical after this.

```ts
if (plantedCrop.baseDurationMs !== undefined) {
  plantedCrop.baseDurationMs = 0;
  plantedCrop.plantedAt = createdAt;
} else {
  plantedCrop.plantedAt = 1;
  plantedCrop.boostedTime = CROPS[plantedCrop.name].harvestSeconds * 1000;
}
```

The blanket `cropYieldAOEItems` reset goes away with it.

## Why

Instant Growth harvests a crop early by design, but `canUseYieldBoostAOE` only re-arms an AOE cell once a full grow duration has passed since its last use. So the skill has to zero that duration or the harvest silently loses Laurie the Chuckle Crow, Sir Goldensnout, Gnome and friends.

The two repos drifted apart on how:

- This side reset every yield-AOE cell to `1`. That frees the boosts, but it also refreshes cells belonging to plots the skill never grew — the bug the API fixed in its #2725, which this repo still had.
- The API replaced the reset with `boostedTime = harvestSeconds * 1000`. When the speed-rate model landed it guarded that write behind `baseDurationMs === undefined`, leaving windowed crops with no mechanism at all server-side.

So on windowed crops the client credited AOE bonuses the server refused. `handleSuccessfulSave` replaces local state with the server's farm, so players saw the gap as a negative toast right after saving.

Zeroing the remaining work is what `usePetalBlessed` and `useGreenhouseGuru` already do for windowed activities. It needs no geometry and no AOE-map surgery, and it fixes the over-broad reset as a side effect.

## Evidence

From a player report (farm 1181, 75 windowed Barley plots, 2026-09-09 02:12:50Z). Replaying `skill.used` + 75 × `crop.harvested` through both codebases:

| | Barley from 75 plots |
|---|---|
| This side, before fix | 313.45 |
| API, before fix | 282.75 |
| **Shortfall the player saw** | **−30.70** |
| Both, after the fix | 313.45 |

Per-plot: 10.3 on the single Gnome plot, 0.5 × 12 Sir Goldensnout plots, 0.3 × 48 Laurie plots (that player's Laurie's Gains rank 1), 14 plots outside every AOE. They reported "-30 barley"; the toast formats to 2dp, so it read `-30.70`.

Note the client was already right about the yield — 313.45 before and after. Only the mechanism changes here; the server is the side that was under-crediting.

## Reviewer notes

- Only affects farms with `SPEED_BOOSTS` (beta flag). Legacy crops keep the `boostedTime` path and their behaviour is unchanged.
- Written test-first. The old `sets the aoe readyAt to the currentTime for yield AOE` test asserted the blanket reset — an implementation detail this PR deliberately removes — so it is replaced by three behavioural tests: the legacy path and the windowed path both earn their AOE bonus through an actual harvest, and a third pins that a plot the skill did *not* grow keeps its cooldown (that one fails on `main`).
- `skillUsed.test.ts` is 42/43. The one failure, `useInstantGratification › does not restart a finished recipe whose cached readyAt is stale`, is pre-existing — it fails identically on unmodified `main` and is unrelated to Instant Growth.
- The 23 failures you get running the four crop suites together are also pre-existing cross-suite interference; identical counts with and without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Instant Growth now correctly updates timing for both legacy and windowed crops.
  - Harvesting affected crops now produces the expected 1.5 Kale yield.
  - Yield-based area effects no longer incorrectly refresh cooldowns for crops they affect.
  - Crops outside the affected area retain their existing cooldowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->