### PR TITLE
[FIX] Pin codex-action to v1.11: v1.12 never exits on heavy reviews

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Codex
         id: run_codex
-        uses: openai/codex-action@v1.12
+        uses: openai/codex-action@v1.11
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           effort: high


### PR DESCRIPTION
Reviews on real PRs never post. The job runs until `timeout-minutes` kills it, and `post_feedback` is skipped, so the largest PRs silently get no review at all.

This is a known upstream regression in **v1.12** specifically: [openai/codex-action#150](https://github.com/openai/codex-action/issues/150).

## What v1.12 broke

v1.12 rewrote `runCodexExec` to pass the runner's stdout and stderr straight to the whole Codex process tree and wait on Node's `close` event. A descendant that outlives the direct child keeps those descriptors open, so the action never observes the end of its log transport.

Codex **finishes the turn and writes its output file** — then the step sits idle until the timeout. The review is produced and thrown away.

## Why it looked random to us

It is workload-sensitive, not deterministic.

| PR | outcome |
|---|---|
| 1 file (the workflow PRs) | completed, ~80s |
| 10 files | hung, killed by timeout |
| 20 files | hung, killed by timeout |
| 31 files | hung, killed by timeout |

We also had a single **one-file** PR hang for 20 minutes, which is what made the pattern hard to read — and matches upstream, where a light run finished cleanly between two hangs on the same branch.

Upstream numbers, model held fixed: **145/145 clean on v1.11 against 69/74 on v1.12**, and one reporter had 33 of 39 real reviews stuck.

## Why v1.11 is the right target

The bubblewrap fix we actually needed — the `sysctl` step that lets the sandbox start at all — landed in **v1.6**, not v1.12. I bisected every tag to confirm:

```
v1.4  no      v1.7  yes     v1.10  yes
v1.5  no      v1.8  yes     v1.11  yes
v1.6  YES     v1.9  yes     v1.12  yes
```

So dropping to v1.11 keeps the sandbox fix and loses only the wrapper rewrite. Its `final-message` output contract is byte-identical to v1.12's, so `post_feedback` is unaffected.

## Follow-up

The wrapper fix ([openai/codex-action#151](https://github.com/openai/codex-action/pull/151)) is still open upstream. Move to a later version once it lands.

Worth considering separately: `codex-version` defaults to empty, which means the action installs whatever `@openai/codex` is `latest` at run time, so pinning the action does not pin the program that runs ([#171](https://github.com/openai/codex-action/issues/171)). Pinning it would make failures reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
