### PR TITLE
[FEAT] Show Finish to everyone once a party game's clock has run out

### DIFF
--- a/src/features/giveaway/GiveawayGame.tsx
+++ b/src/features/giveaway/GiveawayGame.tsx
@@ -58,6 +58,7 @@ export const GiveawayGame: React.FC<{ minigame?: MinigameType }> = ({
     phase,
     countdownMs,
     raceRemainingMs,
+    canFinalise,
     displayScore,
     playerScore,
     isLoading,
@@ -455,8 +456,11 @@ export const GiveawayGame: React.FC<{ minigame?: MinigameType }> = ({
                     ))}
                 </>
               ) : (
-                // Not finalised yet — the leaderboard only appears once the host
-                // ends the event. Until then, wait (or, for the host, finish).
+                // Not finalised yet — the leaderboard only appears once someone
+                // ends the event. Anyone can do that as soon as the mini-game's
+                // clock has run out, so a table full of players is never stuck
+                // waiting on the host; before then it stays admin-only (they can
+                // kill an event that has gone wrong mid-game).
                 <>
                   {playerScore !== undefined && (
                     <>
@@ -469,7 +473,7 @@ export const GiveawayGame: React.FC<{ minigame?: MinigameType }> = ({
                       <p className="text-xs">{t("giveaway.finishedWaiting")}</p>
                     </>
                   )}
-                  {isAdmin ? (
+                  {isAdmin || canFinalise ? (
                     isEnding ? (
                       <Loading text={t("giveaway.finishing")} />
                     ) : (

--- a/src/features/giveaway/lib/GiveawayProvider.tsx
+++ b/src/features/giveaway/lib/GiveawayProvider.tsx
@@ -25,6 +25,12 @@ interface GiveawayContextValue {
   countdownMs: number;
   /** ms left on the 30s race clock (0 unless racing). */
   raceRemainingMs: number;
+  /**
+   * Whether the mini-game's clock has run out, so ANY player may now finalise
+   * the event (the server enforces the same instant). Admins can finish at any
+   * time regardless — see GiveawayGame.
+   */
+  canFinalise: boolean;
   /** Live score for the HUD, updated as the mini-game plays. */
   displayScore: number;
   /** The score the local player achieved, once they finish. */
@@ -87,6 +93,13 @@ export const GiveawayProvider: React.FC<
           Math.min(RACE_DURATION_MS, board.startAt + RACE_DURATION_MS - now),
         )
       : 0;
+
+  // `finalisableAt` is computed by the API from the giveaway's own mini-game, so
+  // this matches what the server will accept to the millisecond rather than
+  // re-deriving it from local constants. Legacy giveaways (created before the
+  // API stored the mini-game) come back with a deliberately far-off value, which
+  // keeps them admin-only — exactly as before.
+  const canFinalise = !!board && now >= board.finalisableAt;
 
   // Keep a ref of the latest board so the (stable) bridge getters see fresh data.
   const boardRef = useRef(board);
@@ -165,6 +178,7 @@ export const GiveawayProvider: React.FC<
     phase,
     countdownMs,
     raceRemainingMs,
+    canFinalise,
     displayScore,
     playerScore,
     isSubmitting,

--- a/src/features/giveaway/lib/mockGiveaways.ts
+++ b/src/features/giveaway/lib/mockGiveaways.ts
@@ -53,6 +53,14 @@ const PRIZES: PrizeTier[] = [
   { from: 4, to: 10, coins: 100 },
 ];
 
+/**
+ * Offline there's no server to compute this, so mirror what the API does for a
+ * race: the game clock plus the same grace period, from `startAt`. Keeps the
+ * "Finish" button appearing at the right moment in UI mode.
+ */
+const FINALISE_GRACE_MS = 15000;
+const finalisableAt = (s: number) => s + 30000 + FINALISE_GRACE_MS;
+
 export function mockGiveaways(): GiveawaysResponse {
   const s = startAt();
   return {
@@ -64,6 +72,8 @@ export function mockGiveaways(): GiveawaysResponse {
         status: Date.now() >= s ? "live" : "upcoming",
         startAt: s,
         endAt: s + DURATION_MS,
+        minigame: "race",
+        finalisableAt: finalisableAt(s),
         prizes: PRIZES,
       },
     ],
@@ -74,6 +84,8 @@ export function mockGiveaways(): GiveawaysResponse {
         status: "complete",
         startAt: s - DURATION_MS,
         endAt: s - 1000,
+        minigame: "race",
+        finalisableAt: finalisableAt(s - DURATION_MS),
         endedAt: s - 1000,
         prizes: PRIZES,
       },
@@ -93,6 +105,11 @@ export function mockGiveawayLeaderboard(
     status: isPast ? "complete" : Date.now() >= s ? "live" : "upcoming",
     startAt: isPast ? s - DURATION_MS : s,
     endAt: isPast ? s - 1000 : s + DURATION_MS,
+    // Offline you can open any mini-game via `?type=`, but the fixture only
+    // models a race — so the finish button unlocks on race timing whatever
+    // you're playing. Harmless: there's no server here to disagree with it.
+    finishesAt: (isPast ? s - DURATION_MS : s) + 30000,
+    finalisableAt: finalisableAt(isPast ? s - DURATION_MS : s),
     prizes: PRIZES,
     // The race scene always adds the local player, so an empty participant list
     // means "just me". A finished mock giveaway shows a sample winner board.

--- a/src/features/giveaway/lib/types.ts
+++ b/src/features/giveaway/lib/types.ts
@@ -1,4 +1,5 @@
 import type { InventoryItemName } from "features/game/types/game";
+import type { MinigameType } from "./minigames";
 
 /**
  * Shared types for the community Giveaway mini-games.
@@ -36,6 +37,10 @@ export type ActiveGiveaway = {
   status: Extract<GiveawayStatus, "upcoming" | "live">;
   startAt: number;
   endAt: number;
+  /** Which mini-game it runs (absent on legacy giveaways). */
+  minigame?: MinigameType;
+  /** When any participant may finalise it. */
+  finalisableAt: number;
   prizes: PrizeTier[];
 };
 
@@ -47,6 +52,9 @@ export type RecentGiveaway = {
   status: Extract<GiveawayStatus, "complete">;
   startAt: number;
   endAt: number;
+  /** Which mini-game it ran (absent on legacy giveaways). */
+  minigame?: MinigameType;
+  finalisableAt: number;
   endedAt: number;
   prizes: PrizeTier[];
 };
@@ -76,6 +84,17 @@ export type GiveawayLeaderboardResponse = {
   status: GiveawayStatus;
   startAt: number;
   endAt: number;
+  /** Which mini-game the event runs (absent on giveaways created before the
+   * API carried the type — those fall back to the `?type=` query param). */
+  minigame?: MinigameType;
+  /** When the mini-game's own clock runs out. */
+  finishesAt: number;
+  /**
+   * When ANY participant may finalise the event — the game clock plus a grace
+   * period for the last scores to land. The server enforces the same instant,
+   * so gating the "Finish" button on this never offers a click that would fail.
+   */
+  finalisableAt: number;
   prizes: PrizeTier[];
   /** Top 10 only, ranked best-first. */
   leaderboard: GiveawayLeaderboardEntry[];

--- a/src/features/giveaway/ui/CreateGiveaway.tsx
+++ b/src/features/giveaway/ui/CreateGiveaway.tsx
@@ -69,10 +69,11 @@ export const CreateGiveaway: React.FC<{ onBack: () => void }> = ({
       { from: 4, to: 10, coins: third },
     ];
 
-    // No `endAt` — the admin ends the giveaway manually and the API no longer
-    // accepts it.
+    // No `endAt` — a giveaway stays live until someone finalises it. `minigame`
+    // is what tells the API how long the event actually runs, and so when any
+    // participant (not just the host) is allowed to finish it.
     gameService.send("giveaway.created", {
-      effect: { type: "giveaway.created", title, prizes, startAt },
+      effect: { type: "giveaway.created", title, prizes, startAt, minigame },
       authToken: token,
     });
   };


### PR DESCRIPTION
## Why

A giveaway could only be ended by an admin, so a table full of players who had already finished their mini-game sat on *"waiting for host"* until someone with a Gift Giver + Beta Pass pressed the button.

The API now stores the mini-game type and works out when an event's own clock runs out, so it will accept a finalise from **any participant** from that moment. This is the client half of that.

## What changed

- **`CreateGiveaway` sends `minigame`.** This is the load-bearing bit: it's what tells the API how long the event actually runs, and so when anyone other than the host may finish it. A giveaway created without it stores no type server-side and stays admin-only.
- **`GiveawayProvider` exposes `canFinalise`**, derived from the server's own `finalisableAt` rather than re-computed from the local clocks in `sim.ts` / `trivia.ts` / `pop.ts`. The button therefore never offers a click the server would reject, and the two can't drift apart.
- **`GiveawayGame` gates Finish on `isAdmin || canFinalise`** instead of `isAdmin`. Admins keep the ability to end early, to kill an event that has gone wrong mid-game.
- **Offline mock fixtures** carry the new `minigame` / `finishesAt` / `finalisableAt` fields.

## Reviewer notes

- **The mocks model a race**, so offline the Finish button unlocks on race timing (30s + grace) whatever you open via `?type=`. Harmless — there's no server in UI mode to disagree with it.
- **Nothing here decides *when* the clock is up** — that's `finalisableAt` off the API, which is `startAt + the mini-game's duration + a 15s grace`. The grace covers the round trip of the slowest client, since all of them submit their score the instant their own clock hits zero.
- `types.ts` still carries `endAt` on the giveaway types. The API no longer returns it, but the offline mocks still use it, so I've left it alone rather than widen this PR.

## Testing

`npx tsc --noEmit` clean; 44 tests pass across `src/features/giveaway`.

## Paired API PR

sunflower-land/sunflower-land-api#3611 — enforces the same instant server-side. **That one should land first or alongside**: without it the API rejects `minigame` on `giveaway.created` (Joi strips unknown keys / errors), and `board.finalisableAt` comes back undefined, which would leave `canFinalise` permanently false and put us back where we started.

### Known gap, not addressed here

Players who join through the lobby rather than a `?type=` link still drop into the **default race** for every event, because `GiveawayApp` picks the scene before the board loads. That bug predates this PR but bites harder now: on a trivia event such a player finishes a 30s race, submits a race score, and then waits while the server correctly reports the trivia clock still running. The API returns `board.minigame` now, so the fix is available — it needs `GiveawayApp` restructured to wait for the board before mounting Phaser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Players can now finish giveaway events once the mini-game clock and grace period have ended, while admin-only access remains in effect beforehand.
  * New giveaways record the selected mini-game and display timing information for gameplay and finalisation.
* **Bug Fixes**
  * Finalisation controls now align with server-enforced event timing, preventing premature finish attempts.
  * Offline giveaway data now reflects mini-game durations and finalisation windows consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->