### PR TITLE
[FIX] Turn on Codex's reasoning and fix its sandbox

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -29,26 +29,12 @@ jobs:
           # Check out the PR's merge commit
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
-      - name: Generate PR diff
-        id: generate_diff
+      - name: Verify the merge commit
         run: |
           if ! git rev-parse --verify HEAD^2 >/dev/null 2>&1; then
             echo "::error::Expected merge commit (HEAD^2) not found. Ensure refs/pull/N/merge exists."
             exit 1
           fi
-
-          R="HEAD^1...HEAD^2"
-          git diff --name-status "$R" > _tmp && head -n 150 _tmp > pr_files.txt
-          git diff --stat "$R" > _tmp && head -n 100 _tmp > pr_stat.txt
-          git diff --unified=3 "$R" > pr.full.diff
-
-          perl -e 'read(STDIN,$b,50000); if(length($b)==50000){$t=$b;$t=~s/[^\n]*\z//; print length($t)?$t:$b}else{print $b}' < pr.full.diff > pr.diff
-
-          for name in diff_content file_list diff_stat; do
-            f=pr.diff; [ "$name" = "file_list" ] && f=pr_files.txt; [ "$name" = "diff_stat" ] && f=pr_stat.txt
-            d="CODEx_$(openssl rand -hex 16)"
-            { echo "${name}<<$d"; cat "$f"; echo "$d"; } >> "$GITHUB_OUTPUT"
-          done
 
       - name: Run Codex
         id: run_codex
@@ -63,16 +49,14 @@ jobs:
             Base SHA: ${{ github.event.pull_request.base.sha }}
             Head SHA: ${{ github.event.pull_request.head.sha }}
 
-            Here are the changed files:
-            ${{ steps.generate_diff.outputs.file_list }}
+            The repository is checked out at this PR's merge commit and you can run commands, so read the changes yourself:
 
-            Diff summary (insertions/deletions per file):
-            ${{ steps.generate_diff.outputs.diff_stat }}
+            - `git diff HEAD^1...HEAD^2` — the complete diff
+            - `git diff --name-status HEAD^1...HEAD^2` — the changed files
+            - `git diff --stat HEAD^1...HEAD^2` — insertions and deletions per file
+            - `git show HEAD^1:<path>` — any file as it was before the PR
 
-            Here is the PR diff (truncated at line boundary if large):
-            ${{ steps.generate_diff.outputs.diff_content }}
-
-            (If content was truncated, use the file list and diff summary above for full context.)
+            Nothing is pasted into this prompt, so nothing is truncated. Open the surrounding code too, not just the changed hunks.
 
             Your job:
             - Review **only** the changes introduced by this PR (the diff between base and head).

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,9 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    # TEMPORARY: synchronize is here only to re-trigger reviews while we
-    # measure this on a real PR. Remove before this is considered done.
-    types: [opened, synchronize]
+    types: [opened]
 
 # One review per PR. A push supersedes the run it replaces rather than
 # stacking beside it, which also stops a slow older run posting a stale

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,16 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened]
+    # TEMPORARY: synchronize is here only to re-trigger reviews while we
+    # measure this on a real PR. Remove before this is considered done.
+    types: [opened, synchronize]
+
+# One review per PR. A push supersedes the run it replaces rather than
+# stacking beside it, which also stops a slow older run posting a stale
+# verdict after a newer one.
+concurrency:
+  group: codex-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   codex:

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -7,6 +7,8 @@ jobs:
   codex:
     environment: develop
     runs-on: ubuntu-24.04-arm
+    # Backstop against a stuck job, not a calibrated value: the default is 6h.
+    timeout-minutes: 30
     permissions:
       contents: read
     outputs:
@@ -41,9 +43,10 @@ jobs:
 
       - name: Run Codex
         id: run_codex
-        uses: openai/codex-action@v1.4
+        uses: openai/codex-action@v1.12
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          effort: high
           prompt: |
             You are an experienced senior engineer reviewing a React, PhaserJS, and TypeScript codebase that uses **React Compiler** in production.
 


