### PR TITLE
[FEAT] Complete the big fruits instantly instead of through the server

### DIFF
--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -751,6 +751,10 @@ import {
   type StartProjectAction,
 } from "./landExpansion/startProject";
 import {
+  collectProject,
+  type CollectProjectAction,
+} from "./landExpansion/collectProject";
+import {
   instaGrowFlower,
   type InstaGrowFlowerAction,
 } from "./landExpansion/instaGrowFlower";
@@ -1025,6 +1029,7 @@ export type PlayingEvent =
   | BurnClutterAction
   | InstantGrowProjectAction
   | StartProjectAction
+  | CollectProjectAction
   | InstaGrowFlowerAction
   | UpgradeRockAction
   | UpgradeTreeAction
@@ -1334,6 +1339,7 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "clutter.burned": burnClutter,
   "project.instantGrow": instantGrowProject,
   "project.started": startProject,
+  "project.collected": collectProject,
   "trial.started": startTrial,
   "rock.upgraded": upgradeRock,
   "tree.upgraded": upgradeTree,

--- a/src/features/game/events/landExpansion/collectProject.test.ts
+++ b/src/features/game/events/landExpansion/collectProject.test.ts
@@ -1,0 +1,151 @@
+import Decimal from "decimal.js-light";
+import { INITIAL_FARM } from "features/game/lib/constants";
+import type { SoloProjectName } from "features/game/types/monuments";
+import type { GameState } from "features/game/types/game";
+import { collectProject } from "./collectProject";
+
+const now = new Date("2026-09-09T00:00:00Z").getTime();
+
+const withProject = (
+  state: GameState,
+  cheers: number,
+  project: "Big Orange" | "Basic Cooking Pot" = "Big Orange",
+): GameState => ({
+  ...state,
+  socialFarming: {
+    ...state.socialFarming,
+    villageProjects: {
+      ...state.socialFarming.villageProjects,
+      [project]: { cheers },
+    },
+  },
+});
+
+describe("collectProject", () => {
+  const baseState: GameState = INITIAL_FARM;
+
+  it("throws if the project has not been started", () => {
+    expect(() =>
+      collectProject({
+        state: baseState,
+        action: { type: "project.collected", project: "Big Orange" },
+        createdAt: now,
+      }),
+    ).toThrow("Project not found");
+  });
+
+  it("throws if the project has not hit the required cheers", () => {
+    expect(() =>
+      collectProject({
+        state: withProject(baseState, 24),
+        action: { type: "project.collected", project: "Big Orange" },
+        createdAt: now,
+      }),
+    ).toThrow("Project is not complete");
+  });
+
+  // The action type rules this out, but it arrives as JSON from the client, so
+  // the reducer has to reject it rather than quietly skip the winner's payout.
+  it("throws for a project that hands a prize to a raffle winner", () => {
+    expect(() =>
+      collectProject({
+        state: withProject(baseState, 10, "Basic Cooking Pot"),
+        action: {
+          type: "project.collected",
+          project: "Basic Cooking Pot" as SoloProjectName,
+        },
+        createdAt: now,
+      }),
+    ).toThrow("Project must be completed on the server");
+  });
+
+  it("rewards the player with the project item", () => {
+    const state = collectProject({
+      state: withProject(baseState, 25),
+      action: { type: "project.collected", project: "Big Orange" },
+      createdAt: now,
+    });
+
+    expect(state.inventory["Giant Orange"]).toEqual(new Decimal(1));
+  });
+
+  it("adds to an existing stack of the reward item", () => {
+    const state = collectProject({
+      state: {
+        ...withProject(baseState, 25),
+        inventory: {
+          ...baseState.inventory,
+          "Giant Orange": new Decimal(3),
+        },
+      },
+      action: { type: "project.collected", project: "Big Orange" },
+      createdAt: now,
+    });
+
+    expect(state.inventory["Giant Orange"]).toEqual(new Decimal(4));
+  });
+
+  it("gives an extra fruit when a Cornucopia is active", () => {
+    const withCornucopia: GameState = {
+      ...withProject(baseState, 25),
+      collectibles: {
+        ...baseState.collectibles,
+        Cornucopia: [
+          {
+            id: "1",
+            createdAt: now,
+            readyAt: now,
+            coordinates: { x: 0, y: 0 },
+          },
+        ],
+      },
+    };
+    withCornucopia.socialFarming.villageProjects.Cornucopia = { cheers: 1000 };
+
+    const state = collectProject({
+      state: withCornucopia,
+      action: { type: "project.collected", project: "Big Orange" },
+      createdAt: now,
+    });
+
+    expect(state.inventory["Giant Orange"]).toEqual(new Decimal(2));
+    expect(state.boostsUsedAt?.Cornucopia).toEqual(now);
+  });
+
+  it("clears the village project and marks it completed", () => {
+    const state = collectProject({
+      state: withProject(baseState, 25),
+      action: { type: "project.collected", project: "Big Orange" },
+      createdAt: now,
+    });
+
+    expect(state.socialFarming.villageProjects["Big Orange"]).toBeUndefined();
+    expect(state.socialFarming.completedProjects).toContain("Big Orange");
+  });
+
+  it("does not duplicate an already completed project", () => {
+    const state = collectProject({
+      state: {
+        ...withProject(baseState, 25),
+        socialFarming: {
+          ...withProject(baseState, 25).socialFarming,
+          completedProjects: ["Big Orange"],
+        },
+      },
+      action: { type: "project.collected", project: "Big Orange" },
+      createdAt: now,
+    });
+
+    expect(state.socialFarming.completedProjects).toEqual(["Big Orange"]);
+  });
+
+  it("tracks the completion in farm activity", () => {
+    const state = collectProject({
+      state: withProject(baseState, 25),
+      action: { type: "project.collected", project: "Big Orange" },
+      createdAt: now,
+    });
+
+    expect(state.farmActivity["Big Orange Completed"]).toEqual(1);
+  });
+});

