### PR TITLE
[FIX] Include post-cure feed in Bulk Mixer

### DIFF
--- a/src/features/feederMachine/getBulkMixRequirements.test.ts
+++ b/src/features/feederMachine/getBulkMixRequirements.test.ts
@@ -133,8 +133,8 @@ describe("getBulkMixRequirements", () => {
     const barnDelight = feeds.find((feed) => feed.item === "Barn Delight");
 
     expect(kernelBlend?.type).toBe("food");
-    expect(kernelBlend?.missing).toEqual(new Decimal(1));
-    expect(kernelBlend?.ingredients.Corn).toEqual(new Decimal(1));
+    expect(kernelBlend?.missing).toEqual(new Decimal(2));
+    expect(kernelBlend?.ingredients.Corn).toEqual(new Decimal(2));
 
     expect(barnDelight?.type).toBe("medicine");
     expect(barnDelight?.missing).toEqual(new Decimal(1));
@@ -142,7 +142,51 @@ describe("getBulkMixRequirements", () => {
     expect(barnDelight?.ingredients.Honey).toEqual(new Decimal(3));
   });
 
-  it("excludes feeds an item makes free to mix (Oracle Syringe cures for free)", () => {
+  it("includes the normal feed an awake sick animal needs after its cure", () => {
+    const { requests, missingRequests } = getBulkMixRequirements(
+      {
+        ...INITIAL_FARM,
+        inventory: {},
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            "0": chicken("sick"),
+          },
+        },
+      },
+      "Hen House",
+      Date.now(),
+    );
+
+    expect(requests["Barn Delight"]).toEqual(new Decimal(1));
+    expect(requests["Kernel Blend"]).toEqual(new Decimal(1));
+    expect(missingRequests["Barn Delight"]).toEqual(new Decimal(1));
+    expect(missingRequests["Kernel Blend"]).toEqual(new Decimal(1));
+  });
+
+  it("does not include post-cure feed while a sick animal is asleep", () => {
+    const now = Date.now();
+    const sleeping = { ...chicken("sick"), awakeAt: now + 60_000 };
+    const { requests } = getBulkMixRequirements(
+      {
+        ...INITIAL_FARM,
+        inventory: {},
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            "0": sleeping,
+          },
+        },
+      },
+      "Hen House",
+      now,
+    );
+
+    expect(requests["Barn Delight"]).toEqual(new Decimal(1));
+    expect(requests["Kernel Blend"]).toBeUndefined();
+  });
+
+  it("excludes medicine made free by Oracle Syringe but includes post-cure feed", () => {
     const { requests, feeds } = getBulkMixRequirements(
       {
         ...INITIAL_FARM,
@@ -167,6 +211,10 @@ describe("getBulkMixRequirements", () => {
 
     expect(requests["Barn Delight"]).toBeUndefined();
     expect(feeds.find((feed) => feed.item === "Barn Delight")).toBeUndefined();
+    expect(requests["Kernel Blend"]).toEqual(new Decimal(1));
+    expect(feeds.find((feed) => feed.item === "Kernel Blend")?.missing).toEqual(
+      new Decimal(1),
+    );
   });
 
   it("surfaces the free-feed collectibles feeding a building's animals", () => {

--- a/src/features/feederMachine/getBulkMixRequirements.ts
+++ b/src/features/feederMachine/getBulkMixRequirements.ts
@@ -55,13 +55,16 @@ export type BulkMixFeed = {
 const MAX_FEED_STEPS_TO_READY = 100;
 const MIX_AMOUNT_EPSILON = new Decimal("0.000000000001");
 
+const isAnimalAwake = (animal: Animal, game: GameState, now: number) =>
+  getAnimalReadyAt(animal, game) <= now;
+
 const isAnimalAwakeAndRequestingFood = (
   animal: Animal,
   game: GameState,
   now: number,
 ) => {
   return (
-    getAnimalReadyAt(animal, game) <= now &&
+    isAnimalAwake(animal, game, now) &&
     (animal.state === "idle" ||
       animal.state === "happy" ||
       animal.state === "sad")
@@ -198,7 +201,23 @@ const getAnimalFeedRequests = ({
 }): FeedRequest[] => {
   if (animal.state === "sick") {
     const { amount } = getBarnDelightCost({ state: game });
-    return [{ item: "Barn Delight", quantity: new Decimal(amount) }];
+    const cureRequest: FeedRequest = {
+      item: "Barn Delight",
+      quantity: new Decimal(amount),
+    };
+
+    // Curing only returns the animal to idle; it still needs its normal feed
+    // immediately afterwards. Include that follow-up feed in the same plan
+    // when the animal will be eligible for feeding after it is cured.
+    if (
+      !isAnimalAwake(animal, game, now) ||
+      hasFreeFeedBoost(animal.type, game) ||
+      !isAnimalFeedable(buildingKey, game, animal.id)
+    ) {
+      return [cureRequest];
+    }
+
+    return [cureRequest, ...getFeedRequestsUntilReady({ animal, game, now })];
   }
 
   if (!isAnimalAwakeAndRequestingFood(animal, game, now)) {


### PR DESCRIPTION
## Summary

- include an awake sick animal's normal feed in the Bulk Mixer plan alongside its medicine
- keep post-cure feed excluded when the animal is asleep, over building capacity, or covered by a free-feed collectible
- keep Oracle Syringe's free cure while still planning the normal feed needed afterwards

## Context

Curing a sick animal with Barn Delight returns it to `idle` without feeding it. The Bulk Mixer previously returned early after adding only the medicine request, so players had to reopen the mixer and make the animal's normal feed separately after curing it.

## Testing

- `yarn test src/features/feederMachine/getBulkMixRequirements.test.ts src/features/feederMachine/bulkMixFeed.test.ts src/features/feederMachine/feedMixed.test.ts --runInBand`
- `yarn tsc --noEmit`
- `yarn eslint src/features/feederMachine/getBulkMixRequirements.ts src/features/feederMachine/getBulkMixRequirements.test.ts`
- `yarn prettier --check src/features/feederMachine/getBulkMixRequirements.ts src/features/feederMachine/getBulkMixRequirements.test.ts`
- `git diff --check upstream/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Feed requirements now include an awake sick animal’s regular food alongside its medicine.
  - Sleeping sick animals continue to request only their medicine until they are awake.
  - Animals receiving free treatment still correctly request the food needed after recovery.
  - Updated feed-breakdown checks ensure missing ingredient quantities accurately reflect both treatment and post-cure feeding needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->