### PR DESCRIPTION
Two config bugs have been making Codex reviews a rubber stamp. Both are plainly visible in the run logs, and this PR fixes only those two. **The prompt is deliberately untouched.**

```
CODEX_EFFORT:           (empty)
reasoning effort: none
warning: Codex could not find bubblewrap on PATH... will use the bundled bubblewrap
bwrap: Operation not permitted
```

The model step in the run above took **11 seconds**.

## Reasoning was off

The `effort` input was never set, so every review ran at `reasoning effort: none`.

## The sandbox never started

`codex-action@v1.4` cannot enable unprivileged user namespaces on GitHub runners, so bubblewrap failed and Codex could not open a single file, grep for a caller, or run anything. Every review was a blind read of the diff we paste into the prompt — which is exactly what its "verification limitation" footer had been telling us on every PR for weeks.

`v1.12` adds a step `v1.4` does not have:

```yaml
- name: Enable Linux user namespaces for bubblewrap
    sudo sysctl -w kernel.unprivileged_userns_clone=1
    sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
```

I verified the `final-message` output contract is byte-identical between the two versions, so `post_feedback` is unaffected. The fix is confirmed working on `ubuntu-24.04-arm`.

## The timeout is a backstop, not a tuned value

The job currently has no `timeout-minutes`, so the default is **6 hours**, and hung jobs do occur. 30 bounds that. It is not calibrated — we have no reliable figure yet for what a real review costs, and picking one from a small PR would be meaningless.

Note the cap is imprecise here: the action's `drop-sudo` strategy runs Codex under bubblewrap in a fresh user namespace, the runner cannot signal that process tree, and the force-kill lands roughly five minutes after the cap fires. A plain cancel — and even a force-cancel — returns `202 Accepted` while the job carries on.

## Codex now reads the diff itself

The `Generate PR diff` step existed *because* the sandbox was broken: Codex could not read a file, so the diff had to be pasted into the prompt. With v1.12 it runs `git` itself, so the step is scaffolding for a problem that no longer exists.

It was also actively harmful. The diff went through `GITHUB_OUTPUT` and was cut at 50,000 bytes, the file list capped at 150 lines, with no warning:

| PR | diff size | seen by the reviewer |
|---|---|---|
| sunflower-land#7608 | 129,328 bytes | **39%** |
| sunflower-land-api#3579 | 99,045 bytes | **50%** |

sunflower-land-api#3609 reported this itself — *"the supplied diff is truncated"* — and we read past it.

Gone with the step: the `perl` truncation, the file and stat caps, and the `GITHUB_OUTPUT` heredoc plumbing. The merge-commit guard stays, so a bad ref still fails loudly. The prompt gains only navigation (which git commands reach the diff), no methodology. Net change is **-4 lines**: the workflow is smaller than the one it replaces.

A side effect worth having: the diff is no longer prompt text, so a hostile diff cannot inject instructions into the review.

## Also here

`concurrency` keyed by PR number with `cancel-in-progress`, so a push supersedes the run it replaces rather than stacking beside it. Two runs overlapping on the same PR hung 2 for 2 during this work.

## What is deliberately not here

No prompt methodology changes and no dependency install.

An earlier attempt bundled a full prompt rewrite with these fixes. That rewrite told Codex to read every changed file in full and trace every changed signature's callers across the repo — unbounded work. It finished in 90 seconds on a one-file PR and **never finished at all** on PRs of 10, 20 and 31 files, and since `post_feedback` is gated on output, those PRs got no review whatsoever. It was reverted.

The lesson applies to this PR too: every measurement so far is from single-file workflow PRs, which proves the config is sound and nothing more. Behaviour on a 31-file PR is still unmeasured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the automated pull request review workflow.
  - Reviews now run when a pull request is opened and validate the checked-out merge commit.
  - Review checks inspect the complete change set and relevant files directly, improving consistency and avoiding truncated diff artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->