--- a/src/features/game/events/landExpansion/collectProject.ts
+++ b/src/features/game/events/landExpansion/collectProject.ts
@@ -1,0 +1,90 @@
+import Decimal from "decimal.js-light";
+import { produce } from "immer";
+import type { GameState } from "features/game/types/game";
+import {
+  getProjectReward,
+  hasProjectRaffle,
+  REQUIRED_CHEERS,
+  REWARD_ITEMS,
+  type SoloProjectName,
+} from "features/game/types/monuments";
+import { trackFarmActivity } from "features/game/types/farmActivity";
+import { updateBoostUsed } from "features/game/types/updateBoostUsed";
+
+export type CollectProjectAction = {
+  type: "project.collected";
+  project: SoloProjectName;
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: CollectProjectAction;
+  createdAt?: number;
+};
+
+/**
+ * Completes a village project and banks its reward.
+ *
+ * This is the local half of project completion: it only ever touches the
+ * owner's own game state, so the player gets their reward straight away and it
+ * syncs on the next autosave. Projects that also pay out a raffle winner write
+ * to someone else's farm and are handled by the `project.completed` effect.
+ */
+export function collectProject({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options): GameState {
+  return produce(state, (game) => {
+    // The type says this cannot happen, but the action arrives as JSON from
+    // the client, so the reducer is the one that has to enforce it.
+    if (hasProjectRaffle(action.project)) {
+      throw new Error("Project must be completed on the server");
+    }
+
+    const project = game.socialFarming.villageProjects?.[action.project];
+
+    if (!project) {
+      throw new Error("Project not found");
+    }
+
+    if (project.cheers < REQUIRED_CHEERS[action.project]) {
+      throw new Error("Project is not complete");
+    }
+
+    const rewardItem = REWARD_ITEMS[action.project];
+
+    const { amount, boostsUsed } = getProjectReward({
+      game,
+      project: action.project,
+      amount: rewardItem.amount,
+    });
+
+    game.inventory[rewardItem.item] = (
+      game.inventory[rewardItem.item] ?? new Decimal(0)
+    ).add(amount);
+
+    game.farmActivity = trackFarmActivity(
+      `${action.project} Completed`,
+      game.farmActivity,
+    );
+
+    // Delete the village project (marks inactive - item stays on land)
+    game.socialFarming.villageProjects[action.project] = undefined;
+
+    // Add to completedProjects so re-placing does not auto-restart
+    const completedProjects = game.socialFarming.completedProjects ?? [];
+    if (!completedProjects.includes(action.project)) {
+      game.socialFarming.completedProjects = [
+        ...completedProjects,
+        action.project,
+      ];
+    }
+
+    game.boostsUsedAt = updateBoostUsed({
+      game,
+      boostNames: boostsUsed,
+      createdAt,
+    });
+  });
+}

--- a/src/features/game/types/monuments.ts
+++ b/src/features/game/types/monuments.ts
@@ -240,7 +240,7 @@ export function getProjectReward({
   game: GameState;
 }) {
   let newAmount = amount;
-  const boostsUsed: BoostName[] = [];
+  const boostsUsed: { name: BoostName; value: string }[] = [];
 
   if (
     isMonumentActive({ game, monument: "Cornucopia" }) &&
@@ -249,7 +249,7 @@ export function getProjectReward({
       project === "Big Banana")
   ) {
     newAmount += 1;
-    boostsUsed.push("Cornucopia");
+    boostsUsed.push({ name: "Cornucopia", value: "+1" });
   }
   return { amount: newAmount, boostsUsed };
 }
@@ -552,14 +552,29 @@ export function hasHitHelpLimit({
   return totalHelpedToday >= getHelpLimit({ game });
 }
 
-export const RAFFLE_REWARDS: Partial<
-  Record<
-    MonumentName,
-    {
-      item: InventoryItemName;
-      amount: number;
-    }
-  >
+/**
+ * Projects whose completion also hands a prize to the raffle winner, which
+ * means writing to *another player's* farm. That can only happen server side,
+ * so these go through the `project.completed` effect.
+ */
+export type RaffleProjectName =
+  | "Basic Cooking Pot"
+  | "Expert Cooking Pot"
+  | "Advanced Cooking Pot";
+
+/**
+ * Projects whose completion touches nothing but the owner's own game state.
+ * These are completed locally by `project.collected` and synced on the next
+ * autosave, so the player gets their reward without a round trip.
+ */
+export type SoloProjectName = Exclude<VillageProjectName, RaffleProjectName>;
+
+export const RAFFLE_REWARDS: Record<
+  RaffleProjectName,
+  {
+    item: InventoryItemName;
+    amount: number;
+  }
 > = {
   "Basic Cooking Pot": {
     item: "Bronze Food Box",
@@ -574,3 +589,15 @@ export const RAFFLE_REWARDS: Partial<
     amount: 1,
   },
 };
+
+export const SOLO_PROJECTS: SoloProjectName[] = [
+  "Big Orange",
+  "Big Apple",
+  "Big Banana",
+];
+
+export function hasProjectRaffle(
+  project: MonumentName,
+): project is RaffleProjectName {
+  return project in RAFFLE_REWARDS;
+}

--- a/src/features/island/collectibles/components/Project.tsx
+++ b/src/features/island/collectibles/components/Project.tsx
@@ -19,9 +19,9 @@ import Decimal from "decimal.js-light";
 import classNames from "classnames";
 import {
   getProjectReward,
+  hasProjectRaffle,
   isHelpComplete,
   type MonumentName,
-  RAFFLE_REWARDS,
   REQUIRED_CHEERS,
   REWARD_ITEMS,
   type VillageProjectName,
@@ -251,7 +251,7 @@ const ProjectComplete: React.FC<{
         </span>
       </div>
 
-      {isProjectComplete && RAFFLE_REWARDS[project] && !!winner && (
+      {isProjectComplete && hasProjectRaffle(project) && !!winner && (
         <>
           <div className="flex justify-between flex-wrap">
             <Label
@@ -591,13 +591,25 @@ export const Project: React.FC<ProjectProps> = (input) => {
   const [showHelped, setShowHelped] = useState(false);
   const [showDetails, setShowDetails] = useState(false);
 
-  const handleComplete = async () => {
-    gameService.send("project.completed", {
-      effect: {
-        type: "project.completed",
-        project: input.project,
-      },
-    });
+  const handleComplete = () => {
+    /**
+     * A raffle project also pays out the winner, which is another player's
+     * farm, so it has to be settled server side. Everything else is purely the
+     * owner's own state: complete it locally and let autosave catch up.
+     */
+    if (hasProjectRaffle(input.project)) {
+      gameService.send("project.completed", {
+        effect: {
+          type: "project.completed",
+          project: input.project,
+        },
+      });
+
+      return;
+    }
+
+    gameService.send("project.collected", { project: input.project });
+    setShowDetails(false);
   };
 
   const handleStartProject = () => {


### PR DESCRIPTION
Backend: sunflower-land/sunflower-land-api#3610 — **must deploy first.**

## Why

Completing a village project went through the `project.completed` **effect** for every project. That is only necessary for the cooking pots: completing one also airdrops its raffle winner a food box, and writing to another player's farm can only happen server side.

The big fruits (Big Orange / Big Apple / Big Banana) share that handler but touch nothing except the owner's own inventory — so the modal sat on a loading spinner and then a success screen for a reward that was already earned.

## What

The two halves are now fully disjoint:

- **`project.collected`** — a new local event. Banks the reward, tracks the farm activity, clears the village project and adds it to `completedProjects`. Same work as the effect, minus the airdrop, and it syncs on the next autosave.
- **`project.completed`** — keeps the cooking pots, the only projects that reach off the farm, and keeps the loading and success screens with them.

`RaffleProjectName` and `SoloProjectName` split `VillageProjectName` in two, and each path takes only its own half. `RAFFLE_REWARDS` is now exhaustive over `RaffleProjectName`, which makes `hasProjectRaffle` a real type guard (`project is RaffleProjectName`) — both the completion branch and the modal's raffle-winner section go through it instead of hand-rolling the check.

The reducer still rejects a raffle project at runtime. The action is JSON on the wire, so the type is not the thing enforcing this; the backend mirrors the same rejection.

Completing a fruit now just closes the modal — the reward toast fires off the inventory diff like every other instant event.

## Drive-by fix

`getProjectReward` returned `BoostName[]`, which `updateBoostUsed` does not accept, so the Cornucopia boost was never recorded on this side. It now returns the `{ name, value }` shape every other call site uses. Nothing consumed the old return value.

## Tests

`collectProject.test.ts` adds 9 cases: not started, not enough cheers, raffle rejection, reward, stacking onto an existing amount, the Cornucopia +1, project cleared and marked completed, no duplicate entry, farm activity.

- `npx tsc --noEmit` clean
- The 11 monument/project suites pass (123 tests)

## Deploy

Not backwards compatible in either direction: the backend effect now refuses a big fruit, and `project.collected` needs the backend deploy to validate. A stale tab gets an error until it refreshes, which the new-version refresh prompt covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for collecting completed solo village projects.
  - Rewards, bonus boosts, completion progress, and activity records are now updated when a project is collected.
  - Collected projects are removed from active project listings and duplicate collection is prevented.
  - Project details close automatically after successful collection.
- **Bug Fixes**
  - Added validation to prevent collecting missing, incomplete, or unsupported projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->