### PR TITLE
[FIX] Keep Love Island item details accessible

### DIFF
--- a/src/components/ui/ModalOverlay.tsx
+++ b/src/components/ui/ModalOverlay.tsx
@@ -6,13 +6,15 @@
  */
 
 import { Transition, TransitionChild } from "@headlessui/react";
-import React, { useState } from "react";
+import React, { useLayoutEffect, useRef, useState } from "react";
 
 interface Props {
   show: boolean;
   className?: string;
   // Width classes for the centered panel. Defaults to "w-full sm:w-5/6".
   panelClassName?: string;
+  panelPosition?: "auto" | "center" | "top";
+  lockBackgroundScroll?: boolean;
   onBackdropClick: () => void;
 }
 
@@ -20,10 +22,57 @@ export const ModalOverlay: React.FC<React.PropsWithChildren<Props>> = ({
   show,
   className,
   panelClassName = "w-full sm:w-5/6",
+  panelPosition = "center",
+  lockBackgroundScroll = false,
   children,
   onBackdropClick,
 }) => {
   const [hideChildren, setHideChildren] = useState(true);
+  const [panelFillsContainer, setPanelFillsContainer] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!show || (panelPosition !== "auto" && !lockBackgroundScroll)) return;
+
+    const panel = panelRef.current;
+    const container = panel?.offsetParent;
+
+    if (!panel || !(container instanceof HTMLElement)) return;
+
+    const updatePanelPosition = () => {
+      if (panelPosition !== "auto") return;
+
+      setPanelFillsContainer(
+        panel.scrollHeight > panel.clientHeight ||
+          panel.offsetHeight >= container.clientHeight,
+      );
+    };
+
+    updatePanelPosition();
+
+    const resizeObserver = new ResizeObserver(updatePanelPosition);
+    resizeObserver.observe(panel);
+    resizeObserver.observe(container);
+
+    const panelContent = panel.firstElementChild;
+    if (panelContent instanceof HTMLElement) {
+      resizeObserver.observe(panelContent);
+    }
+
+    const previousOverflowY = container.style.overflowY;
+    if (lockBackgroundScroll) {
+      container.style.overflowY = "hidden";
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+      container.style.overflowY = previousOverflowY;
+    };
+  }, [hideChildren, lockBackgroundScroll, panelPosition, show]);
+
+  const alignPanelToTop =
+    panelPosition === "top" ||
+    (panelPosition === "auto" && panelFillsContainer);
 
   return (
     <Transition show={show}>
@@ -54,7 +103,14 @@ export const ModalOverlay: React.FC<React.PropsWithChildren<Props>> = ({
         leaveTo="scale-0"
         beforeEnter={() => setHideChildren(false)}
         afterLeave={() => setHideChildren(true)}
-        className={`absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 transform z-50 ${panelClassName}`}
+        ref={panelRef}
+        className={`absolute left-1/2 -translate-x-1/2 transform z-50 ${
+          alignPanelToTop ? "top-1" : "top-1/2 -translate-y-1/2"
+        } ${
+          lockBackgroundScroll
+            ? "max-h-[calc(100%-0.5rem)] overflow-y-auto overscroll-contain scrollable"
+            : ""
+        } ${panelClassName}`}
         as="div"
       >
         {!hideChildren && <>{children}</>}

--- a/src/features/world/ui/loveRewardShop/FloatingIslandShop.tsx
+++ b/src/features/world/ui/loveRewardShop/FloatingIslandShop.tsx
@@ -83,6 +83,8 @@ export const Shop: React.FC = () => {
     <>
       <ModalOverlay
         show={!!selectedItem}
+        panelPosition="auto"
+        lockBackgroundScroll
         onBackdropClick={() => setSelectedItem(null)}
       >
         <ItemDetail


### PR DESCRIPTION
## Problem

Tall item detail overlays in the Love Island Reward Shop were vertically centered inside the shop panel. When an item such as the Time Warp Totem exceeded the available height, its top edge and title were positioned outside the scrollable area and could not be reached. Scrolling the item detail also moved the Reward Shop behind it.

<img width="1214" height="974" alt="image" src="https://github.com/user-attachments/assets/2354ebac-12aa-401e-ab6f-3af6df7937da" />


## Solution

- add an opt-in automatic position mode to `ModalOverlay`
- keep compact overlays centered and align overlays to the top only when they fill or overflow their parent
- observe panel and container size changes so dynamic content is handled
- add an opt-in background scroll lock and give tall overlays their own contained scroll area
- enable both behaviors for Love Island Reward Shop item details

<img width="502" height="281" alt="image" src="https://github.com/user-attachments/assets/4b638342-4f45-41a0-866f-7695b25cbd5d" />


## Validation

- `yarn tsc --noEmit`
- Prettier check
- `git diff --check`
- ESLint and Prettier through the pre-commit hook
- visually reviewed by the requester in an isolated Love Island DevStand synced with current `upstream/main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Modal dialogs can now automatically position their panels based on available space or align them to the top or center.
  - Added an option to keep background content from scrolling while a modal is open.
- **Improvements**
  - The Love Reward Shop now adapts modal positioning to its content and prevents background scrolling for a smoother browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->