### PR TITLE
[FIX] Apply Salt Lick for goldened animals even if petting needed

### DIFF
--- a/src/features/barn/components/Cow.tsx
+++ b/src/features/barn/components/Cow.tsx
@@ -433,11 +433,8 @@ export const Cow: React.FC<{ id: string; disabled: boolean }> = ({
 
     if (sick) return onSickClick();
 
-    if (needsLove) {
-      if (!hasGoldenCow) return onLoveClick();
-
-      handleShowDetails();
-      return;
+    if (needsLove && !hasGoldenCow) {
+      return onLoveClick();
     }
 
     const hasBuffSelected = selectedItem && isAnimalFeedBuffItem(selectedItem);
@@ -457,6 +454,11 @@ export const Cow: React.FC<{ id: string; disabled: boolean }> = ({
       }
 
       await showNoFoodPrompt();
+      return;
+    }
+
+    if (needsLove && hasGoldenCow) {
+      handleShowDetails();
       return;
     }
 

--- a/src/features/barn/components/Sheep.tsx
+++ b/src/features/barn/components/Sheep.tsx
@@ -403,11 +403,8 @@ export const Sheep: React.FC<{ id: string; disabled: boolean }> = ({
 
     if (sick) return onSickClick();
 
-    if (needsLove) {
-      if (!hasGoldenSheep) return onLoveClick();
-
-      handleShowDetails();
-      return;
+    if (needsLove && !hasGoldenSheep) {
+      return onLoveClick();
     }
 
     const hasBuffSelected = selectedItem && isAnimalFeedBuffItem(selectedItem);
@@ -427,6 +424,11 @@ export const Sheep: React.FC<{ id: string; disabled: boolean }> = ({
       }
 
       await showNoFoodPrompt();
+      return;
+    }
+
+    if (needsLove && hasGoldenSheep) {
+      handleShowDetails();
       return;
     }
 

--- a/src/features/henHouse/Chicken.tsx
+++ b/src/features/henHouse/Chicken.tsx
@@ -455,11 +455,8 @@ export const Chicken: React.FC<{ id: string; disabled: boolean }> = ({
 
     if (sick) return onSickClick();
 
-    if (needsLove) {
-      if (!hasGoldEgg) return onLoveClick();
-
-      handleShowDetails();
-      return;
+    if (needsLove && !hasGoldEgg) {
+      return onLoveClick();
     }
 
     const hasBuffSelected = selectedItem && isAnimalFeedBuffItem(selectedItem);
@@ -479,6 +476,11 @@ export const Chicken: React.FC<{ id: string; disabled: boolean }> = ({
       }
 
       await showNoFoodPrompt();
+      return;
+    }
+
+    if (needsLove && hasGoldEgg) {
+      handleShowDetails();
       return;
     }
 


### PR DESCRIPTION
The "ignore petting for players with corresponding Golden boost" logic was preventing application of Salt Lick.

This change is intended to address that issue.

There is a sibling issue that farms without the corresponding Golden boost cannot apply Salt Lick if they do not have petting tools.   Not addressed in this change.