### PR TITLE
[FIX] Preserve cooking queues when using Instant Gratification

### DIFF
--- a/src/features/game/events/landExpansion/skillUsed.test.ts
+++ b/src/features/game/events/landExpansion/skillUsed.test.ts
@@ -5,6 +5,9 @@ import { COOKABLES } from "features/game/types/consumables";
 import { FLOWER_SEEDS, FLOWERS } from "features/game/types/flowers";
 import { getFlowerReadyAt } from "features/game/lib/flowerBedReadiness";
 import { harvest } from "./harvest";
+import { getCookingQueueReadyAts } from "features/game/lib/cookingReadiness";
+import { BUILDING_DAILY_OIL_CAPACITY } from "./supplyCookingOil";
+import { getKeys } from "lib/object";
 import Decimal from "decimal.js-light";
 
 describe("skillUse", () => {
@@ -1228,6 +1231,72 @@ describe("skillUse", () => {
       expect(firePitRecipe?.readyAt).toEqual(dateNow);
       expect(smoothieShackRecipe?.readyAt).toEqual(dateNow);
     });
+
+    it.each(getKeys(BUILDING_DAILY_OIL_CAPACITY))(
+      "only completes the current windowed recipe in %s",
+      (buildingName) => {
+        const HOUR = 60 * 60 * 1000;
+        const now = dateNow;
+        const name = getKeys(COOKABLES).find(
+          (name) => COOKABLES[name].building === buildingName,
+        )!;
+        const game = {
+          ...INITIAL_FARM,
+          inventory: { ...INITIAL_FARM.inventory, "Beta Pass": new Decimal(1) },
+          bumpkin: {
+            ...INITIAL_FARM.bumpkin,
+            skills: { "Instant Gratification": 1 },
+          },
+          buildings: {
+            [buildingName]: [
+              {
+                id: "1",
+                coordinates: { x: 0, y: 0 },
+                createdAt: 0,
+                readyAt: 0,
+                crafting: [
+                  {
+                    id: "head",
+                    name,
+                    startedAt: now - 10 * HOUR,
+                    baseDurationMs: 12 * HOUR,
+                    readyAt: now + 2 * HOUR,
+                  },
+                  {
+                    id: "tail1",
+                    name,
+                    baseDurationMs: 2 * HOUR,
+                    readyAt: now + 4 * HOUR,
+                  },
+                  {
+                    id: "tail2",
+                    name,
+                    baseDurationMs: 2 * HOUR,
+                    readyAt: now + 6 * HOUR,
+                  },
+                ],
+              },
+            ],
+          },
+        };
+        const state = skillUse({
+          state: game,
+          action: { type: "skill.used", skill: "Instant Gratification" },
+          createdAt: now,
+        });
+        const queue = state.buildings[buildingName]![0].crafting!;
+        const expected = [now, now + 2 * HOUR, now + 4 * HOUR];
+        expect(queue.map((recipe) => recipe.readyAt)).toEqual(expected);
+        expect(
+          getCookingQueueReadyAts({ crafting: queue, game: state }),
+        ).toEqual(expected);
+        expect(queue[0].startedAt).toBe(now);
+        expect(queue[0].baseDurationMs).toBe(0);
+        expect(game.buildings[buildingName][0].crafting[0].baseDurationMs).toBe(
+          12 * HOUR,
+        );
+      },
+    );
 
     // Same stale-cache trap as the gem speed-up: a recipe that has actually finished
     // but whose cached `readyAt` still points into the future was treated as

--- a/src/features/game/events/landExpansion/skillUsed.ts
+++ b/src/features/game/events/landExpansion/skillUsed.ts
@@ -215,6 +215,9 @@ function useInstantGratification({
     // undo the instant completion (mirrors the oil reserve above / instaGrowFlower).
     if (queue[recipeIndex].baseDurationMs !== undefined) {
       queue[recipeIndex].baseDurationMs = 0;
+      // Complete at activation, not at the old start: queued recipes derive their
+      // start from this recipe and must not inherit its elapsed cooking time.
+      queue[recipeIndex].startedAt = createdAt;
     }
 
     building.crafting = recalculateQueue({


### PR DESCRIPTION
Instant Gratification can finish queued meals as well as the currently cooking meal in Deli, Fire Pit, Kitchen, Smoothie Shack, and Bakery when recipes use windowed timers.

The skill zeroes the current recipe's `baseDurationMs` but leaves its old `startedAt`. The queue resolver therefore places completion at the original start and credits that elapsed time to subsequent recipes. For example, a recipe started 10 hours ago with 2 hours remaining, followed by two 2-hour recipes, makes the entire queue ready after activation.

Anchor the completed recipe to the activation time so only the current meal finishes immediately in each building and subsequent meals retain their cooking durations. In that example, readiness now becomes immediate, +2 hours, and +4 hours. Legacy timers are unchanged.

Validation:
- Added a parameterized regression covering all five cooking buildings, checking both cached and derived readiness. All five cases fail before the fix and pass afterward.
- `VITE_NETWORK=amoy jest ... --runInBand --silent`: 3 suites / 80 tests passed (`skillUsed`, `cancelQueuedRecipe`, `cookingReadiness`).
- `tsc --noEmit`, scoped ESLint, Prettier, and `git diff --check` passed.
- Without the network setting, two existing speed-boost tests fail identically on clean upstream/main; both pass in the amoy run above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Instant Gratification now completes only the active recipe across cooking buildings.
  * Queued recipes recalculate their readiness times correctly after activation.
  * Completed recipes no longer pass elapsed cooking time to queued recipes.
  * Chained recipes complete correctly even when an earlier recipe is finished but uncollected.
  * Recipes queued during Gourmet Hourglass retain their boosted durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->