### PR TITLE
[FEAT] Gems in the daily login chest are VIP only

### DIFF
--- a/src/features/game/events/landExpansion/claimDailyReward.test.ts
+++ b/src/features/game/events/landExpansion/claimDailyReward.test.ts
@@ -126,6 +126,8 @@ describe("claimDailyReward", () => {
           ...TEST_BUMPKIN,
           experience: LEVEL_3_EXPERIENCE,
         },
+        // Gems in the chest are a VIP perk
+        vip: { expiresAt: now + 30 * 24 * 60 * 60 * 1000, bundles: [] },
         dailyRewards: {
           streaks: 6,
           chest: {
@@ -144,6 +146,34 @@ describe("claimDailyReward", () => {
     expect(state.inventory["Gem"]).toEqual(new Decimal(50 + 20)); // 20 initial + 50 reward
     expect(state.inventory["Cheer"]).toEqual(new Decimal(3));
     expect(state.inventory[getChapterTicket(now)]).toEqual(new Decimal(1));
+  });
+
+  it("withholds the onboarding day 7 Gems from a non-VIP", () => {
+    const now = new Date("2025-01-07T05:00:00.000Z").getTime();
+    const state = claimDailyReward({
+      state: {
+        ...INITIAL_FARM,
+        bumpkin: {
+          ...TEST_BUMPKIN,
+          experience: LEVEL_3_EXPERIENCE,
+        },
+        dailyRewards: {
+          streaks: 6,
+          chest: {
+            collectedAt: now - 24 * 60 * 60 * 1000,
+            code: 1,
+          },
+        },
+        farmActivity: {},
+      },
+      action: { type: "dailyReward.claimed" },
+      createdAt: now,
+    });
+
+    expect(state.inventory["Gem"]).toEqual(new Decimal(20)); // 20 initial, no reward
+    // The rest of the chest is unchanged
+    expect(state.inventory["Weekly Mega Box"]).toEqual(new Decimal(1));
+    expect(state.inventory["Cheer"]).toEqual(new Decimal(3));
   });
 
   it("resets streak after onboarding when a day is missed", () => {
@@ -344,6 +374,8 @@ describe("claimDailyReward", () => {
           ...TEST_BUMPKIN,
           experience: LEVEL_3_EXPERIENCE,
         },
+        // Gems in the chest are a VIP perk
+        vip: { expiresAt: now + 30 * 24 * 60 * 60 * 1000, bundles: [] },
         dailyRewards: {
           streaks: 729,
           chest: {
@@ -364,6 +396,35 @@ describe("claimDailyReward", () => {
     expect(state.inventory["Cheer"]).toEqual(new Decimal(3));
     expect(state.inventory["Luxury Key"]).toEqual(new Decimal(1));
     expect(state.inventory[getChapterTicket(now)]).toEqual(new Decimal(1));
+  });
+
+  it("withholds the day 730 milestone Gems from a non-VIP", () => {
+    const now = new Date("2025-01-01T05:00:00.000Z").getTime();
+    const state = claimDailyReward({
+      state: {
+        ...INITIAL_FARM,
+        inventory: {},
+        bumpkin: {
+          ...TEST_BUMPKIN,
+          experience: LEVEL_3_EXPERIENCE,
+        },
+        dailyRewards: {
+          streaks: 729,
+          chest: {
+            collectedAt: now - 24 * 60 * 60 * 1000,
+            code: 1,
+          },
+        },
+      },
+      action: { type: "dailyReward.claimed" },
+      createdAt: now,
+    });
+
+    expect(state.inventory["Gem"]).toBeUndefined();
+    // The rest of the milestone is unchanged
+    expect(state.inventory["Pizza Margherita"]).toEqual(new Decimal(5));
+    expect(state.inventory["Super Totem"]).toEqual(new Decimal(1));
+    expect(state.inventory["Luxury Key"]).toEqual(new Decimal(1));
   });
 
   it("should claim day 1095", () => {
@@ -408,6 +469,8 @@ describe("claimDailyReward", () => {
           ...TEST_BUMPKIN,
           experience: LEVEL_3_EXPERIENCE,
         },
+        // Gems in the chest are a VIP perk
+        vip: { expiresAt: now + 30 * 24 * 60 * 60 * 1000, bundles: [] },
         dailyRewards: {
           streaks: 1459,
           chest: {

--- a/src/features/game/types/dailyRewards.test.ts
+++ b/src/features/game/types/dailyRewards.test.ts
@@ -105,6 +105,87 @@ describe("getRewardsForStreak — VIP banner perk chapter cutoff", () => {
   });
 });
 
+describe("getRewardsForStreak — Gems are VIP only", () => {
+  const NOW = PAW_PRINTS_NOW;
+
+  // Fresh farm, so the onboarding rewards apply
+  const newFarm: GameState = {
+    ...TEST_FARM,
+    farmActivity: {},
+  };
+
+  const rewardsFor = (game: GameState, streak: number) =>
+    getRewardsForStreak({
+      game,
+      streak,
+      currentDate: new Date(NOW).toISOString(),
+      now: NOW,
+    }).rewards;
+
+  const gemsIn = (game: GameState, streak: number) =>
+    rewardsFor(game, streak).reduce(
+      (total, reward) => total + (reward.items?.Gem ?? 0),
+      0,
+    );
+
+  it("strips the day 7 onboarding Gems for a non-VIP", () => {
+    const finale = rewardsFor(newFarm, 6).find(
+      (r) => r.id === "onboarding-day-7-first-week-finale",
+    )!;
+
+    expect(finale.items?.Gem).toBeUndefined();
+    // The rest of the reward survives
+    expect(finale.items?.["Weekly Mega Box"]).toBe(1);
+  });
+
+  it("grants the day 7 onboarding Gems to a VIP", () => {
+    const finale = rewardsFor({ ...vipFarm(NOW), farmActivity: {} }, 6).find(
+      (r) => r.id === "onboarding-day-7-first-week-finale",
+    )!;
+
+    expect(finale.items?.Gem).toBe(50);
+  });
+
+  it("strips streak milestone Gems for a non-VIP but keeps the rest", () => {
+    const milestone = rewardsFor(TEST_FARM, 729).find(
+      (r) => r.id === "streak-two-year",
+    )!;
+
+    expect(milestone.items?.Gem).toBeUndefined();
+    expect(milestone.coins).toBe(10000);
+    expect(milestone.items?.["Super Totem"]).toBe(1);
+  });
+
+  it("grants streak milestone Gems to a VIP", () => {
+    const milestone = rewardsFor(vipFarm(NOW), 729).find(
+      (r) => r.id === "streak-two-year",
+    )!;
+
+    expect(milestone.items?.Gem).toBe(320);
+  });
+
+  it("does not honour a VIP trial", () => {
+    const trialFarm: GameState = {
+      ...newFarm,
+      vip: { trialStartedAt: NOW, expiresAt: 0, bundles: [] },
+    };
+
+    expect(gemsIn(trialFarm, 6)).toBe(0);
+  });
+
+  it("never leaves a Gem in any daily reward for a non-VIP", () => {
+    for (let streak = 0; streak <= 1459; streak += 1) {
+      expect(gemsIn(newFarm, streak)).toBe(0);
+    }
+  });
+
+  it("does not mutate the shared reward definitions", () => {
+    // Non-VIP first, so a mutating implementation would poison the VIP read
+    expect(gemsIn(newFarm, 6)).toBe(0);
+    expect(gemsIn({ ...vipFarm(NOW), farmActivity: {} }, 6)).toBe(50);
+  });
+});
+
 describe("getRewardsForStreak — ascension-aware reward scaling", () => {
   // A1 L50 (ready to ascend) → total Bumpkin level 200, so the reward curve keys off
   // 200 / 25 = 8. The bug scaled off the within-ascension level (50 → 50 / 25 = 2),

--- a/src/features/game/types/dailyRewards.ts
+++ b/src/features/game/types/dailyRewards.ts
@@ -320,6 +320,31 @@ export function getWeeklyReward({
   return rewards[streak % rewards.length];
 }
 
+/**
+ * Gems in the daily login chest are a VIP perk. Returns the reward with its Gems removed,
+ * or `undefined` when Gems were the only thing in it. Never mutates the definition — the
+ * onboarding/weekly/milestone reward objects are module-level constants shared across
+ * every claim. Mirror of the backend (`domain/game/types/dailyRewards.ts`).
+ */
+function withoutGems(
+  reward: DailyRewardDefinition,
+): DailyRewardDefinition | undefined {
+  if (!reward.items?.Gem) {
+    return reward;
+  }
+
+  const { Gem: _gems, ...items } = reward.items;
+
+  const hasOtherReward =
+    Object.keys(items).length > 0 ||
+    !!reward.coins ||
+    !!reward.sfl ||
+    !!reward.xp ||
+    !!reward.buff;
+
+  return hasOtherReward ? { ...reward, items } : undefined;
+}
+
 export function getMilestoneRewards({
   streak,
 }: {
@@ -395,8 +420,29 @@ export function getRewardsForStreak({
     }
   }
 
+  const rewards = [
+    baseReward,
+    defaultReward,
+    ...getMilestoneRewards({ streak }),
+  ];
+
+  // Gems are a VIP-only perk in the daily login chest. Stripping them here covers every
+  // reward in the chest (onboarding, the weekly cycle and streak milestones), so any Gem
+  // added to a definition later is gated automatically. Non-VIPs keep the rest of the
+  // reward. Trial VIP does not count — the trial is free and one-claim-per-farm, so
+  // honouring it here would leave the gem tap wide open for new/throwaway accounts.
+  // Mirror of the backend (`domain/game/types/dailyRewards.ts`).
+  if (!hasVipAccess({ game, now, type: "full" })) {
+    return {
+      rewards: rewards
+        .map(withoutGems)
+        .filter((reward): reward is DailyRewardDefinition => !!reward),
+      boosts,
+    };
+  }
+
   return {
-    rewards: [baseReward, defaultReward, ...getMilestoneRewards({ streak })],
+    rewards,
     boosts,
   };
 }


### PR DESCRIPTION
Client mirror of sunflower-land/sunflower-land-api#3612. Without it a non-VIP would *see* "50 Gems" in the day-7 chest and receive none.

## What

Three reward definitions paid Gems regardless of VIP: onboarding day 7 "First Week Finale" (50), the two-year streak milestone (320) and the four-year one (500). Rather than patch each, `getRewardsForStreak` now strips `Gem` from every reward it returns for a non-VIP — covering onboarding, the weekly cycle and milestones in one place, so any Gem added to a definition later is gated automatically. The rest of each reward is untouched (day 7 still shows the Mega Box; the two-year milestone still shows coins, Super Totem and Luxury Key).

Both callers go through `getRewardsForStreak` — the 7-day preview strip in `DailyReward.tsx` and the optimistic `claimDailyReward` — so display and local state stay in sync with the server.

## Notes for the reviewer

- **Trial VIP does not count.** As on the backend, the gate is `hasVipAccess({ type: "full" })`. The trial is free and one-per-farm, and day-7 onboarding falls inside the 7-day trial window — honouring it would make the gate a no-op for exactly the accounts it targets.
- `withoutGems` copies rather than mutates: the onboarding/weekly/milestone definitions are module-level constants shared across every call, and the preview strip renders seven consecutive streaks in one pass. There's a test for it.
- **Not mirrored: the Weekly Mega Box.** The API PR also marks that box's Gem 30/50 entries `protected`, but this repo's `rewardBoxes.ts` carries no `protected`/`f2pOnly` flags at all — the box UI lists every possible reward regardless of eligibility, as it already does for the Love Boxes' protected Gems. Filtering that display is a separate change.

## Testing

New coverage for the gate (non-VIP stripped, VIP unaffected, trial not honoured, definitions not mutated, plus a sweep asserting no Gem survives at any streak 0–1459 for a non-VIP). Three existing `claimDailyReward` tests asserted the old behaviour and were made VIP, with non-VIP counterparts added.

`dailyRewards.test.ts` and `claimDailyReward.test.ts` pass; `tsc --noEmit`, eslint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Daily reward chests now reserve Gem rewards for players with full VIP access.
  - Non-VIP players, including those on a VIP trial, will no longer receive Gems from applicable onboarding and streak milestones.
  - Other rewards, such as coins, Weekly Mega Boxes, and Super Totems, remain available as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->