### PR TITLE
[FIX] Raise the Codex review timeout to 30 minutes

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -7,7 +7,7 @@ jobs:
   codex:
     environment: develop
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 10
+    timeout-minutes: 30
     permissions:
       contents: read
     outputs:


### PR DESCRIPTION
`timeout-minutes: 10` is killing reviews on real PRs before they finish. Because `post_feedback` only runs when the review produces output, a killed run posts **nothing** — so the largest PRs, the ones that most need a review, silently get none.

## How I got it wrong

I calibrated the cap on the workflow PR itself, then described 10 minutes as "a 3x margin over the slowest run". That sample was one file:

| PR | size | outcome at the 10m cap |
|---|---|---|
| `chore/codex-review-quality` (what I measured) | **1 file**, +103/-91 | 1m16s – 3m00s |
| sunflower-land-api#3614 | 10 files, +490/-1 | still running |
| sunflower-land-api#3579 | 20 files, +2428/-29 | still running |
| sunflower-land#7608 | **31 files**, +2627/-152 | still running |

A single-file workflow change is not representative of anything, and I should not have drawn a ceiling from it.

## These are not hangs

The prompt instructs Codex to read every changed file in full and grep the repo for usages of each changed signature. On a 31-file PR that is a large amount of genuine work, and the runs were doing exactly what they were told. This is different from the intermittent hang noted in the original PR, where `Run Codex` never returns.

## Why 30

It restores headroom without giving up a real ceiling — a genuinely stuck job still dies, just later. Note the cap is imprecise in this workflow: the action's `drop-sudo` strategy runs Codex under bubblewrap, the runner cannot signal that process tree, and the force-kill lands roughly five minutes after the cap fires.

30 is a starting point, not a measured value. The right number needs completion times from real PRs, which the 10-minute cap prevented us from ever observing. Once a few large PRs have run to completion we can tune it down on actual data, and `effort: medium` is the other lever if reviews turn out to be slower than they are worth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the automated workflow timeout from 10 to 30 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->